### PR TITLE
fix(web): add (app) route-group error boundary

### DIFF
--- a/apps/web/src/app/[locale]/(app)/error.tsx
+++ b/apps/web/src/app/[locale]/(app)/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { FullPageStatus } from "@nebutra/ui/layout";
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function AppError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <FullPageStatus
+      variant="section"
+      code="Error"
+      title="Something went wrong."
+      description={
+        error.message || "An unexpected error occurred. Try again, or return to the dashboard."
+      }
+      primaryAction={{ label: "Try again", onClick: reset }}
+      secondaryAction={{ label: "Go to dashboard", href: "/workspace" }}
+      meta={error.digest ? { errorId: error.digest } : undefined}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
The authenticated `(app)` route group only had `error.tsx` for `analytics`, `audit`, `billing`, and `tenants`. The other segments — `admin`, `atelier`, `chat`, `integrations`, `notifications`, `settings`, `usage`, `workspace` — had no error boundary, so a render/runtime error in any of them bubbled to an unhandled white-screen instead of a recoverable fallback.

Adds a single group-root `error.tsx` that covers all uncovered segments, mirroring the existing pattern exactly (`Sentry.captureException` in `useEffect` + `FullPageStatus` with a "Try again" reset and "Go to dashboard" link). Segment-level boundaries continue to override where present.

## Why this and not the rest of #113
This is the unambiguous, mechanical A16 win. The remaining #113 items are intentionally left for follow-up issues because a correct fix needs a design decision, not a mechanical edit:
- client-side UI swallows (confetti / CommandBox / cosmic-spectrum / code-block) need a **client** logging transport (`@nebutra/logger` is pino/server-only)
- `packages/ai/mcp` `.catch(console.error)` needs a logger dependency added to that package
- `billing/usage/service.ts` SIGTERM drain silently drops usage on shutdown (data-loss tradeoff)

`backends/gateway/src/routes/webhooks/stripe.ts` is already addressed by #119, so it's untouched here.

## Test plan
- [x] `turbo typecheck` green for `@nebutra/web` (pre-push)
- [ ] Manual: throw in an `(app)` segment without its own boundary → fallback renders + "Try again" recovers

Refs #113