### PR TITLE
fix(docs): host sailor-docs on Vercel (drop CF Workers)

### DIFF
--- a/.github/workflows/deploy-sailor-docs.yml
+++ b/.github/workflows/deploy-sailor-docs.yml
@@ -1,165 +1,85 @@
 name: Deploy Sailor Docs
 
+# Production target: Vercel (separate project `docs`, root apps/sailor-docs).
+# Why not Cloudflare Workers/OpenNext: the docs bundle is ~87MB uncompressed
+# (handler.mjs) and exceeds the Workers 64 MiB script limit. Public docs on
+# Next+monorepo belong on Vercel/Node, same as landing/web.
+#
+# Deploy path is Git → Vercel project hook (no heavy Actions build). This
+# workflow only re-triggers production when docs paths change, as a safety net.
+
 on:
   workflow_dispatch:
-    inputs:
-      deploy_target:
-        description: "Sailor docs deploy target to activate"
-        required: true
-        default: "cloudflare-pages"
-        type: choice
-        options:
-          - cloudflare-pages
-          - standalone
-          - vercel
-  workflow_run:
-    workflows: ["CI"]
-    branches: [main]
-    types: [completed]
   push:
     branches: [main]
     paths:
       - "apps/sailor-docs/**"
-      - "packages/ui/**"
-      - "packages/brand/**"
-      - "packages/tokens/**"
-      - "packages/icons/**"
+      - "packages/design/ui/**"
+      - "packages/design/brand/**"
+      - "packages/design/icons/**"
+      - "packages/design/tokens/**"
       - "pnpm-lock.yaml"
-      - ".github/workflows/deploy-sailor-docs.yml"
+      - "apps/sailor-docs/vercel.json"
 
 permissions:
   contents: read
 
 concurrency:
-  group: deploy-sailor-docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy-sailor-docs-production
+  cancel-in-progress: false
 
 jobs:
-  cloudflare-pages:
-    name: Cloudflare Workers (OpenNext) docs
+  vercel:
+    name: Trigger Vercel production
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name == 'workflow_dispatch' && inputs.deploy_target == 'cloudflare-pages') ||
-      (github.event_name == 'push' &&
-        (vars.DEPLOY_TARGET_SAILOR_DOCS == 'cloudflare-pages' || vars.DEPLOY_TARGET_SAILOR_DOCS == '')) ||
-      (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        (vars.DEPLOY_TARGET_SAILOR_DOCS == 'cloudflare-pages' || vars.DEPLOY_TARGET_SAILOR_DOCS == ''))
+      vars.DEPLOY_TARGET_SAILOR_DOCS == 'vercel' ||
+      vars.DEPLOY_TARGET_SAILOR_DOCS == 'cloudflare-pages' ||
+      vars.DEPLOY_TARGET_SAILOR_DOCS == '' ||
+      github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          # Dispatch from a feature branch deploys that ref; CI/main uses default branch.
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.repository.default_branch }}
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-node-pnpm
-
-      - name: Validate Cloudflare credentials
+      - name: Deploy to Vercel (production)
         env:
-          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          [ -n "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || { echo "::error::CLOUDFLARE_API_TOKEN secret is not set"; exit 1; }
-          [ -n "${CF_ACCOUNT_ID:-}" ] || { echo "::error::CLOUDFLARE_ACCOUNT_ID secret or variable is not set"; exit 1; }
-
-      - name: Build workspace packages required by sailor-docs
-        run: |
-          # Same brand/token pipeline as CI (tokens depend on design-tokens CSS).
-          pnpm brand:sync
-          pnpm --filter @nebutra/design-tokens build
-          pnpm --filter @nebutra/tokens build
-          pnpm --filter @nebutra/brand build
-          pnpm --filter @nebutra/icons build
-          pnpm --filter @nebutra/ui build
-
-      - name: Build OpenNext Worker
-        working-directory: apps/sailor-docs
-        env:
-          OPEN_NEXT_BUILD: "true"
-          NEXT_PUBLIC_DOCS_ORIGIN_URL: https://docs.nebutra.com
-          # Optional features stay soft-fail when unset (chat/feedback).
-          INKEEP_API_KEY: ${{ secrets.INKEEP_API_KEY }}
-          GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
-        run: pnpm build:worker
-
-      - name: Deploy Worker
-        id: deploy
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/sailor-docs
-          command: deploy --config wrangler.jsonc
-
-      - name: Point docs.nebutra.com DNS at Workers (proxied)
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID || vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID || vars.VERCEL_DOCS_PROJECT_ID }}
         run: |
           set -euo pipefail
-          # Workers custom-domain style: CNAME docs → nebutra-sailor-docs.<workers-subdomain>.workers.dev
-          # with CF proxy on. Routes in wrangler.jsonc already bind the hostname to the script.
-          TOKEN="$CLOUDFLARE_API_TOKEN"
-          ZONE_JSON=$(curl -sS -H "Authorization: Bearer $TOKEN" \
-            "https://api.cloudflare.com/client/v4/zones?name=nebutra.com")
-          ZONE_ID=$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["result"][0]["id"] if d.get("result") else "")' <<<"$ZONE_JSON")
-          [ -n "$ZONE_ID" ] || { echo "::error::zone nebutra.com not found"; exit 1; }
-
-          # Discover workers.dev subdomain for this account
-          ACC="${CF_ACCOUNT_ID}"
-          SUB=$(curl -sS -H "Authorization: Bearer $TOKEN" \
-            "https://api.cloudflare.com/client/v4/accounts/$ACC/workers/subdomain" \
-            | python3 -c 'import json,sys; d=json.load(sys.stdin); print((d.get("result") or {}).get("subdomain") or "")')
-          if [ -z "$SUB" ]; then
-            echo "::warning::Could not resolve workers subdomain; skip DNS upsert"
+          if [ -z "${VERCEL_TOKEN:-}" ]; then
+            echo "::notice::VERCEL_TOKEN not set — relying on Vercel Git integration only."
+            echo "If docs.nebutra.com is not updating, add VERCEL_TOKEN + VERCEL_DOCS_PROJECT_ID."
             exit 0
           fi
-          TARGET="nebutra-sailor-docs.${SUB}.workers.dev"
-          echo "DNS target: $TARGET"
-
-          EXISTING=$(curl -sS -H "Authorization: Bearer $TOKEN" \
-            "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records?name=docs.nebutra.com")
-          RID=$(python3 -c 'import json,sys; d=json.load(sys.stdin); r=d.get("result") or []; print(r[0]["id"] if r else "")' <<<"$EXISTING")
-          BODY=$(python3 -c "import json; print(json.dumps({'type':'CNAME','name':'docs','content':'$TARGET','proxied':True,'ttl':1}))")
-
-          if [ -n "$RID" ]; then
-            curl -sS -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-              --data "$BODY" \
-              "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records/$RID" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("update ok" if d.get("success") else d)'
-          else
-            curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-              --data "$BODY" \
-              "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("create ok" if d.get("success") else d)'
+          if [ -z "${VERCEL_PROJECT_ID:-}" ]; then
+            echo "::error::Set VERCEL_DOCS_PROJECT_ID (prj_…) for the docs Vercel project"
+            exit 1
           fi
+          npm i -g vercel@latest
+          # Pull project settings into apps/sailor-docs without linking interactively
+          mkdir -p apps/sailor-docs/.vercel
+          cat > apps/sailor-docs/.vercel/project.json <<EOF
+          {"projectId":"${VERCEL_PROJECT_ID}","orgId":"${VERCEL_ORG_ID:-}"}
+          EOF
+          # Deploy from monorepo root so turbo filter + pnpm workspace resolve.
+          vercel deploy --prod --yes --token="$VERCEL_TOKEN" \
+            --cwd apps/sailor-docs \
+            --scope "${VERCEL_ORG_ID:-}"
 
-      - name: Smoke docs origin
+      - name: Smoke docs.nebutra.com
         run: |
           set -euo pipefail
-          sleep 5
-          ok=0
-          for url in \
-            "https://docs.nebutra.com/en" \
-            "https://docs.nebutra.com/"
-          do
-            code=$(curl -sS -o /tmp/docs-smoke.html -w '%{http_code}' --max-time 30 -L "$url" || echo "000")
-            echo "GET $url -> $code"
-            if [ "$code" = "200" ]; then
-              # Reject accidental landing redirect bodies if status somehow 200
-              if grep -qi 'fumadocs\|sailor\|Documentation' /tmp/docs-smoke.html 2>/dev/null; then
-                ok=1
-                break
-              fi
-              # Still accept 200 if not the marketing One Tap page
-              if ! grep -qi 'Google One Tap\|nebutra_session_hint' /tmp/docs-smoke.html 2>/dev/null; then
-                ok=1
-                break
-              fi
-            fi
-          done
-          if [ "$ok" != "1" ]; then
-            echo "::warning::Custom domain smoke did not look healthy yet; deploy may still succeed. Check DNS/routes."
-            # Do not fail the job solely on DNS lag after a successful wrangler deploy.
+          # Allow a short CDN lag; failure here is non-blocking if DNS not yet cut over.
+          code=$(curl -sS -o /tmp/docs.html -w '%{http_code}' --max-time 30 -L https://docs.nebutra.com/en || echo 000)
+          echo "GET https://docs.nebutra.com/en -> $code"
+          if [ "$code" != "200" ]; then
+            echo "::warning::docs.nebutra.com not healthy yet (DNS/domain may still point at ECS)."
+            exit 0
+          fi
+          if grep -qi 'location: https://nebutra.com' /tmp/docs.html 2>/dev/null; then
+            echo "::warning::still redirecting to landing"
             exit 0
           fi
           echo "docs smoke OK"

--- a/apps/sailor-docs/.gitignore
+++ b/apps/sailor-docs/.gitignore
@@ -1,0 +1,1 @@
+apps/sailor-docs/.vercel/

--- a/apps/sailor-docs/vercel.json
+++ b/apps/sailor-docs/vercel.json
@@ -1,0 +1,12 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "pnpm turbo build --filter=@nebutra/sailor-docs",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-build.sh apps/sailor-docs",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": ".next",
+  "regions": ["iad1"],
+  "env": {
+    "NEXT_PUBLIC_DOCS_ORIGIN_URL": "https://docs.nebutra.com",
+    "NEXT_PUBLIC_DOCS_URL": "https://docs.nebutra.com"
+  }
+}

--- a/apps/sailor-docs/wrangler.jsonc
+++ b/apps/sailor-docs/wrangler.jsonc
@@ -9,16 +9,12 @@
     "binding": "ASSETS"
   },
   "observability": {
-    "enabled": true,
-    "head_sampling_rate": 1
+    "enabled": true
   },
   "vars": {
-    "DEPLOY_TARGET_SAILOR_DOCS": "cloudflare-pages",
     "NEXT_PUBLIC_DOCS_ORIGIN_URL": "https://docs.nebutra.com"
   },
-  // Custom domain: docs.nebutra.com (zone nebutra.com).
-  // After first deploy, also attach the domain in CF dashboard if routes alone
-  // are insufficient for SSL edge cert issuance.
+  // One-time DNS: CNAME docs → this worker (proxied). Route binds hostname.
   "routes": [
     {
       "pattern": "docs.nebutra.com/*",

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -10,7 +10,7 @@
 | `api.nebutra.com` | api-gateway | BFF API endpoints |
 | `sso.nebutra.com` | idp | Nebutra-owned OIDC issuer for first-party/internal apps |
 | `design.nebutra.com` | design-docs | Design system docs |
-| `docs.nebutra.com` | sailor-docs (Cloudflare Workers / OpenNext) | Product/docs site |
+| `docs.nebutra.com` | sailor-docs (Vercel project `docs`) | Product/docs site |
 | `nebutra.sanity.studio` | studio | Canonical Sanity-hosted Studio |
 | `studio.nebutra.com` | studio | Optional branded Studio alias; requires external DNS/hosting binding |
 

--- a/docs/architecture/2026-06-04-production-runtime-closure.md
+++ b/docs/architecture/2026-06-04-production-runtime-closure.md
@@ -35,7 +35,7 @@ provider-switchable through per-service selector keys:
 | `web` | `vercel` | `vercel`, `standalone`, `cloudflare-pages`, `railway` |
 | `landing-page` | `vercel` | `vercel`, `standalone`, `cloudflare-pages`, `railway` |
 | `design-docs` | `vercel` | `vercel`, `standalone`, `cloudflare-pages`, `railway` |
-| `sailor-docs` | `cloudflare-pages` | `cloudflare-pages`, `vercel`, `standalone`, `railway` |
+| `sailor-docs` | `vercel` | `vercel`, `standalone`, `cloudflare-pages`, `railway` |
 | `gateway` | `cloudflare-workers` | `cloudflare-workers`, `vercel-functions`, `vm-docker`, `ecs-docker`, `k8s`, `aws`, `gcp`, `railway` |
 | `python-ai` | `ecs-docker` | `ecs-docker`, `k8s`, `aws`, `gcp`, `railway` |
 
@@ -44,10 +44,12 @@ Selector env keys are service-specific:
 ```env
 DEPLOY_TARGET_WEB=vercel
 DEPLOY_TARGET_LANDING_PAGE=vercel
-DEPLOY_TARGET_SAILOR_DOCS=cloudflare-pages
+DEPLOY_TARGET_SAILOR_DOCS=vercel
 DEPLOY_TARGET_GATEWAY=cloudflare-workers
 DEPLOY_TARGET_PYTHON_AI=ecs-docker
 ```
+# Note: cloudflare-pages remains allowed for create-sailor DX, but production
+# sailor-docs exceeds the Cloudflare Workers script size limit (~87MiB); use Vercel.
 
 The governance rule is:
 

--- a/infra/iac/cloudflare/README.md
+++ b/infra/iac/cloudflare/README.md
@@ -32,7 +32,7 @@ User ──────────────►│  │ WAF │──│Cache
 | `app.nebutra.com` | ✅ Proxied after origin health | No cache | Cloud VM (web; EC2/ECS/CVM/GCE compatible) |
 | `api.nebutra.com` | ✅ Proxied after origin health | No cache | Cloud VM (api-gateway; EC2/ECS/CVM/GCE compatible) |
 | `status.nebutra.com` | ✅ Proxied | No cache | Vercel (landing-page status route) |
-| `docs.nebutra.com` | ✅ Proxied | Docs/static cache | Cloudflare Workers (OpenNext `nebutra-sailor-docs`) |
+| `docs.nebutra.com` | ✅ Proxied (CNAME → Vercel) | Docs/static cache | Vercel project `docs` (`apps/sailor-docs`) |
 | `studio.nebutra.com` | ✅ Proxied when active | No cache | Optional branded Studio alias |
 | `cdn.nebutra.com` | ✅ Proxied | Long cache | R2 bucket |
 
@@ -48,23 +48,18 @@ CNAME   www       cname.vercel-dns.com     ✅      Auto
 A       app       106.15.4.31              ✅      Auto
 A       api       106.15.4.31              ✅      Auto
 A       status    76.76.21.21              ✅      Auto
-CNAME   docs      nebutra-sailor-docs.<account-subdomain>.workers.dev  ✅      Auto
+CNAME   docs      cname.vercel-dns.com     ✅      Auto
 CNAME   studio    <active studio host>     ✅      Auto
 CNAME   cdn       <r2-bucket>.r2.dev       ✅      Auto
 ```
 
-`docs.nebutra.com` is served by the OpenNext Cloudflare Worker
-`nebutra-sailor-docs` (`apps/sailor-docs`). Deploy via
-`.github/workflows/deploy-sailor-docs.yml` or:
+`docs.nebutra.com` is the Vercel project `docs` (`apps/sailor-docs`). Deploy is
+Git → Vercel (same pattern as landing). Do **not** attach this hostname to the
+landing-page project, and do **not** point it at ECS (unknown hosts 301 to apex).
 
-```bash
-pnpm --filter @nebutra/sailor-docs build:worker
-pnpm --filter @nebutra/sailor-docs deploy:worker
-```
-
-Do **not** bind `docs.nebutra.com` to the landing-page Vercel project, and do
-**not** point it at the ECS origin (that box no longer runs sailor-docs; unknown
-hosts 301 to the marketing apex).
+> OpenNext → Cloudflare Workers was evaluated and rejected: the docs server
+> bundle is ~87 MiB uncompressed and exceeds the Workers 64 MiB script limit.
+> CF remains the DNS/CDN edge in front of Vercel.
 
 Keep `status` on Vercel/landing-page, not the VM. The status surface is designed to
 stay reachable when the VM-hosted app/API/docs stack is degraded, and exposes a

--- a/infra/ops/scripts/point-docs-dns-vercel.sh
+++ b/infra/ops/scripts/point-docs-dns-vercel.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# One-time / rare: point docs.nebutra.com at Vercel (CNAME cname.vercel-dns.com).
+# Requires CLOUDFLARE_API_TOKEN with Zone.DNS edit on nebutra.com.
+set -euo pipefail
+
+TOKEN="${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN required}"
+ZONE_NAME="${CF_ZONE_NAME:-nebutra.com}"
+RECORD_NAME="docs"
+TARGET="${DOCS_DNS_TARGET:-cname.vercel-dns.com}"
+
+ZONE_ID=$(curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones?name=${ZONE_NAME}" \
+  | python3 -c 'import json,sys; r=json.load(sys.stdin).get("result") or []; print(r[0]["id"] if r else "")')
+[ -n "$ZONE_ID" ] || { echo "zone $ZONE_NAME not found" >&2; exit 1; }
+
+EXISTING=$(curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${RECORD_NAME}.${ZONE_NAME}")
+RID=$(python3 -c 'import json,sys; r=json.load(sys.stdin).get("result") or []; print(r[0]["id"] if r else "")' <<<"$EXISTING")
+BODY=$(python3 -c "import json; print(json.dumps({'type':'CNAME','name':'$RECORD_NAME','content':'$TARGET','proxied':True,'ttl':1}))")
+
+if [ -n "$RID" ]; then
+  curl -sS -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    --data "$BODY" "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RID}"
+else
+  curl -sS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    --data "$BODY" "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records"
+fi
+echo
+echo "docs.${ZONE_NAME} → ${TARGET} (proxied)"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "dev:api": "pnpm --filter @nebutra/gateway dev",
     "dev:storybook": "pnpm --filter @nebutra/storybook dev",
     "dev:docs": "pnpm --filter @nebutra/sailor-docs dev",
-    "build:docs:worker": "pnpm --filter @nebutra/sailor-docs build:worker",
-    "deploy:docs": "pnpm --filter @nebutra/sailor-docs deploy:worker",
     "dev:theme-playground": "pnpm --filter @nebutra/web dev",
     "build": "pnpm brand:sync && turbo run build",
     "build:strict": "pnpm ui:verify-governance && pnpm brand:verify-tokens && pnpm run build",


### PR DESCRIPTION
## Why
- OpenNext → CF Workers failed: **87 MiB > 64 MiB** worker limit
- Full CF path was over-engineered for a docs site

## What
- Production target = **Vercel project `docs`** (`apps/sailor-docs`)
- Slim GitHub workflow (optional trigger, no monorepo OpenNext build)
- DNS helper script for Cloudflare CNAME → `cname.vercel-dns.com`

## Verified
- Production deploy READY: `docs-nebutra.vercel.app` serves docs (307 → installation)