### PR TITLE
fix: close consistency sweep drift

### DIFF
--- a/e2e/smoke/auth.spec.ts
+++ b/e2e/smoke/auth.spec.ts
@@ -7,16 +7,17 @@ import { gotoMarketingPage } from "../helpers/navigation";
 // In CI the web app is not started unless APP_BASE_URL is explicitly provided.
 const APP_BASE = process.env.APP_BASE_URL ?? "http://localhost:3001";
 const skipWebApp = process.env.CI === "true" && !process.env.APP_BASE_URL;
+const authSmokeEnabled = process.env.E2E_AUTH_SMOKE === "1";
 const authSmoke = getAuthCapabilityStatus("auth-smoke");
 const authSmokeSkipReason = skipWebApp
   ? "Web app not running in CI (set APP_BASE_URL to enable)"
   : authSmoke.ready
     ? null
     : authSmoke.reason;
+const authSmokeDescribe =
+  authSmokeEnabled && !authSmokeSkipReason ? test.describe : test.describe.skip;
 
-test.describe("Authentication Flow", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
-
+authSmokeDescribe("Authentication Flow", () => {
   test("sign-in page is accessible", async ({ page }) => {
     await page.goto(APP_BASE + "/sign-in");
     await expect(page).not.toHaveTitle(/404|Not Found/i);

--- a/e2e/smoke/dashboard.spec.ts
+++ b/e2e/smoke/dashboard.spec.ts
@@ -22,16 +22,17 @@ const APP_BASE = process.env.APP_BASE_URL ?? "http://localhost:3001";
 // Skip gracefully rather than failing with a connection-refused error.
 const skipWebApp = process.env.CI === "true" && !process.env.APP_BASE_URL;
 const skipApi = process.env.CI === "true" && !process.env.API_BASE_URL;
+const authSmokeEnabled = process.env.E2E_AUTH_SMOKE === "1";
 const authSmoke = getAuthCapabilityStatus("auth-smoke");
 const authSmokeSkipReason = skipWebApp
   ? "Web app not running in CI (set APP_BASE_URL to enable)"
   : authSmoke.ready
     ? null
     : authSmoke.reason;
+const authSmokeDescribe =
+  authSmokeEnabled && !authSmokeSkipReason ? test.describe : test.describe.skip;
 
-test.describe("Authentication redirect", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
-
+authSmokeDescribe("Authentication redirect", () => {
   test("unauthenticated / redirects to sign-in", async ({ page }) => {
     const response = await page.goto(APP_BASE + "/");
     // Auth middleware redirects unauthenticated requests to /sign-in.
@@ -50,9 +51,7 @@ test.describe("Authentication redirect", () => {
   });
 });
 
-test.describe("Sign-in page", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
-
+authSmokeDescribe("Sign-in page", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(APP_BASE + "/sign-in");
   });
@@ -95,9 +94,7 @@ test.describe("Sign-in page", () => {
   });
 });
 
-test.describe("Sign-up page", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
-
+authSmokeDescribe("Sign-up page", () => {
   test("renders sign-up form", async ({ page }) => {
     await page.goto(APP_BASE + "/sign-up");
     await expect(page).toHaveTitle(/sign.?up|Nebutra/i);

--- a/packages/platform/i18n/locales/zh.json
+++ b/packages/platform/i18n/locales/zh.json
@@ -11,7 +11,7 @@
       "title": "用户",
       "description": "浏览、搜索并以任何用户身份登录。",
       "searchPlaceholder": "搜索用户…",
-      "totalCount": "共 {count} 个用户",
+      "totalCount": "{count, plural, one {# 个用户} other {# 个用户}}",
       "empty": "未找到用户。",
       "loadError": "加载用户失败。",
       "columns": {
@@ -27,7 +27,7 @@
       "title": "组织",
       "description": "系统中的所有工作区，按时间倒序排列。",
       "searchPlaceholder": "搜索组织…",
-      "totalCount": "共 {count} 个组织",
+      "totalCount": "{count, plural, one {# 个组织} other {# 个组织}}",
       "empty": "未找到组织。",
       "loadError": "加载组织失败。",
       "columns": {
@@ -252,7 +252,7 @@
     },
     "pricing": {
       "trial": "免费试用 {days} 天",
-      "seat": "{count} 个席位",
+      "seat": "{count, plural, one {# 个席位} other {# 个席位}}",
       "perSeat": "/ 席位"
     }
   },


### PR DESCRIPTION
## Summary
- Restore explicit `E2E_AUTH_SMOKE=1` gating for auth smoke specs while keeping provider capability checks.
- Align shared zh i18n ICU plural placeholders with the en catalog for admin counts and billing seats.

## New/worsened findings fixed
- A2: `packages/platform/i18n/locales/zh.json` had placeholder-shape drift vs `en.json` for three count strings.
- A16/A4: auth smoke specs no longer matched the CI harness governance contract requiring explicit real-provider opt-in.

## Verification
- `pnpm --config.verify-deps-before-run=false exec biome check e2e/smoke/auth.spec.ts e2e/smoke/dashboard.spec.ts packages/platform/i18n/locales/zh.json`
- platform i18n placeholder parity scan: all locales missing=0 extra=0 placeholders=0
- `pnpm --config.verify-deps-before-run=false exec vitest run --config vitest.arch.config.ts tests/architecture/ci-harness-closure.test.ts`
- `pnpm --config.verify-deps-before-run=false exec vitest run e2e/fixtures/auth.test.ts`
- `pnpm --config.verify-deps-before-run=false --filter @nebutra/i18n typecheck`
- `pnpm --config.verify-deps-before-run=false i18n:check:strict`
- `pnpm --config.verify-deps-before-run=false cloud:verify`
- `NODE_ENV=development pnpm --config.verify-deps-before-run=false check-env`
- `pnpm --config.verify-deps-before-run=false --filter @nebutra/sailor-docs exec node scripts/lint-links.mjs`
- `pnpm --config.verify-deps-before-run=false --filter @nebutra/gateway exec vitest run src/routes/admin/index.test.ts src/routes/ai/gateway.test.ts src/lib/ai-gateway-metering.test.ts`
- `pnpm --config.verify-deps-before-run=false --filter @nebutra/web exec vitest run src/app/api/auth/sso/discovery/__tests__/route.test.ts src/components/auth/__tests__/clerk-enterprise-sso-handoff.test.tsx src/lib/__tests__/env.test.ts src/lib/__tests__/clerk-active-organization-auth.test.ts src/lib/auth/__tests__/oauth-providers.test.ts`
- `pnpm --config.verify-deps-before-run=false --filter create-sailor exec vitest run src/utils/env.test.ts src/utils/database-host-meta.test.ts src/steps/resolve-config.test.ts`
- `pnpm --config.verify-deps-before-run=false --filter nebutra build`
- `pnpm --config.verify-deps-before-run=false --filter nebutra exec vitest run src/utils/command-error.test.ts tests/ui.test.ts`
- `pnpm --config.verify-deps-before-run=false --filter @nebutra/landing-page exec vitest run "src/app/[lang]/(marketing)/get-license/LicenseWizard.test.tsx"`
- `pnpm --config.verify-deps-before-run=false --filter @nebutra/gateway generate:spec` left no OpenAPI diff
- `pnpm --config.verify-deps-before-run=false --filter @nebutra/gateway lint:spec` passed with existing warnings

## Notes
- Full `pnpm test:arch` initially exposed the auth smoke contract failure fixed here. Brand metadata drift tests can time out locally around the `brand:apply` file lock under repeated synchronous child-process runs; single `brand:apply` via `tsx` completed, and no brand files changed in the incremental diff.
- Secret scan only hit example/documentation/test placeholder connection strings; no real secret values were echoed or committed.