### PR TITLE
docs(env): sync apps/web + tsekaluk-dev .env.example with read variables

### DIFF
--- a/apps/tsekaluk-dev/.env.example
+++ b/apps/tsekaluk-dev/.env.example
@@ -40,3 +40,10 @@ LANGFUSE_BASE_URL=https://cloud.langfuse.com
 # Auth (Better Auth)
 AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3002
+
+# Public site URL
+NEXT_PUBLIC_SITE_URL=http://localhost:3002
+
+# Discourse SSO (community bridge) — leave blank to disable
+DISCOURSE_URL=
+DISCOURSE_SSO_SECRET=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -91,3 +91,95 @@ CLICKHOUSE_DATABASE=nebutra
 CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=
 DEFAULT_DASHBOARD_TENANT_ID=demo_org
+
+# ──────────────────────────────────────────────────────────────────────────
+# App URLs (public) — defaults target the local dev port layout
+# ──────────────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3001
+NEXT_PUBLIC_STUDIO_URL=http://localhost:3003
+NEXT_PUBLIC_API_GATEWAY_URL=http://localhost:3002
+# Server-side absolute app URL for invite/member emails (falls back to NEXT_PUBLIC_APP_URL)
+APP_URL=http://localhost:3001
+
+# ──────────────────────────────────────────────────────────────────────────
+# Additional OAuth providers (Apple / Microsoft — Better Auth / NextAuth)
+# ──────────────────────────────────────────────────────────────────────────
+APPLE_CLIENT_ID=
+APPLE_CLIENT_SECRET=
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+# NextAuth secret alias read by some routes (mirror of AUTH_SECRET)
+NEXTAUTH_SECRET=
+# Optional Clerk hosted user-profile URL
+NEXT_PUBLIC_CLERK_USER_PROFILE_URL=
+
+# ──────────────────────────────────────────────────────────────────────────
+# Access gate + invites (early-access controls)
+#   ACCESS_GATE_MODE: "open" | "invite" | "waitlist" (mirror to the public var)
+# ──────────────────────────────────────────────────────────────────────────
+ACCESS_GATE_MODE=open
+NEXT_PUBLIC_ACCESS_GATE_MODE=open
+ACCESS_INVITE_ISSUER_QUOTA=
+AUTH_SSO_DISCOVERY_PROVIDERS=
+# Dub short-link API (invite links) — leave blank to disable
+DUB_API_KEY=
+DUB_DEFAULT_DOMAIN=
+DUB_WORKSPACE_ID=
+
+# ──────────────────────────────────────────────────────────────────────────
+# Billing (Stripe)
+# ──────────────────────────────────────────────────────────────────────────
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+# Price IDs (STRIPE_PRICE_ID_* preferred; PRICE_ID_* kept as fallback aliases)
+STRIPE_PRICE_ID_PRO_MONTHLY=
+STRIPE_PRICE_ID_PRO_YEARLY=
+PRICE_ID_PRO_MONTHLY=
+PRICE_ID_PRO_YEARLY=
+
+# ──────────────────────────────────────────────────────────────────────────
+# AI chat (server) — first provider with a key wins
+# ──────────────────────────────────────────────────────────────────────────
+OPENAI_API_KEY=
+OPENROUTER_API_KEY=
+SILICONFLOW_API_KEY=
+
+# ──────────────────────────────────────────────────────────────────────────
+# Uploads + transactional email
+# ──────────────────────────────────────────────────────────────────────────
+UPLOADS_PUBLIC_BASE_URL=
+EMAIL_FROM=
+
+# ──────────────────────────────────────────────────────────────────────────
+# Cron — shared secret guarding /api/cron/* (sent as a Bearer token)
+# ──────────────────────────────────────────────────────────────────────────
+CRON_SECRET=
+
+# ──────────────────────────────────────────────────────────────────────────
+# Social login widgets (China)
+# ──────────────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_WECHAT_APP_ID=
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+
+# ──────────────────────────────────────────────────────────────────────────
+# Sanity CMS (public client config — project id/dataset are not secrets)
+# ──────────────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_SANITY_PROJECT_ID=wyfqr24v
+NEXT_PUBLIC_SANITY_DATASET=production
+NEXT_PUBLIC_SANITY_API_VERSION=2024-01-01
+
+# ──────────────────────────────────────────────────────────────────────────
+# Observability — Sentry + PostHog (all optional)
+# ──────────────────────────────────────────────────────────────────────────
+SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_RELEASE=
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+# Opt-in: route logger errors to Sentry ("true" | "false")
+LOGGER_SENTRY_ENABLED=false
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com


### PR DESCRIPTION
## Summary
Closes the env-example drift that automation PR #119 does **not** cover (#119 handles `backends/gateway/.env.example`; these two apps were untouched).

- **apps/web/.env.example** — adds the vars the app actually reads but didn't document: Stripe (secret/webhook/publishable + price IDs), full Sentry block + `LOGGER_SENTRY_ENABLED`, PostHog, public app URLs (`SITE/APP/STUDIO/API_GATEWAY`), AI provider keys (OpenAI/OpenRouter/SiliconFlow), access-gate + invite quota + SSO discovery, Dub short-links, Apple/Microsoft OAuth, `CRON_SECRET`, uploads base URL, `EMAIL_FROM`, WeChat/Turnstile, and Sanity public client config.
- **apps/tsekaluk-dev/.env.example** — adds `NEXT_PUBLIC_SITE_URL`, `DISCOURSE_URL`, `DISCOURSE_SSO_SECRET`.

Var set derived deterministically from `apps/web/src/lib/env.ts` (the `createEnv` schema) + a `process.env.*` scan of production source — not guessed.

## Safety
- **Names + safe placeholders only.** Every secret-like var (`*_KEY`/`*_SECRET`/`*_TOKEN`) is left blank; URLs are localhost defaults; Sanity project id/dataset are public (non-secret) client config. No real secret values added.
- "Orphaned" SDK-implicit vars (`ANTHROPIC_API_KEY`, `BLOB_READ_WRITE_TOKEN`, Langfuse) left as-is — they're read by their SDKs, not dead.

## Test plan
- [x] `turbo typecheck` green for web + tsekaluk-dev (pre-push)
- [ ] `gitleaks protect` clean (pre-commit gate already passed locally)

Refs #116