### PR TITLE
fix(release): restore studio catalog deps

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -10,13 +10,13 @@
   },
   "dependencies": {
     "@sanity/vision": "^5.13.0",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "sanity": "^5.13.0",
     "styled-components": "^6.3.11"
   },
   "devDependencies": {
-    "@types/react": "^19.2.14",
+    "@types/react": "catalog:",
     "typescript": "catalog:"
   }
 }


### PR DESCRIPTION
## Summary
- restore `apps/studio/package.json` to use `catalog:` for `react`, `react-dom`, and `@types/react`
- unblock `pnpm install --frozen-lockfile` inside the release workflow

## Why
`Release` on main failed before it reached Changesets because the lockfile already expected catalog-managed React versions while `apps/studio/package.json` had drifted to explicit semver ranges.
