### PR TITLE
fix(landing): refresh capability folder stats

### DIFF
--- a/apps/landing-page/src/components/landing/features/capability-folder-data.ts
+++ b/apps/landing-page/src/components/landing/features/capability-folder-data.ts
@@ -79,11 +79,11 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
     icon: Bot,
     layout: "wide",
     sourceStats: {
-      unitCount: 38,
+      unitCount: 40,
       unitLabel: copy("packages", "包"),
-      sourceFiles: 192,
-      testFiles: 95,
-      readmes: 33,
+      sourceFiles: 219,
+      testFiles: 116,
+      readmes: 34,
     },
     title: copy("AI Runtime & Agent Substrate", "AI 运行时与智能体底座"),
     summary: copy(
@@ -95,11 +95,11 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
       "这张卡按工作台设计：@nebutra/agent-runtime 位于中心，检索、工具、沙箱、供应商与媒体包围绕它协同。",
     ),
     signature: {
-      value: "38",
+      value: "40",
       label: copy("AI packages", "AI 包"),
       detail: copy(
-        "192 runtime source files and 95 tests, with the heaviest coverage in agent-runtime, knowledge-rag, reel, graph, and execution policies.",
-        "192 个运行时源码文件与 95 个测试，重心落在 agent-runtime、knowledge-rag、reel、graph 与 execution policy。",
+        "219 runtime source files and 116 tests, with the heaviest coverage in agent-runtime, knowledge-rag, reel, graph, and execution policies.",
+        "219 个运行时源码文件与 116 个测试，重心落在 agent-runtime、knowledge-rag、reel、graph 与 execution policy。",
       ),
     },
     topology: {
@@ -172,7 +172,7 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
         detail: copy("retrieval contracts and ingestion behavior", "检索契约与 ingestion 行为"),
       },
       {
-        value: "33",
+        value: "34",
         label: copy("README surfaces", "README 面"),
         detail: copy("package-level docs for most AI capabilities", "多数 AI 能力有包级文档"),
       },
@@ -228,8 +228,8 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
     sourceStats: {
       unitCount: 18,
       unitLabel: copy("packages", "包"),
-      sourceFiles: 149,
-      testFiles: 30,
+      sourceFiles: 164,
+      testFiles: 35,
       readmes: 13,
     },
     title: copy("Platform Control Plane", "平台控制平面"),
@@ -245,8 +245,8 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
       value: "18",
       label: copy("foundation packages", "基础包"),
       detail: copy(
-        "149 runtime source files spanning db, gateway-core, provider-factory, tenant-store, trace-store, config, errors, and observability.",
-        "149 个运行时源码文件覆盖 db、gateway-core、provider-factory、tenant-store、trace-store、config、errors 与可观测性。",
+        "164 runtime source files spanning db, gateway-core, provider-factory, tenant-store, trace-store, config, errors, and observability.",
+        "164 个运行时源码文件覆盖 db、gateway-core、provider-factory、tenant-store、trace-store、config、errors 与可观测性。",
       ),
     },
     topology: {
@@ -378,7 +378,7 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
     sourceStats: {
       unitCount: 8,
       unitLabel: copy("packages", "包"),
-      sourceFiles: 91,
+      sourceFiles: 92,
       testFiles: 27,
       readmes: 8,
     },
@@ -506,8 +506,8 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
     sourceStats: {
       unitCount: 8,
       unitLabel: copy("packages", "包"),
-      sourceFiles: 1139,
-      testFiles: 27,
+      sourceFiles: 1150,
+      testFiles: 33,
       readmes: 9,
     },
     title: copy("Design System Supply Chain", "设计系统供应链"),
@@ -642,7 +642,7 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
       unitCount: 17,
       unitLabel: copy("packages", "包"),
       sourceFiles: 103,
-      testFiles: 34,
+      testFiles: 35,
       readmes: 14,
     },
     title: copy("Integration Runtime Layer", "集成运行时层"),
@@ -771,7 +771,7 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
       unitCount: 9,
       unitLabel: copy("packages", "包"),
       sourceFiles: 86,
-      testFiles: 21,
+      testFiles: 22,
       readmes: 9,
     },
     title: copy("Commercial System of Record", "商业系统记录源"),
@@ -908,8 +908,8 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
     sourceStats: {
       unitCount: 1,
       unitLabel: copy("backend", "后端"),
-      sourceFiles: 68,
-      testFiles: 22,
+      sourceFiles: 82,
+      testFiles: 27,
       readmes: 0,
     },
     title: copy("Typed API Gateway Boundary", "类型化 API 网关边界"),
@@ -922,7 +922,7 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
       "这张卡按请求路径设计，因为 gateway 的价值只有把 middleware 顺序、route 契约与异步 jobs 放在一起才看得清。",
     ),
     signature: {
-      value: "22",
+      value: "27",
       label: copy("gateway tests", "gateway 测试"),
       detail: copy(
         "Billing idempotency, RBAC, middleware, queue delivery, events, health, notifications, and AI gateway routes are covered.",
@@ -975,7 +975,7 @@ export const CAPABILITY_FOLDERS: CapabilityFolder[] = [
     ],
     evidence: [
       {
-        value: "63",
+        value: "82",
         label: copy("source files", "源码文件"),
         detail: copy(
           "routes, middleware, services, clients, adapters",


### PR DESCRIPTION
## Summary
- Refresh landing capability folder source/test/README counts against the current repository tree.
- Keep visible AI/platform/gateway metric copy aligned with the counted values.

## Verification
- `pnpm --filter @nebutra/landing-page test -- capability-folder-data` (passed in primary worktree)
- `pnpm --filter @nebutra/landing-page typecheck` (passed in primary worktree)
- `pnpm size` (passed)

## Notes
- A clean `/tmp` worktree could not run landing validation until all internal `@nebutra/*` packages have built dist outputs; it failed on workspace package resolution, not on this patch.
