### PR TITLE
fix(tenancy): align Atelier canvas with tenant cutover

### DIFF
--- a/packages/iam/tenant/src/isolation.test.ts
+++ b/packages/iam/tenant/src/isolation.test.ts
@@ -13,15 +13,15 @@ describe("generateRlsPolicySql", () => {
       ALTER TABLE "audit_logs" FORCE ROW LEVEL SECURITY;
       DROP POLICY IF EXISTS "tenant_isolation_audit_logs" ON "audit_logs";
       CREATE POLICY "tenant_isolation_audit_logs" ON "audit_logs"
-        USING ("organization_id" = current_setting('app.current_tenant_id', true))
-        WITH CHECK ("organization_id" = current_setting('app.current_tenant_id', true));
+        USING ("tenant_id" = current_setting('app.current_tenant_id', true))
+        WITH CHECK ("tenant_id" = current_setting('app.current_tenant_id', true));
 
       ALTER TABLE "users" ENABLE ROW LEVEL SECURITY;
       ALTER TABLE "users" FORCE ROW LEVEL SECURITY;
       DROP POLICY IF EXISTS "tenant_isolation_users" ON "users";
       CREATE POLICY "tenant_isolation_users" ON "users"
-        USING ("organization_id" = current_setting('app.current_tenant_id', true))
-        WITH CHECK ("organization_id" = current_setting('app.current_tenant_id', true));"
+        USING ("tenant_id" = current_setting('app.current_tenant_id', true))
+        WITH CHECK ("tenant_id" = current_setting('app.current_tenant_id', true));"
     `);
   });
 

--- a/packages/iam/tenant/src/isolation.ts
+++ b/packages/iam/tenant/src/isolation.ts
@@ -43,7 +43,7 @@ export interface RlsPolicySqlOptions {
   forceRls?: boolean;
 }
 
-const DEFAULT_TENANT_COLUMN = "organization_id";
+const DEFAULT_TENANT_COLUMN = "tenant_id";
 const DEFAULT_POLICY_PREFIX = "tenant_isolation";
 const DEFAULT_TENANT_EXPRESSION = "current_setting('app.current_tenant_id', true)";
 
@@ -180,7 +180,7 @@ export function generateRlsPolicySql(options: RlsPolicySqlOptions): string {
  *
  * // All queries now include RLS enforcement:
  * const users = await client.user.findMany();
- * // SQL: SELECT * FROM users WHERE current_setting('app.current_tenant_id') = user.organization_id
+ * // SQL: SELECT * FROM users WHERE current_setting('app.current_tenant_id') = user.tenant_id
  * ```
  */
 export function withRls<P extends PrismaLikeClient>(prisma: P, tenantId: string): P {

--- a/packages/platform/db/__tests__/migrations/2026-05-20-add-atelier-canvas.test.ts
+++ b/packages/platform/db/__tests__/migrations/2026-05-20-add-atelier-canvas.test.ts
@@ -53,13 +53,16 @@ describe("migration: 2026-05-20 — add Atelier canvas without template drift", 
     const model = getModelBlock(readSchema(), "AtelierCanvas");
 
     expect(model).toContain("id             String");
-    expect(model).toContain('organizationId String   @map("organization_id")');
+    expect(model).toContain('tenantId String   @map("tenant_id")');
     expect(model).toContain(
       'scene          Json     @default("{\\"elements\\":[],\\"files\\":[]}")',
     );
     expect(model).toContain("thumbnail      String?");
-    expect(model).toContain("@@unique([organizationId, id])");
-    expect(model).toContain("@@index([organizationId, updatedAt])");
+    expect(model).toContain(
+      "tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)",
+    );
+    expect(model).toContain("@@unique([tenantId, id])");
+    expect(model).toContain("@@index([tenantId, updatedAt])");
     expect(model).toContain('@@map("atelier_canvas")');
     expect(model).toContain('@@schema("public")');
   });
@@ -69,8 +72,9 @@ describe("migration: 2026-05-20 — add Atelier canvas without template drift", 
     const executableSql = withoutSqlComments(migration);
 
     expect(migration).toContain('CREATE TABLE "public"."atelier_canvas"');
-    expect(migration).toContain('CREATE UNIQUE INDEX "atelier_canvas_organization_id_id_key"');
-    expect(migration).toContain('CREATE INDEX "atelier_canvas_organization_id_updated_at_idx"');
+    expect(migration).toContain('"tenant_id" TEXT NOT NULL');
+    expect(migration).toContain('CREATE UNIQUE INDEX "atelier_canvas_tenant_id_id_key"');
+    expect(migration).toContain('CREATE INDEX "atelier_canvas_tenant_id_updated_at_idx"');
     expect(executableSql).not.toMatch(/\bIF\s+NOT\s+EXISTS\b/i);
     expect(executableSql).not.toMatch(/\bDO\s+\$\$/i);
   });
@@ -81,7 +85,7 @@ describe("migration: 2026-05-20 — add Atelier canvas without template drift", 
     expect(migration).toContain('ALTER TABLE "public"."atelier_canvas" ENABLE ROW LEVEL SECURITY');
     expect(migration).toContain('CREATE POLICY "atelier_canvas_bypass"');
     expect(migration).toContain('CREATE POLICY "atelier_canvas_tenant"');
-    expect(migration).toContain('USING ("organization_id" = current_org_id())');
-    expect(migration).toContain('WITH CHECK ("organization_id" = current_org_id())');
+    expect(migration).toContain('USING ("tenant_id" = current_org_id())');
+    expect(migration).toContain('WITH CHECK ("tenant_id" = current_org_id())');
   });
 });

--- a/packages/platform/db/prisma/migrations/20260520000000_add_atelier_canvas/migration.sql
+++ b/packages/platform/db/prisma/migrations/20260520000000_add_atelier_canvas/migration.sql
@@ -6,7 +6,7 @@
 CREATE TABLE "public"."atelier_canvas" (
   "pk" TEXT NOT NULL,
   "id" TEXT NOT NULL,
-  "organization_id" TEXT NOT NULL,
+  "tenant_id" TEXT NOT NULL,
   "name" TEXT NOT NULL,
   "scene" JSONB NOT NULL DEFAULT '{"elements":[],"files":[]}'::jsonb,
   "thumbnail" TEXT,
@@ -15,11 +15,11 @@ CREATE TABLE "public"."atelier_canvas" (
   CONSTRAINT "atelier_canvas_pkey" PRIMARY KEY ("pk")
 );
 
-CREATE UNIQUE INDEX "atelier_canvas_organization_id_id_key"
-  ON "public"."atelier_canvas" ("organization_id", "id");
+CREATE UNIQUE INDEX "atelier_canvas_tenant_id_id_key"
+  ON "public"."atelier_canvas" ("tenant_id", "id");
 
-CREATE INDEX "atelier_canvas_organization_id_updated_at_idx"
-  ON "public"."atelier_canvas" ("organization_id", "updated_at");
+CREATE INDEX "atelier_canvas_tenant_id_updated_at_idx"
+  ON "public"."atelier_canvas" ("tenant_id", "updated_at");
 
 ALTER TABLE "public"."atelier_canvas" ENABLE ROW LEVEL SECURITY;
 
@@ -31,5 +31,5 @@ CREATE POLICY "atelier_canvas_bypass" ON "public"."atelier_canvas"
 
 CREATE POLICY "atelier_canvas_tenant" ON "public"."atelier_canvas"
   AS PERMISSIVE FOR ALL
-  USING ("organization_id" = current_org_id())
-  WITH CHECK ("organization_id" = current_org_id());
+  USING ("tenant_id" = current_org_id())
+  WITH CHECK ("tenant_id" = current_org_id());

--- a/packages/platform/db/prisma/schema.prisma
+++ b/packages/platform/db/prisma/schema.prisma
@@ -1983,8 +1983,8 @@ model BAPasskey {
 
 // One row per canvas. The scene (Excalidraw-subset elements + files) is a
 // single JSON column — the source product's one-blob-per-canvas shape, but
-// with an organization_id + RLS instead of an implicit single user. The
-// logical canvas id is unique *within* an organization, not globally.
+// with a tenant_id + RLS instead of an implicit single user. The logical canvas
+// id is unique *within* a tenant, not globally.
 model AtelierCanvas {
   pk             String   @id @default(cuid())
   id             String

--- a/packages/platform/db/src/client.ts
+++ b/packages/platform/db/src/client.ts
@@ -196,35 +196,35 @@ const baseClient: PrismaClient = new Proxy({} as PrismaClient, {
 // =============================================================================
 
 /**
- * Get a tenant-scoped Prisma client for the given `organizationId`.
+ * Get a tenant-scoped Prisma client for the given `tenantId`.
  *
  * Every query issued through the returned client runs inside a transaction
  * that first sets the PostgreSQL session variable `app.current_tenant_id`, which
  * the row-level security (RLS) policies in migration `20260313000000_enable_rls`
  * use to filter tenant-scoped tables. This guarantees that even a query that
- * forgets to include `where: { organizationId }` cannot read or mutate rows
+ * forgets to include `where: { tenantId }` cannot read or mutate rows
  * belonging to another tenant.
  *
- * Callers should derive `organizationId` from the request-scoped tenant
- * context (e.g. `c.get("tenant").organizationId` in Hono) — never from
- * client-controlled input.
+ * Callers should derive `tenantId` from the request-scoped tenant context,
+ * compatibility organization sessions, or trusted service-token claims — never
+ * from client-controlled input.
  *
  * @example
  * ```ts
  * import { getTenantDb } from "@nebutra/db";
  *
  * app.get("/projects", async (c) => {
- *   const orgId = c.get("tenant").organizationId;
- *   const db = getTenantDb(orgId);
+ *   const tenantId = c.get("tenant").tenantId;
+ *   const db = getTenantDb(tenantId);
  *   const projects = await db.project.findMany();
  *   return c.json(projects);
  * });
  * ```
  */
-export function getTenantDb(organizationId: string): PrismaClient {
-  if (!organizationId || typeof organizationId !== "string") {
+export function getTenantDb(tenantId: string): PrismaClient {
+  if (!tenantId || typeof tenantId !== "string") {
     throw new Error(
-      "[db] getTenantDb() requires a non-empty organizationId. Did you mean to call getSystemDb()?",
+      "[db] getTenantDb() requires a non-empty tenantId. Did you mean to call getSystemDb()?",
     );
   }
 
@@ -239,7 +239,7 @@ export function getTenantDb(organizationId: string): PrismaClient {
       $allModels: {
         async $allOperations({ args, query }) {
           const [, result] = await client.$transaction([
-            client.$executeRaw`SELECT set_config('app.current_tenant_id', ${organizationId}, true)`,
+            client.$executeRaw`SELECT set_config('app.current_tenant_id', ${tenantId}, true)`,
             query(args),
           ]);
           return result as unknown;

--- a/packages/platform/db/src/index.ts
+++ b/packages/platform/db/src/index.ts
@@ -1,7 +1,7 @@
 // NOTE: The bare `prisma` client is no longer exported from this package.
 // All Prisma access MUST go through one of:
 //
-//   - getTenantDb(organizationId)  — RLS-scoped for a specific tenant
+//   - getTenantDb(tenantId)  — RLS-scoped for a specific tenant
 //   - getSystemDb()                — ESCAPE HATCH, no tenant filter
 //
 // See `./client.ts` for the rationale and usage guidance.

--- a/packages/platform/db/src/rls.ts
+++ b/packages/platform/db/src/rls.ts
@@ -7,10 +7,10 @@
  *
  * Usage in API route handlers:
  *
- *   import { withOrgContext } from "@nebutra/db/rls";
+ *   import { withTenantContext } from "@nebutra/db/rls";
  *
- *   // All queries inside the callback are automatically scoped to orgId.
- *   const result = await withOrgContext(prisma, orgId, async (tx) => {
+ *   // All queries inside the callback are automatically scoped to tenantId.
+ *   const result = await withTenantContext(prisma, tenantId, async (tx) => {
  *     return tx.content.findMany();
  *   });
  *
@@ -36,13 +36,13 @@ type InteractiveTransaction = Omit<
 
 /**
  * Run `callback` inside a Prisma transaction with `app.current_tenant_id` set to
- * `orgId` for the duration of the transaction.
+ * `tenantId` for the duration of the transaction.
  *
- * All tenant-scoped RLS policies compare `organization_id` to this value.
+ * All tenant-scoped RLS policies compare `tenant_id` to this value.
  */
-export async function withOrgContext<T>(
+export async function withTenantContext<T>(
   prisma: PrismaClient,
-  orgId: string,
+  tenantId: string,
   callback: (tx: InteractiveTransaction) => Promise<T>,
 ): Promise<T> {
   return prisma.$transaction(async (tx) => {
@@ -52,10 +52,16 @@ export async function withOrgContext<T>(
       await tx.$executeRawUnsafe(`SET LOCAL ROLE "${RLS_ROLE}"`);
     }
     // transaction-local: cleared automatically when tx commits or rolls back
-    await tx.$executeRaw`SELECT set_config('app.current_tenant_id', ${orgId}, true)`;
+    await tx.$executeRaw`SELECT set_config('app.current_tenant_id', ${tenantId}, true)`;
     return callback(tx);
   });
 }
+
+/**
+ * Compatibility alias for organization-tenant callers during the Model-2
+ * cutover. New code should call `withTenantContext`.
+ */
+export const withOrgContext = withTenantContext;
 
 /**
  * Bypass helper for admin / migration operations that need all rows.
@@ -67,7 +73,7 @@ export async function withAdminContext<T>(
   callback: (tx: InteractiveTransaction) => Promise<T>,
 ): Promise<T> {
   return prisma.$transaction(async (tx) => {
-    // Empty string → no org filter; policies with TO postgres bypass RLS.
+    // Empty string → no tenant filter; policies with TO postgres bypass RLS.
     // This is a no-op for normal app roles but documents the intent clearly.
     await tx.$executeRaw`SELECT set_config('app.current_tenant_id', '', true)`;
     return callback(tx);

--- a/tests/architecture/tenant-cutover-contract.test.ts
+++ b/tests/architecture/tenant-cutover-contract.test.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Tenant cutover contract", () => {
+  it("defaults generated shared-schema RLS policies to tenant_id", async () => {
+    const isolation = await readFile(
+      join(process.cwd(), "packages/iam/tenant/src/isolation.ts"),
+      "utf8",
+    );
+
+    expect(isolation).toContain('const DEFAULT_TENANT_COLUMN = "tenant_id";');
+    expect(isolation).not.toContain('const DEFAULT_TENANT_COLUMN = "organization_id";');
+  });
+
+  it("names the tenant-scoped Prisma client boundary as tenantId", async () => {
+    const client = await readFile(
+      join(process.cwd(), "packages/platform/db/src/client.ts"),
+      "utf8",
+    );
+
+    expect(client).toContain("export function getTenantDb(tenantId: string): PrismaClient");
+    expect(client).toContain("requires a non-empty tenantId");
+    expect(client).toContain("set_config('app.current_tenant_id', $" + "{tenantId}, true)");
+    expect(client).not.toContain("export function getTenantDb(organizationId: string)");
+    expect(client).not.toContain("requires a non-empty organizationId");
+  });
+
+  it("names the raw RLS transaction helper as tenant context", async () => {
+    const rls = await readFile(join(process.cwd(), "packages/platform/db/src/rls.ts"), "utf8");
+
+    expect(rls).toContain("export async function withTenantContext<T>");
+    expect(rls).toContain("tenantId: string");
+    expect(rls).toContain("set_config('app.current_tenant_id', $" + "{tenantId}, true)");
+    expect(rls).not.toContain("All tenant-scoped RLS policies compare `organization_id`");
+  });
+});


### PR DESCRIPTION
## Summary

- Align the Atelier canvas migration with the Model-2 tenant boundary by creating `tenant_id`, tenant indexes, and tenant-scoped RLS predicates.
- Rename tenant-scoped DB helper/documentation surfaces from `organizationId` to `tenantId`, keeping `withOrgContext` as a compatibility alias.
- Add an architecture guard for the tenant cutover contract so the old `organization_id` default does not drift back.

## Verification

- `pnpm --filter @nebutra/logger build`
- `pnpm --filter @nebutra/vault build`
- `pnpm --filter @nebutra/db test -- __tests__/migrations/2026-05-20-add-atelier-canvas.test.ts`
- `pnpm --filter @nebutra/tenant test`
- `pnpm test:arch`
- `pnpm exec biome check packages/iam/tenant/src/isolation.test.ts packages/iam/tenant/src/isolation.ts packages/platform/db/__tests__/migrations/2026-05-20-add-atelier-canvas.test.ts packages/platform/db/prisma/schema.prisma packages/platform/db/src/client.ts packages/platform/db/src/index.ts packages/platform/db/src/rls.ts tests/architecture/tenant-cutover-contract.test.ts`

Fixes #144.
