### PR TITLE
fix(ai): restore Python CI health

### DIFF
--- a/backends/python/ai/app/api/v1/routes_agents.py
+++ b/backends/python/ai/app/api/v1/routes_agents.py
@@ -67,7 +67,9 @@ async def run_agent(
     if request.system_prompt:
         messages.append(ChatMessage(role="system", content=request.system_prompt))
     for m in request.messages:
-        messages.append(ChatMessage(role=m.get("role", "user"), content=m.get("content", "")))
+        messages.append(
+            ChatMessage(role=m.get("role", "user"), content=m.get("content", ""))
+        )
 
     chat_req = ChatCompletionRequest(
         model=request.model or default_model,

--- a/backends/python/ai/app/api/v1/routes_generate.py
+++ b/backends/python/ai/app/api/v1/routes_generate.py
@@ -22,8 +22,8 @@ from pydantic import BaseModel, Field
 from _shared.auth import TenantContext, get_tenant
 from _shared.contracts import UsageEvent
 from _shared.usage import dispatch_usage
-from providers.factory import get_default_provider
 from providers.base import ChatCompletionRequest, ChatMessage
+from providers.factory import get_default_provider
 
 router = APIRouter()
 
@@ -65,12 +65,13 @@ class GenerateResponse(BaseModel):
 # ── Shared helper ─────────────────────────────────────────────────────────────
 
 
-def _build_chat_request(req: GenerateRequest, provider_default_model: str) -> ChatCompletionRequest:
+def _build_chat_request(
+    req: GenerateRequest, provider_default_model: str
+) -> ChatCompletionRequest:
     return ChatCompletionRequest(
         model=req.model or provider_default_model,
         messages=[
-            ChatMessage(role=m.role, content=m.content)
-            for m in req.to_messages()
+            ChatMessage(role=m.role, content=m.content) for m in req.to_messages()
         ],
         temperature=req.temperature,
         max_tokens=req.max_tokens,
@@ -184,7 +185,11 @@ async def generate_stream(
             return
 
         duration_ms = (time.perf_counter() - start) * 1000
-        yield f"data: {json.dumps({'delta': '', 'done': True, 'total_tokens': token_estimate})}\n\n"
+        yield (
+            "data: "
+            f"{json.dumps({'delta': '', 'done': True, 'total_tokens': token_estimate})}"
+            "\n\n"
+        )
 
         _dispatch(
             tenant=tenant,

--- a/backends/python/ai/app/api/v1/routes_sandbox.py
+++ b/backends/python/ai/app/api/v1/routes_sandbox.py
@@ -56,7 +56,7 @@ async def run_code(
     The sandbox is destroyed immediately after execution regardless of outcome.
     """
     try:
-        from e2b_code_interpreter import AsyncSandbox  # noqa: PLC0415
+        from e2b_code_interpreter import AsyncSandbox
     except ImportError:
         raise HTTPException(
             status_code=503,
@@ -73,7 +73,7 @@ async def run_code(
                 sandbox.run_code(request.code, language=request.language),
                 timeout=request.timeout_s,
             )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         raise HTTPException(status_code=408, detail="sandbox_timeout") from None
     except Exception as exc:
         raise HTTPException(

--- a/backends/python/ai/app/main.py
+++ b/backends/python/ai/app/main.py
@@ -11,7 +11,13 @@ from _shared.health import router as health_router
 from _shared.middleware import RequestLoggingMiddleware
 from _shared.otel import instrument_app
 from _shared.usage import start_usage_worker, stop_usage_worker
-from app.api.v1 import routes_agents, routes_embed, routes_generate, routes_sandbox, routes_translate
+from app.api.v1 import (
+    routes_agents,
+    routes_embed,
+    routes_generate,
+    routes_sandbox,
+    routes_translate,
+)
 
 
 @asynccontextmanager
@@ -23,7 +29,10 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(
     title="Nebutra AI Service",
-    description="AI-powered generation, embedding, translation, sandbox, and agent orchestration",
+    description=(
+        "AI-powered generation, embedding, translation, sandbox, "
+        "and agent orchestration"
+    ),
     version="0.2.0",
     lifespan=lifespan,
 )
@@ -32,12 +41,14 @@ instrument_app(app, service_name="ai-service")
 app.add_middleware(RequestLoggingMiddleware)
 app.add_exception_handler(Exception, generic_exception_handler)
 
-# CORS is handled at the Hono API Gateway layer — do not add CORSMiddleware here.
+# CORS is handled at the Hono API Gateway layer.
 
 app.include_router(health_router)
 app.include_router(routes_generate.router, prefix="/api/v1/generate", tags=["generate"])
 app.include_router(routes_embed.router, prefix="/api/v1/embed", tags=["embed"])
-app.include_router(routes_translate.router, prefix="/api/v1/translate", tags=["translate"])
+app.include_router(
+    routes_translate.router, prefix="/api/v1/translate", tags=["translate"]
+)
 app.include_router(routes_sandbox.router, prefix="/api/v1/sandbox", tags=["sandbox"])
 app.include_router(routes_agents.router, prefix="/api/v1/agents", tags=["agents"])
 

--- a/backends/python/ai/providers/_litellm.py
+++ b/backends/python/ai/providers/_litellm.py
@@ -55,8 +55,7 @@ def _openai_route(model: str) -> str:
 
 def _messages_to_dicts(request: ChatCompletionRequest) -> list[dict[str, Any]]:
     return [
-        {"role": m.role, "content": m.content, "name": m.name}
-        for m in request.messages
+        {"role": m.role, "content": m.content, "name": m.name} for m in request.messages
     ]
 
 
@@ -179,9 +178,7 @@ def _adapt_chat_response(response: Any) -> ChatCompletionResponse:
         finish_reason=choice.finish_reason,
         usage={
             "prompt_tokens": getattr(usage, "prompt_tokens", 0) if usage else 0,
-            "completion_tokens": getattr(usage, "completion_tokens", 0)
-            if usage
-            else 0,
+            "completion_tokens": getattr(usage, "completion_tokens", 0) if usage else 0,
             "total_tokens": getattr(usage, "total_tokens", 0) if usage else 0,
         },
         tool_calls=tool_calls,
@@ -219,6 +216,7 @@ async def embedding(
             "total_tokens": getattr(usage, "total_tokens", 0) if usage else 0,
         },
     )
+
 
 # NOTE: reranking is intentionally NOT delegated to litellm. SiliconFlow's
 # /rerank returns ``document`` as an object ({"text": ...} / {"image": ...})

--- a/backends/python/ai/providers/factory.py
+++ b/backends/python/ai/providers/factory.py
@@ -59,6 +59,7 @@ def create_provider(
         )
 
     # Create provider-specific config
+    config: ProviderConfig
     if name == "siliconflow":
         config = SiliconFlowConfig(
             api_key=key,

--- a/backends/python/ai/providers/openrouter.py
+++ b/backends/python/ai/providers/openrouter.py
@@ -254,9 +254,10 @@ OPENROUTER_VARIANTS = {
 class OpenRouterProvider(BaseProvider):
     """OpenRouter unified API provider"""
 
+    config: OpenRouterConfig
+
     def __init__(self, config: OpenRouterConfig):
-        self._config = config
-        self._validate_api_key()
+        super().__init__(config)
 
         self.base_url = config.base_url or OPENROUTER_BASE_URL
 
@@ -288,10 +289,6 @@ class OpenRouterProvider(BaseProvider):
             "vision",
             "reasoning",
         }
-
-    @property
-    def config(self) -> OpenRouterConfig:
-        return self._config
 
     @property
     def name(self) -> str:
@@ -389,7 +386,7 @@ class OpenRouterProvider(BaseProvider):
     # ============================================
 
     async def embed(self, request: EmbeddingRequest) -> EmbeddingResponse:
-        """Create embeddings via OpenRouter (delegated to litellm openai-compatible route).
+        """Create embeddings via OpenRouter.
 
         OpenRouter's ``/embeddings`` endpoint is OpenAI wire-protocol compatible.
         Routing through litellm keeps the same error-handling, retry, and usage

--- a/backends/python/ai/providers/siliconflow.py
+++ b/backends/python/ai/providers/siliconflow.py
@@ -9,6 +9,7 @@ Supports: Chat, Embeddings, Reranking, Image Generation
 
 import os
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 
 import httpx
 
@@ -108,6 +109,7 @@ SILICONFLOW_MODELS: list[ModelInfo] = [
 ]
 
 
+@dataclass
 class SiliconFlowConfig(ProviderConfig):
     """SiliconFlow specific configuration"""
 

--- a/backends/python/ai/requirements.txt
+++ b/backends/python/ai/requirements.txt
@@ -13,3 +13,4 @@ opentelemetry-exporter-otlp-proto-grpc==1.42.1
 opentelemetry-instrumentation-fastapi==0.63b1
 structlog==24.4.0
 setuptools>=65.0.0
+tenacity>=9.1

--- a/backends/python/ai/services/embedding_service.py
+++ b/backends/python/ai/services/embedding_service.py
@@ -10,7 +10,7 @@ async def create_embedding(
     text: str,
     model: str | None = None,
 ) -> dict:
-    """Create a text embedding using the configured AI provider (via provider abstraction layer).
+    """Create a text embedding using the configured AI provider.
 
     The default model is resolved from the ``DEFAULT_EMBEDDING_MODEL`` environment
     variable so that callers do not need to hard-code a vendor-specific model name.

--- a/backends/python/ai/tests/test_embed.py
+++ b/backends/python/ai/tests/test_embed.py
@@ -2,46 +2,50 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 EMBED_URL = "/api/v1/embed/"
 
-MOCK_RESULT = {
-    "embedding": [0.1, 0.2, 0.3],
-    "model": "text-embedding-3-small",
-    "dimensions": 3,
-}
+MOCK_RESULT = SimpleNamespace(
+    embeddings=[[0.1, 0.2, 0.3]],
+    model="text-embedding-3-small",
+    usage={"total_tokens": 3},
+)
 
 
 @pytest.mark.asyncio
 async def test_embed_success(client):
+    provider = SimpleNamespace(name="mock", embed=AsyncMock(return_value=MOCK_RESULT))
+
     with patch(
-        "app.api.v1.routes_embed.create_embedding",
-        new_callable=AsyncMock,
-        return_value=MOCK_RESULT,
+        "app.api.v1.routes_embed.get_default_provider",
+        Mock(return_value=provider),
     ):
-        response = await client.post(EMBED_URL, json={"text": "hello world"})
+        response = await client.post(EMBED_URL, json={"input": "hello world"})
 
     assert response.status_code == 200
     data = response.json()
-    assert data["embedding"] == [0.1, 0.2, 0.3]
+    assert data["embeddings"] == [[0.1, 0.2, 0.3]]
     assert data["dimensions"] == 3
 
 
 @pytest.mark.asyncio
 async def test_embed_custom_model(client):
+    provider = SimpleNamespace(name="mock", embed=AsyncMock(return_value=MOCK_RESULT))
+
     with patch(
-        "app.api.v1.routes_embed.create_embedding",
-        new_callable=AsyncMock,
-        return_value=MOCK_RESULT,
-    ) as mock_fn:
+        "app.api.v1.routes_embed.get_default_provider",
+        Mock(return_value=provider),
+    ):
         await client.post(
             EMBED_URL,
-            json={"text": "test", "model": "text-embedding-3-large"},
+            json={"input": "test", "model": "text-embedding-3-large"},
         )
-        assert mock_fn.call_args.kwargs.get("model") == "text-embedding-3-large"
+        embed_request = provider.embed.call_args.args[0]
+        assert embed_request.model == "text-embedding-3-large"
 
 
 @pytest.mark.asyncio
@@ -54,11 +58,14 @@ async def test_embed_empty_text_returns_422(client):
 
 @pytest.mark.asyncio
 async def test_embed_service_error_returns_500(client):
-    with patch(
-        "app.api.v1.routes_embed.create_embedding",
-        new_callable=AsyncMock,
-        side_effect=ConnectionError("OpenAI unreachable"),
-    ):
-        response = await client.post(EMBED_URL, json={"text": "fail"})
+    provider = SimpleNamespace(
+        name="mock", embed=AsyncMock(side_effect=ConnectionError("OpenAI unreachable"))
+    )
 
-    assert response.status_code == 500
+    with patch(
+        "app.api.v1.routes_embed.get_default_provider",
+        Mock(return_value=provider),
+    ):
+        response = await client.post(EMBED_URL, json={"input": "fail"})
+
+    assert response.status_code == 502

--- a/backends/python/ai/tests/test_generate.py
+++ b/backends/python/ai/tests/test_generate.py
@@ -2,25 +2,33 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 GENERATE_URL = "/api/v1/generate/"
 
-MOCK_RESULT = {
-    "text": "Hello, world!",
-    "model": "gpt-5.2",
-    "tokens_used": 12,
-}
+MOCK_RESULT = SimpleNamespace(
+    content="Hello, world!",
+    model="gpt-5.2",
+    usage={
+        "prompt_tokens": 5,
+        "completion_tokens": 7,
+        "total_tokens": 12,
+    },
+    finish_reason="stop",
+    tool_calls=None,
+)
 
 
 @pytest.mark.asyncio
 async def test_generate_success(client):
+    provider = SimpleNamespace(name="mock", chat=AsyncMock(return_value=MOCK_RESULT))
+
     with patch(
-        "app.api.v1.routes_generate.generate_text",
-        new_callable=AsyncMock,
-        return_value=MOCK_RESULT,
+        "app.api.v1.routes_generate.get_default_provider",
+        Mock(return_value=provider),
     ):
         response = await client.post(
             GENERATE_URL,
@@ -31,36 +39,40 @@ async def test_generate_success(client):
     data = response.json()
     assert data["text"] == "Hello, world!"
     assert data["model"] == "gpt-5.2"
-    assert data["tokens_used"] == 12
+    assert data["total_tokens"] == 12
 
 
 @pytest.mark.asyncio
 async def test_generate_default_model(client):
-    """Defaults to gpt-5.2 when model is omitted."""
+    """Defaults to the route provider model when model is omitted."""
+    provider = SimpleNamespace(name="mock", chat=AsyncMock(return_value=MOCK_RESULT))
+
     with patch(
-        "app.api.v1.routes_generate.generate_text",
-        new_callable=AsyncMock,
-        return_value=MOCK_RESULT,
-    ) as mock_fn:
+        "app.api.v1.routes_generate.get_default_provider",
+        Mock(return_value=provider),
+    ):
         await client.post(GENERATE_URL, json={"prompt": "hi"})
-        call_kwargs = mock_fn.call_args.kwargs
-        assert call_kwargs.get("model", "gpt-5.2") == "gpt-5.2"
+        chat_request = provider.chat.call_args.args[0]
+        assert chat_request.model == "Qwen/Qwen2.5-72B-Instruct"
 
 
 @pytest.mark.asyncio
 async def test_generate_service_error_returns_500(client):
+    provider = SimpleNamespace(
+        name="mock", chat=AsyncMock(side_effect=RuntimeError("upstream failure"))
+    )
+
     with patch(
-        "app.api.v1.routes_generate.generate_text",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("upstream failure"),
+        "app.api.v1.routes_generate.get_default_provider",
+        Mock(return_value=provider),
     ):
         response = await client.post(
             GENERATE_URL,
             json={"prompt": "fail"},
         )
 
-    assert response.status_code == 500
-    assert "internal server error" in response.json()["detail"].lower()
+    assert response.status_code == 502
+    assert "provider error" in response.json()["detail"].lower()
 
 
 @pytest.mark.asyncio

--- a/backends/python/ai/tests/test_services.py
+++ b/backends/python/ai/tests/test_services.py
@@ -1,0 +1,78 @@
+"""Tests for provider-backed service compatibility helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from services.embedding_service import create_embedding
+from services.llm_service import generate_text
+from services.translate_service import translate_text
+
+
+@pytest.mark.asyncio
+async def test_generate_text_uses_provider_chat():
+    provider = SimpleNamespace(
+        chat=AsyncMock(
+            return_value=SimpleNamespace(
+                content="Hello",
+                model="mock-chat",
+                usage={"total_tokens": 4},
+            )
+        )
+    )
+
+    with patch(
+        "services.llm_service.get_default_provider", Mock(return_value=provider)
+    ):
+        result = await generate_text("Say hello", max_tokens=12, temperature=0.1)
+
+    chat_request = provider.chat.call_args.args[0]
+    assert chat_request.model == "Qwen/Qwen2.5-72B-Instruct"
+    assert chat_request.messages[0].content == "Say hello"
+    assert chat_request.max_tokens == 12
+    assert result == {"text": "Hello", "model": "mock-chat", "tokens_used": 4}
+
+
+@pytest.mark.asyncio
+async def test_create_embedding_uses_provider_embed():
+    provider = SimpleNamespace(
+        embed=AsyncMock(
+            return_value=SimpleNamespace(
+                embeddings=[[0.1, 0.2]],
+                model="mock-embedding",
+            )
+        )
+    )
+
+    with patch(
+        "services.embedding_service.get_default_provider", Mock(return_value=provider)
+    ):
+        result = await create_embedding("hello", model="custom-embedding")
+
+    embed_request = provider.embed.call_args.args[0]
+    assert embed_request.model == "custom-embedding"
+    assert embed_request.input == "hello"
+    assert result == {
+        "embedding": [0.1, 0.2],
+        "model": "mock-embedding",
+        "dimensions": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_translate_text_preserves_legacy_response_shape():
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(content="你好", model="mock-chat"))
+    )
+
+    with patch(
+        "services.translate_service.get_default_provider", Mock(return_value=provider)
+    ):
+        result = await translate_text("hello", source="en", target="zh")
+
+    chat_request = provider.chat.call_args.args[0]
+    assert "from English to Chinese" in chat_request.messages[0].content
+    assert result == {"translatedText": "你好", "source": "en", "target": "zh"}


### PR DESCRIPTION
## Summary
- Fix Python CI ruff failures in `backends/python/ai` without weakening checks.
- Align provider typing so the CI mypy step passes.
- Update stale AI route tests to the current provider-backed API contract and add service helper coverage so the existing coverage gate remains intact.

## Daily health findings
- A1 changed-file scan: no new hardcoded secret/token/connection-string hits in this PR.
- A6 root cause: latest Dependabot Python PRs (#157/#158) fail in `Python CI (ai)` at ruff lint; after lint repair, local verification also exposed real format, mypy, and coverage blockers that this PR fixes.

## Verification
- `ruff check . --output-format=github`
- `ruff format . --check`
- `mypy . --ignore-missing-imports --no-error-summary`
- `bandit -r app providers services utils -q`
- `pytest -q`
