### PR TITLE
fix(gateway): regenerate stale web API client types + harden contract chain

### DIFF
--- a/apps/web/src/lib/api/types.generated.ts
+++ b/apps/web/src/lib/api/types.generated.ts
@@ -126,18 +126,6 @@ export interface paths {
               services: {
                 /** @enum {string} */
                 ai: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                content: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                recsys: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                ecommerce: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                web3: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                billing: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                eventIngest: "available" | "unavailable" | "unknown";
               };
               uptime: number;
               checks: {
@@ -168,18 +156,6 @@ export interface paths {
               services: {
                 /** @enum {string} */
                 ai: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                content: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                recsys: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                ecommerce: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                web3: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                billing: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                eventIngest: "available" | "unavailable" | "unknown";
               };
               uptime: number;
               checks: {
@@ -458,18 +434,6 @@ export interface paths {
               services: {
                 /** @enum {string} */
                 ai: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                content: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                recsys: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                ecommerce: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                web3: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                billing: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                eventIngest: "available" | "unavailable" | "unknown";
               };
               uptime: number;
               checks: {
@@ -500,18 +464,6 @@ export interface paths {
               services: {
                 /** @enum {string} */
                 ai: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                content: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                recsys: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                ecommerce: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                web3: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                billing: "available" | "unavailable" | "unknown";
-                /** @enum {string} */
-                eventIngest: "available" | "unavailable" | "unknown";
               };
               uptime: number;
               checks: {
@@ -1304,7 +1256,7 @@ export interface paths {
     put?: never;
     /**
      * Ingest events
-     * @description Accepts a batch of events (1-1000) and forwards them to the event ingest service for processing.
+     * @description Accepts a batch of events (1-1000) and persists them to ClickHouse bronze.
      */
     post: {
       parameters: {
@@ -1320,7 +1272,17 @@ export interface paths {
               eventName: string;
               context: {
                 tenantId: string;
+                userId?: string | null;
+                sessionId?: string | null;
+                utmSource?: string | null;
+                utmMedium?: string | null;
+                utmCampaign?: string | null;
+                experimentId?: string | null;
+                requestId?: string | null;
+                traceId?: string | null;
                 occurredAt: string;
+                /** @default v1 */
+                contractVersion?: string;
               };
               /** @default {} */
               payload?: {
@@ -1334,18 +1296,31 @@ export interface paths {
         };
       };
       responses: {
-        /** @description Events accepted for processing */
+        /** @description Events accepted */
         200: {
           headers: {
             [name: string]: unknown;
           };
           content: {
             "application/json": {
-              [key: string]: unknown;
+              accepted: number;
+              duplicated: number;
             };
           };
         };
-        /** @description Event ingest service unavailable */
+        /** @description Tenant mismatch between authenticated context and event payload */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              error: string;
+              message: string;
+            };
+          };
+        };
+        /** @description Ingest backend (ClickHouse) unavailable */
         502: {
           headers: {
             [name: string]: unknown;
@@ -1574,6 +1549,23 @@ export interface paths {
         };
       };
     };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/agent-runtime/turns": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Run an agent runtime turn */
+    post: operations["createAgentRuntimeTurn"];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -2288,6 +2280,7 @@ export interface paths {
             successUrl: string;
             /** Format: uri */
             cancelUrl: string;
+            quantity?: number;
             trialPeriodDays?: number;
           };
         };
@@ -2352,6 +2345,62 @@ export interface paths {
         };
       };
     };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/billing/provider-status": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get billing provider readiness */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Billing provider readiness */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              provider: string;
+              /** @enum {string} */
+              status: "disabled" | "degraded" | "ready";
+              checkoutReady: boolean;
+              portalReady: boolean;
+              missing: string[];
+              title: string;
+              description: string;
+            };
+          };
+        };
+        /** @description Organization membership required */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -3067,7 +3116,7 @@ export interface paths {
             "application/json": {
               runtime: {
                 /** @enum {string} */
-                provider: "novu" | "direct";
+                provider: "novu" | "knock" | "direct";
                 providerLabel: string;
                 /** @enum {string} */
                 mode: "managed" | "self_hosted" | "preview" | "degraded";
@@ -4252,4 +4301,52 @@ export interface components {
   pathItems: never;
 }
 export type $defs = Record<string, never>;
-export type operations = Record<string, never>;
+export interface operations {
+  createAgentRuntimeTurn: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          input: string;
+          threadId: string;
+          model?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description SSE stream of thread events */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Unauthenticated */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Feature disabled */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Model stack unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+}

--- a/scripts/generate-api-types.ts
+++ b/scripts/generate-api-types.ts
@@ -46,8 +46,12 @@ if (gatewayUrl) {
   formatGeneratedTypes();
 } else {
   // ── File mode: build gateway → export spec → generate types ───────────────
-  process.stdout.write("[generate:api-types] Building api-gateway…\n");
-  execSync("pnpm --filter @nebutra/gateway build", {
+  // Build via turbo so workspace dependencies (their dist/ outputs) are built
+  // first via `^build`. A bare `pnpm --filter @nebutra/gateway build` compiles
+  // only the gateway and fails with ERR_MODULE_NOT_FOUND when a dependency's
+  // dist/ is missing (the environmental cause of the contract-chain breakage).
+  process.stdout.write("[generate:api-types] Building api-gateway (+ workspace deps)…\n");
+  execSync("pnpm exec turbo run build --filter=@nebutra/gateway", {
     stdio: "inherit",
     cwd: ROOT,
     env: { ...process.env, SKIP_ENV_VALIDATION: "true" },
@@ -69,6 +73,12 @@ if (gatewayUrl) {
     process.stderr.write(`[generate:api-types] Spec file not found: ${specFile}\n`);
     process.exit(1);
   }
+
+  // export-spec.ts writes raw `JSON.stringify(spec, null, 2)` (arrays expanded),
+  // but the committed spec is Biome-formatted (short arrays collapsed). Format
+  // it here so the canonical artifact stays churn-free across regenerations.
+  process.stdout.write("[generate:api-types] Formatting OpenAPI spec with Biome\n");
+  execSync(`pnpm exec biome format --write ${specFile}`, { stdio: "inherit", cwd: ROOT });
 
   process.stdout.write(`[generate:api-types] Generating types from ${specFile}\n`);
   execSync(`pnpm exec openapi-typescript ${specFile} --output ${outFile}`, {


### PR DESCRIPTION
## Summary
- Regenerates `apps/web/src/lib/api/types.generated.ts` from the current OpenAPI spec. The committed types still referenced Python backends removed per ADR 2026-05-10 (`recsys`/`ecommerce`/`web3`/`content`/`event-ingest`), while the committed spec had already dropped them — so CI's `git diff --exit-code types.generated.ts` drift gate was red.
- Hardens `scripts/generate-api-types.ts`: builds workspace deps via turbo (`^build`) before the gateway `tsc` (removes the `ERR_MODULE_NOT_FOUND` root cause from #117), and Biome-formats the exported spec so the committed artifact stays churn-free across regenerations.
- `openapi.json` itself is unchanged — it was already current; the large diff seen during diagnosis was purely unformatted-array churn, which Biome formatting collapses to zero.

## Why
#117 reported the gateway build chain broken. Root cause was environmental (a dependency's `dist/` not built when the filtered build is invoked directly), not a source defect — build/typecheck/spec/type-gen all pass once deps are built. The residual *real* drift was the stale generated client types, which this regenerates.

## Test plan
- [x] `pnpm --filter @nebutra/web generate:api-types` runs end-to-end and is deterministic across two consecutive runs (spec stable, types stable at +151/-54)
- [x] `turbo typecheck --filter="...[origin/main]"` green — web typechecks with the dead-service types removed (no web code references them)
- [ ] CI `openapi-validate` passes (`git diff --exit-code types.generated.ts` clean after regeneration)

Closes #117