### PR TITLE
fix(e2e): gate auth smoke specs explicitly

### DIFF
--- a/e2e/smoke/auth.spec.ts
+++ b/e2e/smoke/auth.spec.ts
@@ -7,32 +7,37 @@ import { gotoMarketingPage } from "../helpers/navigation";
 // In CI the web app is not started unless APP_BASE_URL is explicitly provided.
 const APP_BASE = process.env.APP_BASE_URL ?? "http://localhost:3001";
 const skipWebApp = process.env.CI === "true" && !process.env.APP_BASE_URL;
+const authSmokeEnabled = process.env.E2E_AUTH_SMOKE === "1";
 const authSmoke = getAuthCapabilityStatus("auth-smoke");
 const authSmokeSkipReason = skipWebApp
   ? "Web app not running in CI (set APP_BASE_URL to enable)"
-  : authSmoke.ready
-    ? null
-    : authSmoke.reason;
+  : !authSmokeEnabled
+    ? "Set E2E_AUTH_SMOKE=1 to enable real-provider auth smoke"
+    : authSmoke.ready
+      ? null
+      : authSmoke.reason;
 
-test.describe("Authentication Flow", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
+test.describe.skip(
+  Boolean(authSmokeSkipReason),
+  authSmokeSkipReason ?? "Auth smoke configured",
+  () => {
+    test("sign-in page is accessible", async ({ page }) => {
+      await page.goto(APP_BASE + "/sign-in");
+      await expect(page).not.toHaveTitle(/404|Not Found/i);
+    });
 
-  test("sign-in page is accessible", async ({ page }) => {
-    await page.goto(APP_BASE + "/sign-in");
-    await expect(page).not.toHaveTitle(/404|Not Found/i);
-  });
+    test("sign-up page is accessible", async ({ page }) => {
+      await page.goto(APP_BASE + "/sign-up");
+      await expect(page).not.toHaveTitle(/404|Not Found/i);
+    });
 
-  test("sign-up page is accessible", async ({ page }) => {
-    await page.goto(APP_BASE + "/sign-up");
-    await expect(page).not.toHaveTitle(/404|Not Found/i);
-  });
-
-  test("sign-in link from landing page navigates correctly", async ({ page }) => {
-    await gotoMarketingPage(page, "/");
-    const signInLink = page.getByRole("link", { name: /sign in|log in/i }).first();
-    if (await signInLink.isVisible()) {
-      await signInLink.click();
-      await expect(page).not.toHaveTitle(/Error|404/i);
-    }
-  });
-});
+    test("sign-in link from landing page navigates correctly", async ({ page }) => {
+      await gotoMarketingPage(page, "/");
+      const signInLink = page.getByRole("link", { name: /sign in|log in/i }).first();
+      if (await signInLink.isVisible()) {
+        await signInLink.click();
+        await expect(page).not.toHaveTitle(/Error|404/i);
+      }
+    });
+  },
+);

--- a/e2e/smoke/dashboard.spec.ts
+++ b/e2e/smoke/dashboard.spec.ts
@@ -22,102 +22,111 @@ const APP_BASE = process.env.APP_BASE_URL ?? "http://localhost:3001";
 // Skip gracefully rather than failing with a connection-refused error.
 const skipWebApp = process.env.CI === "true" && !process.env.APP_BASE_URL;
 const skipApi = process.env.CI === "true" && !process.env.API_BASE_URL;
+const authSmokeEnabled = process.env.E2E_AUTH_SMOKE === "1";
 const authSmoke = getAuthCapabilityStatus("auth-smoke");
 const authSmokeSkipReason = skipWebApp
   ? "Web app not running in CI (set APP_BASE_URL to enable)"
-  : authSmoke.ready
-    ? null
-    : authSmoke.reason;
+  : !authSmokeEnabled
+    ? "Set E2E_AUTH_SMOKE=1 to enable real-provider auth smoke"
+    : authSmoke.ready
+      ? null
+      : authSmoke.reason;
 
-test.describe("Authentication redirect", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
-
-  test("unauthenticated / redirects to sign-in", async ({ page }) => {
-    const response = await page.goto(APP_BASE + "/");
-    // Auth middleware redirects unauthenticated requests to /sign-in.
-    expect(page.url()).toMatch(/sign-in/);
-    expect(response?.status()).not.toBe(500);
-  });
-
-  test("unauthenticated /settings redirects to sign-in", async ({ page }) => {
-    await page.goto(APP_BASE + "/settings");
-    expect(page.url()).toMatch(/sign-in/);
-  });
-
-  test("unauthenticated /analytics redirects to sign-in", async ({ page }) => {
-    await page.goto(APP_BASE + "/analytics");
-    expect(page.url()).toMatch(/sign-in/);
-  });
-});
-
-test.describe("Sign-in page", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
-
-  test.beforeEach(async ({ page }) => {
-    await page.goto(APP_BASE + "/sign-in");
-  });
-
-  test("renders sign-in form", async ({ page }) => {
-    await expect(page).toHaveTitle(/sign.?in|Nebutra/i);
-    // Provider-rendered forms have at minimum an email input.
-    const emailInput = page
-      .getByRole("textbox", { name: /email/i })
-      .or(page.locator("input[type='email']"))
-      .first();
-    await expect(emailInput).toBeVisible({ timeout: 8000 });
-  });
-
-  test("has sign-up link", async ({ page }) => {
-    const signUpLink = page
-      .getByRole("link", { name: /sign.?up|create.+account|get.+started/i })
-      .first();
-    if (await signUpLink.isVisible()) {
-      const href = await signUpLink.getAttribute("href");
-      expect(href).toBeTruthy();
-    }
-  });
-
-  test("page has no console errors", async ({ page }) => {
-    const errors: string[] = [];
-    page.on("console", (msg) => {
-      if (msg.type() === "error") errors.push(msg.text());
+test.describe.skip(
+  Boolean(authSmokeSkipReason),
+  authSmokeSkipReason ?? "Auth smoke configured",
+  () => {
+    test("unauthenticated / redirects to sign-in", async ({ page }) => {
+      const response = await page.goto(APP_BASE + "/");
+      // Auth middleware redirects unauthenticated requests to /sign-in.
+      expect(page.url()).toMatch(/sign-in/);
+      expect(response?.status()).not.toBe(500);
     });
-    await page.goto(APP_BASE + "/sign-in");
-    await page.waitForLoadState("networkidle");
-    // Filter out known third-party auth/font noise.
-    const appErrors = errors.filter(
-      (e) =>
-        !e.includes("clerk") &&
-        !e.includes("fonts.googleapis") &&
-        !e.includes("Failed to load resource"),
-    );
-    expect(appErrors).toHaveLength(0);
-  });
-});
 
-test.describe("Sign-up page", () => {
-  test.skip(Boolean(authSmokeSkipReason), authSmokeSkipReason ?? "Auth smoke configured");
+    test("unauthenticated /settings redirects to sign-in", async ({ page }) => {
+      await page.goto(APP_BASE + "/settings");
+      expect(page.url()).toMatch(/sign-in/);
+    });
 
-  test("renders sign-up form", async ({ page }) => {
-    await page.goto(APP_BASE + "/sign-up");
-    await expect(page).toHaveTitle(/sign.?up|Nebutra/i);
-    const continueBtn = page.getByRole("button", { name: /continue|sign up|next/i }).first();
-    if (await continueBtn.isVisible()) {
-      await expect(continueBtn).toBeEnabled();
-    }
-  });
+    test("unauthenticated /analytics redirects to sign-in", async ({ page }) => {
+      await page.goto(APP_BASE + "/analytics");
+      expect(page.url()).toMatch(/sign-in/);
+    });
+  },
+);
 
-  test("has sign-in link", async ({ page }) => {
-    await page.goto(APP_BASE + "/sign-up");
-    const signInLink = page
-      .getByRole("link", { name: /sign.?in|log.?in|already.+account/i })
-      .first();
-    if (await signInLink.isVisible()) {
-      const href = await signInLink.getAttribute("href");
-      expect(href).toBeTruthy();
-    }
-  });
-});
+test.describe.skip(
+  Boolean(authSmokeSkipReason),
+  authSmokeSkipReason ?? "Auth smoke configured",
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(APP_BASE + "/sign-in");
+    });
+
+    test("renders sign-in form", async ({ page }) => {
+      await expect(page).toHaveTitle(/sign.?in|Nebutra/i);
+      // Provider-rendered forms have at minimum an email input.
+      const emailInput = page
+        .getByRole("textbox", { name: /email/i })
+        .or(page.locator("input[type='email']"))
+        .first();
+      await expect(emailInput).toBeVisible({ timeout: 8000 });
+    });
+
+    test("has sign-up link", async ({ page }) => {
+      const signUpLink = page
+        .getByRole("link", { name: /sign.?up|create.+account|get.+started/i })
+        .first();
+      if (await signUpLink.isVisible()) {
+        const href = await signUpLink.getAttribute("href");
+        expect(href).toBeTruthy();
+      }
+    });
+
+    test("page has no console errors", async ({ page }) => {
+      const errors: string[] = [];
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+      await page.goto(APP_BASE + "/sign-in");
+      await page.waitForLoadState("networkidle");
+      // Filter out known third-party auth/font noise.
+      const appErrors = errors.filter(
+        (e) =>
+          !e.includes("clerk") &&
+          !e.includes("fonts.googleapis") &&
+          !e.includes("Failed to load resource"),
+      );
+      expect(appErrors).toHaveLength(0);
+    });
+  },
+);
+
+test.describe.skip(
+  Boolean(authSmokeSkipReason),
+  authSmokeSkipReason ?? "Auth smoke configured",
+  () => {
+    test("renders sign-up form", async ({ page }) => {
+      await page.goto(APP_BASE + "/sign-up");
+      await expect(page).toHaveTitle(/sign.?up|Nebutra/i);
+      const continueBtn = page.getByRole("button", { name: /continue|sign up|next/i }).first();
+      if (await continueBtn.isVisible()) {
+        await expect(continueBtn).toBeEnabled();
+      }
+    });
+
+    test("has sign-in link", async ({ page }) => {
+      await page.goto(APP_BASE + "/sign-up");
+      const signInLink = page
+        .getByRole("link", { name: /sign.?in|log.?in|already.+account/i })
+        .first();
+      if (await signInLink.isVisible()) {
+        const href = await signInLink.getAttribute("href");
+        expect(href).toBeTruthy();
+      }
+    });
+  },
+);
 
 test.describe("API health checks", () => {
   test.skip(skipApi, "API gateway not running in CI (set API_BASE_URL to enable)");


### PR DESCRIPTION
## Summary
- Restore explicit `E2E_AUTH_SMOKE === "1"` gates in auth smoke specs.
- Use `test.describe.skip` for auth-gated describe blocks so the CI harness closure contract matches runtime behavior.

## Root cause
The latest main CI failed in `Lint & Typecheck` during `Architecture smoke checks`; `tests/architecture/ci-harness-closure.test.ts` requires auth UI smoke tests to remain behind an explicit real-provider opt-in. The smoke specs only used the capability helper skip reason, so the architecture guard failed before build/test jobs could run.

## Verification
- `pnpm exec biome check e2e/smoke/auth.spec.ts e2e/smoke/dashboard.spec.ts`
- `pnpm test:arch`
- `pnpm lint:microcopy`
- `pnpm lint:brand-literals`

## Security scan
- `gitleaks git . --redact=100`: no leaks found across 1773 commits.

Labels requested: `ci/cd`, `tests`, `automated`. `codex` and `codex-automation` labels are not present in this repository.