### PR TITLE
chore: fix consistency sweep drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ DIRECT_URL="postgresql://postgres:postgres@localhost:5432/nebutra?schema=public"
 # ============================================
 UPSTASH_REDIS_REST_URL="http://localhost:6379"
 UPSTASH_REDIS_REST_TOKEN=""
+# Local/BullMQ-compatible Redis URL. Some scripts also use this as a stub value
+# while exporting runtime contracts.
+REDIS_URL="redis://localhost:6379"
 
 # ============================================
 # Authentication
@@ -27,6 +30,11 @@ UPSTASH_REDIS_REST_TOKEN=""
 # Values: "better-auth" (self-hosted, default) | "nextauth" | "clerk" | "supabase" | "dev"
 AUTH_PROVIDER="better-auth"
 NEXT_PUBLIC_AUTH_PROVIDER="better-auth"
+
+# Early-access gate. Keep server/client values mirrored so server route guards
+# and client-side form fields agree.
+ACCESS_GATE_MODE="open"                # "open" | "invite" | "waitlist"
+NEXT_PUBLIC_ACCESS_GATE_MODE="open"
 
 # --- Better Auth (self-hosted — uses the Postgres from DATABASE_URL) ---
 # Generate with: openssl rand -base64 32
@@ -108,6 +116,7 @@ STRIPE_PRICE_ID_PRO_MONTHLY="price_xxx"
 STRIPE_PRICE_ID_PRO_YEARLY="price_xxx"
 STRIPE_PRICE_ID_ENTERPRISE_MONTHLY="price_xxx"
 STRIPE_PRICE_ID_ENTERPRISE_YEARLY="price_xxx"
+STRIPE_PRICE_ID_STARTUP_LICENSE="price_xxx"
 
 # ============================================
 # Email (@nebutra/email)
@@ -240,6 +249,12 @@ POSTHOG_KEY=""
 POSTHOG_HOST="https://us.i.posthog.com"
 NEXT_PUBLIC_POSTHOG_KEY=""
 NEXT_PUBLIC_POSTHOG_HOST="https://us.i.posthog.com"
+# Product telemetry toggles. Set to "0" or "false" to disable emission.
+NEBUTRA_TELEMETRY="true"
+NEXT_PUBLIC_NEBUTRA_TELEMETRY="true"
+# Optional Nebutra-specific aliases accepted by gateway webhook analytics.
+NEBUTRA_POSTHOG_KEY=""
+NEBUTRA_POSTHOG_HOST=""
 
 # OpenTelemetry
 OTEL_ENABLED="false"
@@ -259,6 +274,7 @@ NEXT_PUBLIC_SITE_URL="http://localhost:3000"           # Production: https://neb
 NEXT_PUBLIC_APP_URL=https://app.nebutra.com
 NEXT_PUBLIC_API_URL=https://api.nebutra.com
 NEXT_PUBLIC_STUDIO_URL="http://localhost:3003"         # Production: https://studio.nebutra.com
+NEXT_PUBLIC_COMMUNITY_URL="https://github.com/Nebutra"
 
 # Internal URLs (server-side only)
 LANDING_URL="http://localhost:3000"
@@ -342,3 +358,8 @@ CRON_SECRET=""
 # ============================================
 NODE_ENV="development"
 LOG_LEVEL="debug"
+
+# E2E controls
+PLAYWRIGHT_BASE_URL="http://127.0.0.1:3100"
+E2E_SKIP_CMS="false"
+E2E_FAIL_ON_PREWARM="false"

--- a/apps/landing-page/src/components/landing/features/glyphs/atelier-canvas-glyph.tsx
+++ b/apps/landing-page/src/components/landing/features/glyphs/atelier-canvas-glyph.tsx
@@ -30,7 +30,7 @@ export function AtelierCanvasGlyph(_props: SubpackageGlyphProps) {
       <div className="mt-5 flex items-start gap-3">
         <div className="relative h-[80px] w-[120px] shrink-0 rounded-[var(--radius-sm)] border border-neutral-7 bg-neutral-1">
           <div className="absolute left-1.5 top-1.5 flex items-center gap-1 font-mono text-[8.5px] text-neutral-9">
-            <Image size={9} />
+            <Image size={9} aria-hidden />
             <span>canvas</span>
           </div>
           {TILE_TINTS.map((tint, i) => (

--- a/apps/landing-page/src/lib/analytics/emit.test.ts
+++ b/apps/landing-page/src/lib/analytics/emit.test.ts
@@ -43,4 +43,19 @@ describe("emitBrowserEvent", () => {
     expect(payload.distinct_id).toMatch(/^anon_/);
     expect(payload.properties.distinct_id).toBe(payload.distinct_id);
   });
+
+  it("reports fallback fetch failures without throwing", async () => {
+    const error = new Error("network down");
+    const onError = vi.fn();
+    Object.defineProperty(window.navigator, "sendBeacon", {
+      configurable: true,
+      value: undefined,
+    });
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error));
+
+    expect(() => emitBrowserEvent("checkout", {}, { onError })).not.toThrow();
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
 });

--- a/apps/landing-page/src/lib/analytics/emit.ts
+++ b/apps/landing-page/src/lib/analytics/emit.ts
@@ -15,6 +15,8 @@ const DEFAULT_POSTHOG_HOST = "https://analytics.nebutra.com";
 export interface EmitOptions {
   /** Pass `true` from a caller that has already opted the user out. */
   noTelemetry?: boolean;
+  /** Optional diagnostics hook. Analytics failures must not interrupt UX. */
+  onError?: (error: unknown) => void;
 }
 
 function isTelemetryDisabled(opts: EmitOptions = {}): boolean {
@@ -79,17 +81,17 @@ export function emitBrowserEvent(
       return;
     }
 
-    // Fallback — fire-and-forget fetch. Errors silently swallowed.
+    // Fallback — fire-and-forget fetch. Report diagnostics without interrupting UX.
     void fetch(`${host}/capture/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
       keepalive: true,
-    }).catch(() => {
-      // Silent
+    }).catch((error: unknown) => {
+      opts.onError?.(error);
     });
-  } catch {
-    // Silent — analytics outages must never break UX.
+  } catch (error) {
+    opts.onError?.(error);
   }
 }
 

--- a/apps/tsekaluk-dev/src/components/guestbook/endorsement-dialog.tsx
+++ b/apps/tsekaluk-dev/src/components/guestbook/endorsement-dialog.tsx
@@ -195,7 +195,7 @@ export function EndorsementDialog({ onSubmitted }: EndorsementDialogProps) {
               className="absolute bottom-0 right-0 flex h-7 w-7 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80 transition-colors"
               aria-label="Change avatar"
             >
-              <Image size={14} />
+              <Image size={14} aria-hidden />
             </button>
             <input
               data-allow-native

--- a/backends/gateway/.env.example
+++ b/backends/gateway/.env.example
@@ -116,6 +116,8 @@ SENTRY_RELEASE=
 POSTHOG_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
 NEBUTRA_TELEMETRY=true
+NEBUTRA_POSTHOG_KEY=
+NEBUTRA_POSTHOG_HOST=
 
 # ──────────────────────────────────────────────────────────────────────────
 # Redis backward-compatible aliases (still accepted by the gateway)

--- a/infra/iac/terraform/README.md
+++ b/infra/iac/terraform/README.md
@@ -247,4 +247,4 @@ docker push "$REGISTRY/$PROJECT_ID/$REPOSITORY/nebutra-web:latest"
 ## Related
 
 - [Cloudflare config](../cloudflare/) — CDN and DNS
-- [Database config](../database/) — RLS policies
+- Database config — RLS policies live outside this Terraform tree.

--- a/scripts/verify-cloud-portability.mjs
+++ b/scripts/verify-cloud-portability.mjs
@@ -30,6 +30,12 @@ function providerIds(manifest) {
 }
 
 const failures = [];
+const writeLine = (message = "") => {
+  process.stdout.write(`${message}\n`);
+};
+const writeErrorLine = (message = "") => {
+  process.stderr.write(`${message}\n`);
+};
 const manifestPath = "infra/platforms/cloud-portability.json";
 
 assert(existsSync(resolve(root, manifestPath)), `${manifestPath} does not exist`, failures);
@@ -147,28 +153,25 @@ assert(
 
 if (doctorMode) {
   const active = manifest.defaultTopology ?? {};
-  console.log("[cloud-portability] providers:", providerIds(manifest).join(", "));
-  console.log(
-    "[cloud-portability] defaults:",
-    `frontend=${active.frontend}, gateway=${active.gateway}, originBackend=${active.originBackend}`,
+  writeLine(`[cloud-portability] providers: ${providerIds(manifest).join(", ")}`);
+  writeLine(
+    `[cloud-portability] defaults: frontend=${active.frontend}, gateway=${active.gateway}, originBackend=${active.originBackend}`,
   );
-  console.log(
-    "[cloud-portability] AWS registry:",
-    manifest.providers?.aws?.registry?.kind ?? "missing",
+  writeLine(
+    `[cloud-portability] AWS registry: ${manifest.providers?.aws?.registry?.kind ?? "missing"}`,
   );
-  console.log(
-    "[cloud-portability] GCP registry:",
-    manifest.providers?.gcp?.registry?.kind ?? "missing",
+  writeLine(
+    `[cloud-portability] GCP registry: ${manifest.providers?.gcp?.registry?.kind ?? "missing"}`,
   );
-  console.log("[cloud-portability] CI workflow:", ".github/workflows/docker-build-push.yml");
-  console.log("[cloud-portability] Terraform modules:", "aws, gcp");
+  writeLine("[cloud-portability] CI workflow: .github/workflows/docker-build-push.yml");
+  writeLine("[cloud-portability] Terraform modules: aws, gcp");
 }
 
 if (failures.length > 0) {
   for (const failure of failures) {
-    console.error(`cloud-portability: ${failure}`);
+    writeErrorLine(`cloud-portability: ${failure}`);
   }
   process.exit(1);
 }
 
-console.log("cloud portability contract: ok");
+writeLine("cloud portability contract: ok");


### PR DESCRIPTION
## Summary
- Fill env example gaps for newly-read access gate, telemetry, E2E, Redis, community, and startup-license variables.
- Replace a stale Terraform README local link with portable text.
- Expose browser analytics failures via an optional diagnostics callback and avoid console.log in cloud portability verification.

## Verification
- pnpm --config.verify-deps-before-run=false --filter @nebutra/landing-page exec vitest run src/lib/analytics/emit.test.ts src/lib/app-url.test.ts src/__tests__/api/license.test.ts
- node scripts/verify-cloud-portability.mjs
- node scripts/verify-cloud-portability.mjs --doctor
- node scripts/check-missing-keys.js
- incremental static sweep from 2026-07-02 baseline to working tree: 0 findings

## Notes
- Default pnpm invocation still fails locally before command execution with ERR_PNPM_VERIFY_DEPS_BEFORE_RUN, so verification used the repo CI workaround flag.