### PR TITLE
[codex] Resolve consistency sweep drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,8 @@ POSTHOG_KEY=""
 POSTHOG_HOST="https://us.i.posthog.com"
 NEXT_PUBLIC_POSTHOG_KEY=""
 NEXT_PUBLIC_POSTHOG_HOST="https://us.i.posthog.com"
+NEBUTRA_POSTHOG_KEY=""
+NEBUTRA_POSTHOG_HOST="https://analytics.nebutra.com"
 
 # OpenTelemetry
 OTEL_ENABLED="false"
@@ -275,6 +277,7 @@ CLICKHOUSE_DATABASE="nebutra"
 CLICKHOUSE_USER="default"
 CLICKHOUSE_PASSWORD=""
 DEFAULT_DASHBOARD_TENANT_ID="demo_org"
+APP_DB_ROLE=""
 
 # ============================================
 # CMS (Sanity)

--- a/apps/landing-page/messages/de.json
+++ b/apps/landing-page/messages/de.json
@@ -71,7 +71,7 @@
       "about": "Über uns",
       "showcase": "Showcase",
       "blog": "Blog",
-      "playbook": "Playbook",
+      "playbook": "Leitfaden",
       "changelog": "Änderungsprotokoll",
       "roadmap": "Roadmap",
       "docs": "Dokumentation",

--- a/apps/landing-page/messages/es.json
+++ b/apps/landing-page/messages/es.json
@@ -72,7 +72,7 @@
       "about": "Acerca de",
       "showcase": "Escaparate",
       "blog": "Blog",
-      "playbook": "Playbook",
+      "playbook": "Guía",
       "changelog": "Registro de cambios",
       "roadmap": "Hoja de ruta",
       "docs": "Documentación",

--- a/apps/landing-page/messages/fr.json
+++ b/apps/landing-page/messages/fr.json
@@ -71,7 +71,7 @@
       "about": "À propos",
       "showcase": "Vitrine",
       "blog": "Blog",
-      "playbook": "Playbook",
+      "playbook": "Guide",
       "changelog": "Journal des modifications",
       "roadmap": "Feuille de route",
       "docs": "Documentation",

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -91,6 +91,7 @@ CLICKHOUSE_DATABASE=nebutra
 CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=
 DEFAULT_DASHBOARD_TENANT_ID=demo_org
+APP_DB_ROLE=
 
 # ──────────────────────────────────────────────────────────────────────────
 # App URLs (public) — defaults target the local dev port layout
@@ -185,3 +186,5 @@ POSTHOG_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+NEBUTRA_POSTHOG_KEY=
+NEBUTRA_POSTHOG_HOST=https://analytics.nebutra.com

--- a/backends/gateway/.env.example
+++ b/backends/gateway/.env.example
@@ -112,6 +112,8 @@ SENTRY_DSN=
 SENTRY_RELEASE=
 POSTHOG_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
+NEBUTRA_POSTHOG_KEY=
+NEBUTRA_POSTHOG_HOST=https://analytics.nebutra.com
 NEBUTRA_TELEMETRY=true
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -128,6 +130,7 @@ S2S_ALLOW_LEGACY=false
 SKIP_ENV_VALIDATION=false
 FEATURE_FLAG_BILLING=true
 AGENT_ROLLOUT_DURABLE=false
+APP_DB_ROLE=
 
 # ──────────────────────────────────────────────────────────────────────────
 # China SMS providers


### PR DESCRIPTION
## What changed
- Localized the landing footer Playbook label in de/es/fr so strict i18n no longer reports untranslated advisory drift.
- Added checked example placeholders for NEBUTRA_POSTHOG_KEY, NEBUTRA_POSTHOG_HOST, and APP_DB_ROLE across root, web, and gateway env examples.

## Why
The consistency sweep found new A2 i18n advisory drift and A11 env contract drift after recent telemetry/RLS changes. These are mechanical, reversible source-of-truth updates.

## Validation
- node apps/landing-page/scripts/verify-i18n-keys.mjs -- --strict
- git diff --check
- custom env example scan for newly introduced process.env reads

## Notes
pnpm i18n:check:strict passed in the main checkout. In the isolated PR worktree, pnpm itself refused to run before install with ERR_PNPM_VERIFY_DEPS_BEFORE_RUN, so the same verifier was run directly.