### PR TITLE
fix(config): disable frozen lockfile in vercel install

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pnpm install --no-frozen-lockfile"
+}


### PR DESCRIPTION
Use a root-level vercel.json installCommand to run pnpm with --no-frozen-lockfile in CI so deployments are not blocked by lockfile drift in this monorepo.