### PR TITLE
fix: declare task route response schemas

### DIFF
--- a/backends/gateway/openapi.json
+++ b/backends/gateway/openapi.json
@@ -2394,7 +2394,95 @@
         },
         "responses": {
           "202": {
-            "description": "Task envelope"
+            "description": "Task envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": ["queued", "running", "succeeded", "failed", "cancelled"]
+                    },
+                    "progress": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 100
+                    },
+                    "queue": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "string",
+                      "enum": ["low", "normal", "high"]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "result": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": {}
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": {}
+                    },
+                    "dispatcher_provider": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "provider_job_id": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "started_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "completed_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "type",
+                    "status",
+                    "progress",
+                    "queue",
+                    "priority",
+                    "metadata",
+                    "result",
+                    "error",
+                    "dispatcher_provider",
+                    "provider_job_id",
+                    "created_at",
+                    "updated_at",
+                    "started_at",
+                    "completed_at"
+                  ]
+                }
+              }
+            }
           },
           "401": {
             "description": "Authentication required"
@@ -2403,7 +2491,20 @@
             "description": "Organization membership required"
           },
           "503": {
-            "description": "Task origin unavailable"
+            "description": "Task origin unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
           }
         }
       }
@@ -2427,7 +2528,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Server-sent task events"
+            "description": "Server-sent task events",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "description": "Server-sent events stream; each task event carries a TaskEnvelope JSON payload.",
+                  "example": "event: task\ndata: {\"id\":\"task_1\",\"type\":\"document.parse\",\"status\":\"running\",\"progress\":50}\n\n"
+                }
+              }
+            }
           },
           "401": {
             "description": "Authentication required"
@@ -2436,7 +2546,20 @@
             "description": "Organization membership required"
           },
           "503": {
-            "description": "Task origin unavailable"
+            "description": "Task origin unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
           }
         }
       }
@@ -2460,7 +2583,95 @@
         ],
         "responses": {
           "200": {
-            "description": "Task envelope"
+            "description": "Task envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": ["queued", "running", "succeeded", "failed", "cancelled"]
+                    },
+                    "progress": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 100
+                    },
+                    "queue": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "string",
+                      "enum": ["low", "normal", "high"]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "result": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": {}
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": {}
+                    },
+                    "dispatcher_provider": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "provider_job_id": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "started_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "completed_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "type",
+                    "status",
+                    "progress",
+                    "queue",
+                    "priority",
+                    "metadata",
+                    "result",
+                    "error",
+                    "dispatcher_provider",
+                    "provider_job_id",
+                    "created_at",
+                    "updated_at",
+                    "started_at",
+                    "completed_at"
+                  ]
+                }
+              }
+            }
           },
           "401": {
             "description": "Authentication required"
@@ -2472,7 +2683,20 @@
             "description": "Task not found"
           },
           "503": {
-            "description": "Task origin unavailable"
+            "description": "Task origin unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
           }
         }
       }
@@ -2496,7 +2720,95 @@
         ],
         "responses": {
           "200": {
-            "description": "Task envelope"
+            "description": "Task envelope",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": ["queued", "running", "succeeded", "failed", "cancelled"]
+                    },
+                    "progress": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 100
+                    },
+                    "queue": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "string",
+                      "enum": ["low", "normal", "high"]
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    },
+                    "result": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": {}
+                    },
+                    "error": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": {}
+                    },
+                    "dispatcher_provider": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "provider_job_id": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "started_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "completed_at": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "type",
+                    "status",
+                    "progress",
+                    "queue",
+                    "priority",
+                    "metadata",
+                    "result",
+                    "error",
+                    "dispatcher_provider",
+                    "provider_job_id",
+                    "created_at",
+                    "updated_at",
+                    "started_at",
+                    "completed_at"
+                  ]
+                }
+              }
+            }
           },
           "401": {
             "description": "Authentication required"
@@ -2508,7 +2820,20 @@
             "description": "Task not found"
           },
           "503": {
-            "description": "Task origin unavailable"
+            "description": "Task origin unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
           }
         }
       }

--- a/backends/gateway/src/routes/tasks/index.ts
+++ b/backends/gateway/src/routes/tasks/index.ts
@@ -26,6 +26,37 @@ taskRoutes.use("*", requireAuth, requireOrganization);
 
 const JsonRecordSchema = z.record(z.string(), z.unknown());
 
+const TaskStatusSchema = z.enum(["queued", "running", "succeeded", "failed", "cancelled"]);
+const TaskPrioritySchema = z.enum(["low", "normal", "high"]);
+
+const TaskEnvelopeSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  status: TaskStatusSchema,
+  progress: z.number().int().min(0).max(100),
+  queue: z.string(),
+  priority: TaskPrioritySchema,
+  metadata: JsonRecordSchema,
+  result: JsonRecordSchema.nullable(),
+  error: JsonRecordSchema.nullable(),
+  dispatcher_provider: z.string().nullable(),
+  provider_job_id: z.string().nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  started_at: z.string().datetime().nullable(),
+  completed_at: z.string().datetime().nullable(),
+});
+
+const ErrorResponseSchema = z.object({
+  error: z.string(),
+});
+
+const SseStreamSchema = z.string().openapi({
+  description: "Server-sent events stream; each task event carries a TaskEnvelope JSON payload.",
+  example:
+    'event: task\ndata: {"id":"task_1","type":"document.parse","status":"running","progress":50}\n\n',
+});
+
 const TaskCreateRequestSchema = z.object({
   type: z
     .string()
@@ -135,10 +166,16 @@ const createTaskRoute = createRoute({
   summary: "Create a long-running origin task",
   request: { body: { content: { "application/json": { schema: TaskCreateRequestSchema } } } },
   responses: {
-    202: { description: "Task envelope" },
+    202: {
+      description: "Task envelope",
+      content: { "application/json": { schema: TaskEnvelopeSchema } },
+    },
     401: { description: "Authentication required" },
     403: { description: "Organization membership required" },
-    503: { description: "Task origin unavailable" },
+    503: {
+      description: "Task origin unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
   },
 });
 
@@ -157,10 +194,16 @@ const streamTaskEventsRoute = createRoute({
   summary: "Stream task state changes",
   request: { params: TaskIdParamsSchema },
   responses: {
-    200: { description: "Server-sent task events" },
+    200: {
+      description: "Server-sent task events",
+      content: { "text/event-stream": { schema: SseStreamSchema } },
+    },
     401: { description: "Authentication required" },
     403: { description: "Organization membership required" },
-    503: { description: "Task origin unavailable" },
+    503: {
+      description: "Task origin unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
   },
 });
 
@@ -183,11 +226,17 @@ const cancelTaskRoute = createRoute({
   summary: "Cancel a long-running origin task",
   request: { params: TaskIdParamsSchema },
   responses: {
-    200: { description: "Task envelope" },
+    200: {
+      description: "Task envelope",
+      content: { "application/json": { schema: TaskEnvelopeSchema } },
+    },
     401: { description: "Authentication required" },
     403: { description: "Organization membership required" },
     404: { description: "Task not found" },
-    503: { description: "Task origin unavailable" },
+    503: {
+      description: "Task origin unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
   },
 });
 
@@ -210,11 +259,17 @@ const getTaskRoute = createRoute({
   summary: "Get a task envelope",
   request: { params: TaskIdParamsSchema },
   responses: {
-    200: { description: "Task envelope" },
+    200: {
+      description: "Task envelope",
+      content: { "application/json": { schema: TaskEnvelopeSchema } },
+    },
     401: { description: "Authentication required" },
     403: { description: "Organization membership required" },
     404: { description: "Task not found" },
-    503: { description: "Task origin unavailable" },
+    503: {
+      description: "Task origin unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
   },
 });
 

--- a/tests/architecture/api-contract.test.ts
+++ b/tests/architecture/api-contract.test.ts
@@ -197,9 +197,12 @@ describe("Property 5b: OpenAPI Spec File", () => {
         for (const [code, resp] of Object.entries(op.responses)) {
           if (code !== "200" && code !== "201") continue;
           const key = `${method.toUpperCase()} ${path} ${code}`;
-          const hasJson =
-            !!resp.content && Object.hasOwn(resp.content as object, "application/json");
-          if (!hasJson && !KNOWN_JSON_CONTENT_DEBT.has(key)) {
+          const declaredContent =
+            resp.content && typeof resp.content === "object" ? (resp.content as object) : null;
+          const hasJson = !!declaredContent && Object.hasOwn(declaredContent, "application/json");
+          const declaresNonJsonContent =
+            !!declaredContent && Object.keys(declaredContent).length > 0;
+          if (!hasJson && !declaresNonJsonContent && !KNOWN_JSON_CONTENT_DEBT.has(key)) {
             newDrift.push(key);
           }
           if (hasJson && KNOWN_JSON_CONTENT_DEBT.has(key)) {


### PR DESCRIPTION
## Summary
- declare TaskEnvelope response schemas for gateway task create/get/cancel routes
- declare task event streams as text/event-stream instead of leaving 200 content-less
- keep the A9 OpenAPI drift guard focused on content-less JSON responses while allowing explicit non-JSON streams

## Verification
- pnpm exec biome check backends/gateway/src/routes/tasks/index.ts tests/architecture/api-contract.test.ts
- pnpm vitest run tests/architecture/api-contract.test.ts
- pnpm --filter @nebutra/gateway test -- src/routes/tasks/index.test.ts