### PR TITLE
fix(landing): enable Google One Tap on Vercel production

### DIFF
--- a/apps/landing-page/vercel.json
+++ b/apps/landing-page/vercel.json
@@ -10,7 +10,10 @@
     "NEXT_PUBLIC_APP_URL": "https://app.nebutra.com",
     "NEXT_PUBLIC_API_URL": "https://api.nebutra.com",
     "NEXT_PUBLIC_DOCS_URL": "https://nebutra.com/docs",
-    "DOCS_ORIGIN_URL": "https://docs.nebutra.com"
+    "DOCS_ORIGIN_URL": "https://docs.nebutra.com",
+    "NEXT_PUBLIC_AUTH_PROVIDER": "better-auth",
+    "NEXT_PUBLIC_ENABLE_GOOGLE_ONE_TAP": "true",
+    "NEXT_PUBLIC_GOOGLE_CLIENT_ID": "470784717517-g1rcks9d8ud342e1b0g8i6qeth96h41u.apps.googleusercontent.com"
   },
   "headers": [
     {


### PR DESCRIPTION
## Summary
- Bake `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_AUTH_PROVIDER=better-auth`, and `NEXT_PUBLIC_ENABLE_GOOGLE_ONE_TAP=true` into landing `vercel.json`.
- Production landing was mounting One Tap with `googleClientId: undefined`, so the Better Auth path short-circuited to `null`.

## Test plan
- [ ] Production deploy succeeds for landing
- [ ] `nebutra.com` HTML/RSC includes google client id (not `$undefined`)
- [ ] Browser shows One Tap when signed into Google (or `data-testid=better-auth-google-one-tap` present after hydrate)