### PR TITLE
feat(auth): login center auth.nebutra.com for multi-app RPs

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -41,7 +41,7 @@ on:
   workflow_dispatch:
     inputs:
       apps:
-        description: "Apps to deploy (space-separated subset of: landing web api idp design-docs sailor-docs). Empty = auto-detect."
+        description: "Apps to deploy (space-separated subset of: landing web api idp auth design-docs sailor-docs). Empty = auto-detect."
         required: false
         default: ""
       reason:
@@ -78,6 +78,7 @@ jobs:
       web:         ${{ steps.resolve.outputs.web }}
       api:         ${{ steps.resolve.outputs.api }}
       idp:         ${{ steps.resolve.outputs.idp }}
+      auth:        ${{ steps.resolve.outputs.auth }}
       design-docs: ${{ steps.resolve.outputs['design-docs'] }}
       sailor-docs: ${{ steps.resolve.outputs['sailor-docs'] }}
       any:         ${{ steps.resolve.outputs.any }}
@@ -127,6 +128,16 @@ jobs:
               - 'infra/ops/scripts/ecs-deploy-remote.sh'
               - 'infra/runtime/nginx/**'
               - '.github/workflows/deploy-ecs.yml'
+            auth:
+              - 'apps/auth/**'
+              - 'packages/iam/auth/**'
+              - 'packages/platform/db/**'
+              - 'packages/design/**'
+              - 'pnpm-lock.yaml'
+              - 'infra/iac/ecs/**'
+              - 'infra/ops/scripts/ecs-deploy-remote.sh'
+              - 'infra/runtime/nginx/**'
+              - '.github/workflows/deploy-ecs.yml'
             design-docs:
               - 'apps/design-docs/**'
               - 'packages/**'
@@ -150,6 +161,7 @@ jobs:
           F_WEB:          ${{ steps.filter.outputs.web }}
           F_API:          ${{ steps.filter.outputs.api }}
           F_IDP:          ${{ steps.filter.outputs.idp }}
+          F_AUTH:         ${{ steps.filter.outputs.auth }}
           F_DESIGN_DOCS:  ${{ steps.filter.outputs['design-docs'] }}
           F_SAILOR_DOCS:  ${{ steps.filter.outputs['sailor-docs'] }}
         run: |
@@ -170,13 +182,13 @@ jobs:
             unknown_apps=""
             for app in $normalized_apps; do
               case "$app" in
-                landing|web|api|idp|design-docs|sailor-docs) ;;
+                landing|web|api|idp|auth|design-docs|sailor-docs) ;;
                 *) unknown_apps="$unknown_apps $app" ;;
               esac
             done
 
             if [ -n "$unknown_apps" ]; then
-              echo "::error::Unsupported apps: $(echo "$unknown_apps" | xargs). Allowed: landing web api idp design-docs sailor-docs"
+              echo "::error::Unsupported apps: $(echo "$unknown_apps" | xargs). Allowed: landing web api idp auth design-docs sailor-docs"
               exit 1
             fi
           fi
@@ -187,6 +199,7 @@ jobs:
               echo "web=$(contains_app "$normalized_apps" web)"
               echo "api=$(contains_app "$normalized_apps" api)"
               echo "idp=$(contains_app "$normalized_apps" idp)"
+              echo "auth=$(contains_app "$normalized_apps" auth)"
               echo "design-docs=$(contains_app "$normalized_apps" design-docs)"
               echo "sailor-docs=$(contains_app "$normalized_apps" sailor-docs)"
               echo "any=true"
@@ -195,9 +208,10 @@ jobs:
               echo "web=$F_WEB"
               echo "api=$F_API"
               echo "idp=$F_IDP"
+              echo "auth=$F_AUTH"
               echo "design-docs=$F_DESIGN_DOCS"
               echo "sailor-docs=$F_SAILOR_DOCS"
-              echo "any=$([[ "$F_LANDING" == "true" || "$F_WEB" == "true" || "$F_API" == "true" || "$F_IDP" == "true" || "$F_DESIGN_DOCS" == "true" || "$F_SAILOR_DOCS" == "true" ]] && echo true || echo false)"
+              echo "any=$([[ "$F_LANDING" == "true" || "$F_WEB" == "true" || "$F_API" == "true" || "$F_IDP" == "true" || "$F_AUTH" == "true" || "$F_DESIGN_DOCS" == "true" || "$F_SAILOR_DOCS" == "true" ]] && echo true || echo false)"
             fi
           } >> "$GITHUB_OUTPUT"
 
@@ -239,6 +253,13 @@ jobs:
             build_command: "build"
             condition: ${{ needs.detect-changes.outputs.idp }}
             site_url: "https://sso.nebutra.com"
+          - app: auth
+            package: "@nebutra/auth-center"
+            workspace: apps/auth
+            kind: "next-standalone"
+            build_command: "build"
+            condition: ${{ needs.detect-changes.outputs.auth }}
+            site_url: "https://auth.nebutra.com"
           - app: design-docs
             package: "@nebutra/design-docs"
             workspace: apps/design-docs
@@ -778,6 +799,7 @@ jobs:
           [ "${{ needs.detect-changes.outputs.web }}"            = "true" ] && APPS="$APPS web"
           [ "${{ needs.detect-changes.outputs.api }}"            = "true" ] && APPS="$APPS api"
           [ "${{ needs.detect-changes.outputs.idp }}"            = "true" ] && APPS="$APPS idp"
+          [ "${{ needs.detect-changes.outputs.auth }}"           = "true" ] && APPS="$APPS auth"
           [ "${{ needs.detect-changes.outputs['design-docs'] }}" = "true" ] && APPS="$APPS design-docs"
           [ "${{ needs.detect-changes.outputs['sailor-docs'] }}" = "true" ] && APPS="$APPS sailor-docs"
           APPS="$(echo "$APPS" | xargs)"
@@ -860,6 +882,7 @@ jobs:
           [ "${{ needs.detect-changes.outputs.web }}"            = "true" ] && targets[web]="https://app.nebutra.com"
           [ "${{ needs.detect-changes.outputs.api }}"            = "true" ] && targets[api]="https://api.nebutra.com/api/misc/health"
           [ "${{ needs.detect-changes.outputs.idp }}"            = "true" ] && targets[idp]="https://sso.nebutra.com/.well-known/openid-configuration"
+          [ "${{ needs.detect-changes.outputs.auth }}"           = "true" ] && targets[auth]="https://auth.nebutra.com/health"
           [ "${{ needs.detect-changes.outputs['design-docs'] }}" = "true" ] && targets[design-docs]="https://design.nebutra.com"
           [ "${{ needs.detect-changes.outputs['sailor-docs'] }}" = "true" ] && targets[sailor-docs]="https://docs.nebutra.com"
           ok_codes='^(200|301|302|307)$'
@@ -980,6 +1003,7 @@ jobs:
           [ "${{ needs.detect-changes.outputs.web }}"            = "true" ] && APPS="$APPS web"
           [ "${{ needs.detect-changes.outputs.api }}"            = "true" ] && APPS="$APPS api"
           [ "${{ needs.detect-changes.outputs.idp }}"            = "true" ] && APPS="$APPS idp"
+          [ "${{ needs.detect-changes.outputs.auth }}"           = "true" ] && APPS="$APPS auth"
           [ "${{ needs.detect-changes.outputs['design-docs'] }}" = "true" ] && APPS="$APPS design-docs"
           [ "${{ needs.detect-changes.outputs['sailor-docs'] }}" = "true" ] && APPS="$APPS sailor-docs"
           APPS="$(echo "$APPS" | xargs)"

--- a/apps/auth/next-env.d.ts
+++ b/apps/auth/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited — see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: "standalone",
+  transpilePackages: [
+    "@nebutra/auth",
+    "@nebutra/brand",
+    "@nebutra/db",
+    "@nebutra/logger",
+    "@nebutra/tokens",
+    "@nebutra/ui",
+  ],
+};
+
+export default nextConfig;

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@nebutra/auth-center",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3101",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "node ../../scripts/next-typegen-guard.mjs && tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@nebutra/auth": "workspace:*",
+    "@nebutra/brand": "workspace:*",
+    "@nebutra/db": "workspace:*",
+    "@nebutra/logger": "workspace:*",
+    "@nebutra/tokens": "workspace:*",
+    "@nebutra/ui": "workspace:*",
+    "next": "^16.2.6",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.1",
+    "@types/node": "^22.19.15",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "tailwindcss": "^4.2.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "AGPL-3.0-only"
+}

--- a/apps/auth/postcss.config.mjs
+++ b/apps/auth/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -29,11 +29,8 @@ async function handle(request: Request): Promise<Response> {
   }
 
   const auth = await getAuth();
-  if (!auth.middleware) {
-    return new Response("Auth middleware not configured", { status: 500 });
-  }
-
-  const response = await auth.middleware(request);
+  const authHandler = auth.middleware();
+  const response = (await authHandler(request)) ?? new Response(null, { status: 404 });
   const url = new URL(request.url);
   return applySessionHint(response, url.pathname, response.status);
 }

--- a/apps/auth/src/app/api/auth/[...all]/route.ts
+++ b/apps/auth/src/app/api/auth/[...all]/route.ts
@@ -1,0 +1,45 @@
+/**
+ * Auth-center catch-all — Better Auth / NextAuth surface for all first-party apps.
+ * Canonical host: auth.nebutra.com (BETTER_AUTH_URL).
+ */
+
+import type { AuthProvider, AuthProviderId } from "@nebutra/auth";
+import { getConfiguredAuthProvider } from "@nebutra/auth";
+import { createAuth } from "@nebutra/auth/server";
+import { applySessionHint } from "@/lib/session-hint";
+
+const PROVIDERS_USING_THIS_ROUTE: ReadonlySet<AuthProviderId> = new Set([
+  "better-auth",
+  "nextauth",
+]);
+
+const provider = getConfiguredAuthProvider();
+let authInstance: AuthProvider | null = null;
+
+async function getAuth(): Promise<AuthProvider> {
+  if (!authInstance) {
+    authInstance = await createAuth({ provider });
+  }
+  return authInstance;
+}
+
+async function handle(request: Request): Promise<Response> {
+  if (!PROVIDERS_USING_THIS_ROUTE.has(provider)) {
+    return new Response("Auth provider does not use this route", { status: 404 });
+  }
+
+  const auth = await getAuth();
+  if (!auth.middleware) {
+    return new Response("Auth middleware not configured", { status: 500 });
+  }
+
+  const response = await auth.middleware(request);
+  const url = new URL(request.url);
+  return applySessionHint(response, url.pathname, response.status);
+}
+
+export const GET = handle;
+export const POST = handle;
+export const PUT = handle;
+export const PATCH = handle;
+export const DELETE = handle;

--- a/apps/auth/src/app/globals.css
+++ b/apps/auth/src/app/globals.css
@@ -1,0 +1,14 @@
+@import "@nebutra/tokens/styles.css";
+@import "tailwindcss";
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  background: var(--background, #0a0a0b);
+  color: var(--foreground, #fafafa);
+}

--- a/apps/auth/src/app/health/route.ts
+++ b/apps/auth/src/app/health/route.ts
@@ -1,0 +1,13 @@
+import { getAuthCenterOrigin } from "@nebutra/auth";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return Response.json({
+    service: "nebutra-auth-center",
+    status: "ok",
+    origin: getAuthCenterOrigin(),
+    role: "login-center",
+    idp: process.env.OIDC_ISSUER || "https://sso.nebutra.com",
+  });
+}

--- a/apps/auth/src/app/layout.tsx
+++ b/apps/auth/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Nebutra Auth",
+  description: "Nebutra login center — shared authentication for all first-party apps",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen antialiased">{children}</body>
+    </html>
+  );
+}

--- a/apps/auth/src/app/page.tsx
+++ b/apps/auth/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AuthHomePage() {
+  redirect("/sign-in");
+}

--- a/apps/auth/src/app/sign-in/page.tsx
+++ b/apps/auth/src/app/sign-in/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { CredentialsForm } from "@/components/credentials-form";
+import { resolveAppOrigin, resolvePostLoginReturnTo } from "@/lib/return-to";
+
+export const dynamic = "force-dynamic";
+
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const query = await searchParams;
+  const raw =
+    (typeof query.returnTo === "string" && query.returnTo) ||
+    (typeof query.returnUrl === "string" && query.returnUrl) ||
+    (typeof query.redirect === "string" && query.redirect) ||
+    null;
+
+  const appOrigin = resolveAppOrigin();
+  const returnTo = resolvePostLoginReturnTo(raw);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center gap-8 px-6 py-16">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-widest text-zinc-500">Nebutra Auth</p>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight">Sign in</h1>
+        <p className="mt-2 text-sm text-zinc-400">
+          Shared login center for all first-party apps. OIDC issuer stays{" "}
+          <code className="text-zinc-300">sso.nebutra.com</code>.
+        </p>
+      </div>
+
+      <CredentialsForm mode="sign-in" returnTo={returnTo} appOrigin={appOrigin} />
+
+      <p className="text-sm text-zinc-500">
+        No account?{" "}
+        <Link
+          className="text-zinc-200 underline-offset-4 hover:underline"
+          href={`/sign-up?returnTo=${encodeURIComponent(returnTo)}`}
+        >
+          Create one
+        </Link>
+      </p>
+    </main>
+  );
+}

--- a/apps/auth/src/app/sign-up/page.tsx
+++ b/apps/auth/src/app/sign-up/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { CredentialsForm } from "@/components/credentials-form";
+import { resolveAppOrigin, resolvePostLoginReturnTo } from "@/lib/return-to";
+
+export const dynamic = "force-dynamic";
+
+export default async function SignUpPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const query = await searchParams;
+  const raw =
+    (typeof query.returnTo === "string" && query.returnTo) ||
+    (typeof query.returnUrl === "string" && query.returnUrl) ||
+    null;
+
+  const appOrigin = resolveAppOrigin();
+  const returnTo = resolvePostLoginReturnTo(raw);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center gap-8 px-6 py-16">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-widest text-zinc-500">Nebutra Auth</p>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight">Create account</h1>
+        <p className="mt-2 text-sm text-zinc-400">One account for every Nebutra app.</p>
+      </div>
+
+      <CredentialsForm mode="sign-up" returnTo={returnTo} appOrigin={appOrigin} />
+
+      <p className="text-sm text-zinc-500">
+        Already have an account?{" "}
+        <Link
+          className="text-zinc-200 underline-offset-4 hover:underline"
+          href={`/sign-in?returnTo=${encodeURIComponent(returnTo)}`}
+        >
+          Sign in
+        </Link>
+      </p>
+    </main>
+  );
+}

--- a/apps/auth/src/components/credentials-form.tsx
+++ b/apps/auth/src/components/credentials-form.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { getAuthReturnAllowedHosts, sanitizeReturnUrl } from "@nebutra/auth";
+import { useMemo, useState } from "react";
+
+interface CredentialsFormProps {
+  mode: "sign-in" | "sign-up";
+  returnTo?: string;
+  appOrigin: string;
+}
+
+export function CredentialsForm({ mode, returnTo, appOrigin }: CredentialsFormProps) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const safeReturn = useMemo(() => {
+    const allowed = getAuthReturnAllowedHosts();
+    const fallback = `${appOrigin.replace(/\/$/, "")}/dashboard`;
+    if (!returnTo) return fallback;
+    if (returnTo.startsWith("/")) {
+      return `${appOrigin.replace(/\/$/, "")}${returnTo}`;
+    }
+    return sanitizeReturnUrl(returnTo, { allowedHosts: allowed, fallback });
+  }, [returnTo, appOrigin]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const endpoint = mode === "sign-in" ? "/api/auth/sign-in/email" : "/api/auth/sign-up/email";
+      const body =
+        mode === "sign-in"
+          ? { email, password, callbackURL: safeReturn }
+          : { email, password, name: name || email.split("@")[0], callbackURL: safeReturn };
+
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { message?: string } | null;
+        setError(data?.message || (mode === "sign-in" ? "Sign in failed" : "Sign up failed"));
+        return;
+      }
+
+      window.location.assign(safeReturn);
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex w-full max-w-sm flex-col gap-3">
+      {mode === "sign-up" ? (
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-zinc-400">Name</span>
+          <input
+            className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoComplete="name"
+          />
+        </label>
+      ) : null}
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-zinc-400">Email</span>
+        <input
+          required
+          type="email"
+          className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          autoComplete="email"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-zinc-400">Password</span>
+        <input
+          required
+          type="password"
+          minLength={8}
+          className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete={mode === "sign-in" ? "current-password" : "new-password"}
+        />
+      </label>
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded-md bg-white px-3 py-2 text-sm font-medium text-black disabled:opacity-60"
+      >
+        {loading ? "Please wait…" : mode === "sign-in" ? "Sign in" : "Create account"}
+      </button>
+    </form>
+  );
+}

--- a/apps/auth/src/lib/auth.ts
+++ b/apps/auth/src/lib/auth.ts
@@ -1,0 +1,14 @@
+import "server-only";
+
+import { getConfiguredAuthProvider } from "@nebutra/auth";
+import { createAuth } from "@nebutra/auth/server";
+
+let authInstance: Awaited<ReturnType<typeof createAuth>> | null = null;
+
+export async function getAuth() {
+  if (!authInstance) {
+    const provider = getConfiguredAuthProvider();
+    authInstance = await createAuth({ provider });
+  }
+  return authInstance;
+}

--- a/apps/auth/src/lib/return-to.test.ts
+++ b/apps/auth/src/lib/return-to.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolvePostLoginReturnTo } from "./return-to";
+
+describe("resolvePostLoginReturnTo", () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  it("defaults to app dashboard", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.nebutra.com";
+    expect(resolvePostLoginReturnTo(null)).toBe("https://app.nebutra.com/dashboard");
+  });
+
+  it("joins relative paths to app origin", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.nebutra.com";
+    expect(resolvePostLoginReturnTo("/settings")).toBe("https://app.nebutra.com/settings");
+  });
+
+  it("allows absolute app host", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.nebutra.com";
+    expect(resolvePostLoginReturnTo("https://app.nebutra.com/billing")).toBe(
+      "https://app.nebutra.com/billing",
+    );
+  });
+
+  it("rejects evil absolute hosts", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.nebutra.com";
+    expect(resolvePostLoginReturnTo("https://evil.com/phish")).toBe(
+      "https://app.nebutra.com/dashboard",
+    );
+  });
+});

--- a/apps/auth/src/lib/return-to.ts
+++ b/apps/auth/src/lib/return-to.ts
@@ -1,0 +1,29 @@
+import { getAuthReturnAllowedHosts, sanitizeReturnUrl } from "@nebutra/auth";
+
+export function resolveAppOrigin(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "https://app.nebutra.com"
+  ).replace(/\/$/, "");
+}
+
+/**
+ * Resolve a safe post-login destination for multi-app returnTo.
+ */
+export function resolvePostLoginReturnTo(raw: string | null | undefined): string {
+  const appOrigin = resolveAppOrigin();
+  const fallback = `${appOrigin}/dashboard`;
+  const allowedHosts = getAuthReturnAllowedHosts();
+
+  if (!raw || !raw.trim()) return fallback;
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("/")) {
+    return sanitizeReturnUrl(trimmed, { fallback: "/dashboard" }) === "/dashboard"
+      ? fallback
+      : `${appOrigin}${sanitizeReturnUrl(trimmed, { fallback: "/dashboard" })}`;
+  }
+
+  return sanitizeReturnUrl(trimmed, { allowedHosts, fallback });
+}

--- a/apps/auth/src/lib/session-hint.ts
+++ b/apps/auth/src/lib/session-hint.ts
@@ -1,0 +1,47 @@
+/**
+ * Cross-subdomain "session exists" hint for landing / other first-party sites.
+ * Mirrors apps/web session-hint: non-sensitive presence cookie only.
+ */
+
+export const SESSION_HINT_COOKIE = "nebutra_session_hint";
+
+function resolveHintDomain(): string | undefined {
+  const explicit = process.env.NEBUTRA_SESSION_HINT_DOMAIN?.trim();
+  if (explicit) return explicit;
+  if (process.env.NODE_ENV === "production") return ".nebutra.com";
+  return undefined;
+}
+
+export function applySessionHint(response: Response, path: string, status: number): Response {
+  const success = status >= 200 && status < 400;
+  const isAuthPath =
+    path.includes("/sign-in") ||
+    path.includes("/sign-up") ||
+    path.includes("/callback") ||
+    path.includes("/sign-out") ||
+    path.endsWith("/session");
+
+  if (!isAuthPath) return response;
+
+  const headers = new Headers(response.headers);
+  const domain = resolveHintDomain();
+  const domainPart = domain ? `; Domain=${domain}` : "";
+
+  if (path.includes("/sign-out")) {
+    headers.append(
+      "Set-Cookie",
+      `${SESSION_HINT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax${domainPart}`,
+    );
+  } else if (success && status !== 204) {
+    headers.append(
+      "Set-Cookie",
+      `${SESSION_HINT_COOKIE}=1; Path=/; Max-Age=2592000; SameSite=Lax${domainPart}`,
+    );
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/apps/auth/tsconfig.json
+++ b/apps/auth/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/auth/vitest.config.ts
+++ b/apps/auth/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import type { Session, User } from "@nebutra/auth";
-import { getConfiguredAuthProvider } from "@nebutra/auth";
+import { buildAuthCenterSignInUrl, getConfiguredAuthProvider } from "@nebutra/auth";
 import { createAuth } from "@nebutra/auth/server";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
@@ -194,14 +194,15 @@ export async function getUser(): Promise<User | null> {
 }
 
 /**
- * Require authentication, redirect to sign-in if not authenticated
- * Use at the top of protected Server Components
+ * Require authentication, redirect to login center if not authenticated.
+ * Multi-app RP model: product apps never own the primary login UI.
  */
 export async function requireAuth() {
   const { userId } = await getAuth();
 
   if (!userId) {
-    redirect("/sign-in");
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || defaultPublicUrls.appUrl;
+    redirect(buildAuthCenterSignInUrl(`${appUrl.replace(/\/$/, "")}/dashboard`));
   }
 
   return { userId };
@@ -215,7 +216,8 @@ export async function requireOrg() {
   const { userId, orgId } = await getAuth();
 
   if (!userId) {
-    redirect("/sign-in");
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || defaultPublicUrls.appUrl;
+    redirect(buildAuthCenterSignInUrl(`${appUrl.replace(/\/$/, "")}/select-org`));
   }
 
   if (!orgId) {

--- a/apps/web/src/lib/public-url-defaults.ts
+++ b/apps/web/src/lib/public-url-defaults.ts
@@ -2,12 +2,14 @@ const DEVELOPMENT_PUBLIC_URLS = {
   siteUrl: "http://localhost:3001",
   appUrl: "http://localhost:3001",
   apiUrl: "http://localhost:3002",
+  authUrl: "http://localhost:3101",
 } as const;
 
 const PRODUCTION_PUBLIC_URLS = {
-  siteUrl: "https://app.nebutra.com",
+  siteUrl: "https://nebutra.com",
   appUrl: "https://app.nebutra.com",
   apiUrl: "https://api.nebutra.com",
+  authUrl: "https://auth.nebutra.com",
 } as const;
 
 export function getDefaultPublicUrls(nodeEnv: string | undefined) {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,4 +1,9 @@
-import { getConfiguredAuthProvider } from "@nebutra/auth";
+import {
+  buildAuthCenterSignInUrl,
+  buildAuthCenterSignUpUrl,
+  getAuthCenterOrigin,
+  getConfiguredAuthProvider,
+} from "@nebutra/auth";
 import { logger } from "@nebutra/logger";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -126,6 +131,37 @@ export async function proxy(req: NextRequest, event: NextFetchEvent) {
 
   if (isDesktopAuthRemotePath(pathname)) {
     return withNonce(req, NextResponse.next());
+  }
+
+  // Login center owns /sign-in and /sign-up (multi-app RP model).
+  // Preserve returnTo so auth redirects back into this app.
+  const authCenter = getAuthCenterOrigin();
+  const thisOrigin = req.nextUrl.origin;
+  const isAuthCenterHost = (() => {
+    try {
+      return new URL(authCenter).host === req.nextUrl.host;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (
+    !isAuthCenterHost &&
+    authProvider !== "clerk" &&
+    (pathname === "/sign-in" ||
+      pathname.startsWith("/sign-in/") ||
+      pathname === "/sign-up" ||
+      pathname.startsWith("/sign-up/"))
+  ) {
+    const existing =
+      req.nextUrl.searchParams.get("returnTo") ||
+      req.nextUrl.searchParams.get("returnUrl") ||
+      req.nextUrl.searchParams.get("redirect");
+    const returnTo = existing || `${thisOrigin}/dashboard`;
+    const target = pathname.startsWith("/sign-up")
+      ? buildAuthCenterSignUpUrl(returnTo)
+      : buildAuthCenterSignInUrl(returnTo);
+    return NextResponse.redirect(target, 307);
   }
 
   if (authProvider === "clerk" && hasClerkKey) {

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -6,9 +6,10 @@
 |-----------|-----|---------|
 | `nebutra.com` | landing-page | Marketing site |
 | `www.nebutra.com` | landing-page | Redirect to apex |
-| `app.nebutra.com` | web | Main SaaS dashboard |
+| `auth.nebutra.com` | auth-center | **Login center** (Better Auth UX + session authority for multi-app RPs) |
+| `app.nebutra.com` | web | Main SaaS dashboard (RP — redirects unauthenticated users to auth) |
 | `api.nebutra.com` | api-gateway | BFF API endpoints |
-| `sso.nebutra.com` | idp | Nebutra-owned OIDC issuer for first-party/internal apps |
+| `sso.nebutra.com` | idp | **OIDC IdP** — issuer URL permanent; used for SSO / internal tools |
 | `design.nebutra.com` | design-docs | Design system docs |
 | `docs.nebutra.com` | sailor-docs (Vercel project `docs`) | Product/docs site |
 | `nebutra.sanity.studio` | studio | Canonical Sanity-hosted Studio |
@@ -24,6 +25,7 @@ Type    Name      Value                    TTL
 A       @         76.76.21.21              Auto
 CNAME   www       cname.vercel-dns.com     Auto
 CNAME   app       cname.vercel-dns.com     Auto
+CNAME   auth      <auth-center host>       Auto
 CNAME   api       cname.vercel-dns.com     Auto
 CNAME   sso       <idp host>               Auto
 CNAME   studio    <studio host>            Auto
@@ -42,18 +44,28 @@ CNAME   studio    <studio host>            Auto
 - Domain: `nebutra.com`, `www.nebutra.com`
 - Redirect: `www` → apex (301)
 
-### 2. web
-- Domain: `app.nebutra.com`
+### 2. auth-center (`apps/auth`)
+- Domain: `auth.nebutra.com`
+- `BETTER_AUTH_URL=https://auth.nebutra.com`
+- `NEXT_PUBLIC_AUTH_URL=https://auth.nebutra.com`
+- `AUTH_COOKIE_DOMAIN=.nebutra.com` (multi-app session cookies)
+- `NEXT_PUBLIC_APP_URL=https://app.nebutra.com` (default returnTo)
+- Do **not** change OIDC issuer to this host — issuer stays on `sso`.
 
-### 3. api-gateway
+### 3. web
+- Domain: `app.nebutra.com`
+- Unauthenticated product routes redirect to `auth.nebutra.com/sign-in?returnTo=…`
+- `NEXT_PUBLIC_AUTH_URL=https://auth.nebutra.com`
+
+### 4. api-gateway
 - Domain: `api.nebutra.com`
 
-### 4. idp
+### 5. idp
 - Domain: `sso.nebutra.com`
 - Serves `https://sso.nebutra.com/.well-known/openid-configuration`
 - Keep `OIDC_ISSUER=https://sso.nebutra.com` and do not path-prefix the issuer.
 
-### 5. studio
+### 6. studio
 - Canonical hosted Studio: `nebutra.sanity.studio`
 - Optional branded domain: `studio.nebutra.com` after the hosting/DNS binding is
   active
@@ -66,8 +78,20 @@ Set these in each project's Vercel dashboard:
 ```
 NEXT_PUBLIC_SITE_URL=https://nebutra.com
 NEXT_PUBLIC_APP_URL=https://app.nebutra.com
+NEXT_PUBLIC_AUTH_URL=https://auth.nebutra.com
 NEXT_PUBLIC_API_URL=https://api.nebutra.com
 NEXT_PUBLIC_STUDIO_URL=https://studio.nebutra.com
+```
+
+### auth-center
+```
+BETTER_AUTH_URL=https://auth.nebutra.com
+NEXT_PUBLIC_AUTH_URL=https://auth.nebutra.com
+AUTH_COOKIE_DOMAIN=.nebutra.com
+NEXT_PUBLIC_APP_URL=https://app.nebutra.com
+NEXT_PUBLIC_SITE_URL=https://nebutra.com
+BETTER_AUTH_SECRET=<base64-32+>
+AUTH_PROVIDER=better-auth
 ```
 
 ### idp
@@ -81,6 +105,7 @@ REDIS_URL=redis://...
 ```
 LANDING_URL=https://nebutra.com
 WEB_URL=https://app.nebutra.com
+AUTH_URL=https://auth.nebutra.com
 STUDIO_URL=https://studio.nebutra.com
 ```
 

--- a/docs/architecture/2026-07-22-auth-center-multi-app.md
+++ b/docs/architecture/2026-07-22-auth-center-multi-app.md
@@ -1,0 +1,33 @@
+# Auth Center + Multi-App RP Model
+
+**Status:** Accepted  
+**Date:** 2026-07-22
+
+## Decision
+
+Nebutra separates:
+
+| Layer | Host | Role |
+|-------|------|------|
+| Login center (Auth UX + session authority) | `auth.nebutra.com` | `apps/auth` + Better Auth |
+| OIDC IdP (issuer permanent) | `sso.nebutra.com` | `apps/idp` |
+| Product apps (RPs) | `app.nebutra.com`, future apps | Redirect unauthenticated users to auth |
+
+SSO is the **pattern** of multiple RPs trusting the auth center session and/or the sso issuer — not a third product domain.
+
+## Rules
+
+1. **Do not** rename or move `OIDC_ISSUER` off `https://sso.nebutra.com`.
+2. **Do not** implement full login UI inside product apps; redirect to auth.
+3. Cross-subdomain session cookies use `AUTH_COOKIE_DOMAIN=.nebutra.com` in production.
+4. `returnTo` / `returnUrl` must pass `sanitizeReturnUrl` with `getAuthReturnAllowedHosts()`.
+5. Future apps only add allowlisted hosts + client config — no forked login stacks.
+
+## Env (production)
+
+```bash
+NEXT_PUBLIC_AUTH_URL=https://auth.nebutra.com
+BETTER_AUTH_URL=https://auth.nebutra.com
+AUTH_COOKIE_DOMAIN=.nebutra.com
+OIDC_ISSUER=https://sso.nebutra.com
+```

--- a/infra/iac/ecs/ecosystem.config.cjs
+++ b/infra/iac/ecs/ecosystem.config.cjs
@@ -6,6 +6,7 @@
 //   $DEPLOY_ROOT/web/current/apps/web/server.js                  (Next standalone)
 //   $DEPLOY_ROOT/api/current/dist/node.js                        (pnpm-deploy + tsc)
 //   $DEPLOY_ROOT/idp/current/apps/idp/server.js                  (Next standalone)
+//   $DEPLOY_ROOT/auth/current/apps/auth/server.js                (Next standalone login center)
 //   $DEPLOY_ROOT/design-docs/current/apps/design-docs/server.js  (Next standalone)
 //   $DEPLOY_ROOT/sailor-docs/current/apps/sailor-docs/server.js  (Next standalone)
 //
@@ -88,6 +89,23 @@ module.exports = {
       env: {
         NODE_ENV: "production",
         PORT: 3100,
+        HOSTNAME: "127.0.0.1",
+      },
+      max_memory_restart: "450M",
+      instances: 1,
+      exec_mode: "fork",
+      autorestart: true,
+      max_restarts: 10,
+      kill_timeout: 8000,
+      listen_timeout: 10000,
+    },
+    {
+      name: "auth-center",
+      cwd: "/var/www/nebutra/auth/current",
+      script: "apps/auth/server.js",
+      env: {
+        NODE_ENV: "production",
+        PORT: 3101,
         HOSTNAME: "127.0.0.1",
       },
       max_memory_restart: "450M",

--- a/infra/ops/scripts/ecs-deploy-remote.sh
+++ b/infra/ops/scripts/ecs-deploy-remote.sh
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 DEPLOY_ROOT="${DEPLOY_ROOT:-/var/www/nebutra}"
-APPS="${APPS:-landing web api idp design-docs sailor-docs}"
+APPS="${APPS:-landing web api idp auth design-docs sailor-docs}"
 # Default 1 (was 2 since the May 12 disk-full incident reduced it from 5).
 # Cut to 1 on 2026-05-15 when design-docs joined as the 4th VM app — at 4
 # apps × ~1 GB/release × 2 releases small cloud disks can fill quickly.
@@ -45,11 +45,11 @@ capture_deploy_runtime_env() {
 DEPLOY_RUNTIME_KEYS=(
   DATABASE_URL DIRECT_URL SUPABASE_DATABASE_URL SUPABASE_DIRECT_URL
   AUTH_PROVIDER NEXT_PUBLIC_AUTH_PROVIDER VITE_AUTH_PROVIDER VITE_API_GATEWAY_URL VITE_AUTH_API_URL
-  BETTER_AUTH_SECRET BETTER_AUTH_URL
+  BETTER_AUTH_SECRET BETTER_AUTH_URL NEXT_PUBLIC_AUTH_URL AUTH_COOKIE_DOMAIN AUTH_RETURN_ALLOWED_HOSTS
   NEXT_PUBLIC_SITE_URL NEXT_PUBLIC_APP_URL NEXT_PUBLIC_API_URL NEXT_PUBLIC_API_GATEWAY_URL
   NEXT_PUBLIC_STUDIO_URL NEXT_PUBLIC_DOCS_URL NEBUTRA_LANDING_ORIGIN
-  NEBUTRA_SESSION_HINT_DOMAIN DOMAIN_LANDING DOMAIN_APP DOMAIN_API DOMAIN_STUDIO
-  LANDING_URL WEB_URL STUDIO_URL CORS_ORIGINS
+  NEBUTRA_SESSION_HINT_DOMAIN DOMAIN_LANDING DOMAIN_APP DOMAIN_API DOMAIN_AUTH DOMAIN_STUDIO
+  LANDING_URL WEB_URL AUTH_URL STUDIO_URL CORS_ORIGINS
   UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN UPSTASH_REDIS_URL UPSTASH_REDIS_TOKEN
   REDIS_URL OIDC_ISSUER OIDC_COOKIE_KEYS OIDC_ENABLE_CLIENT_CREDENTIALS
   GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET NEXT_PUBLIC_GOOGLE_CLIENT_ID
@@ -86,8 +86,8 @@ log()  { echo "[$(date -u +%H:%M:%S)] $*"; }
 fail() { echo "::error:: $*" >&2; exit 1; }
 
 case "$APPS" in
-  *landing*|*web*|*api*|*idp*|*design-docs*|*sailor-docs*) : ;;
-  *) fail "APPS must contain at least one of: landing web api idp design-docs sailor-docs (got: $APPS)" ;;
+  *landing*|*web*|*api*|*idp*|*auth*|*design-docs*|*sailor-docs*) : ;;
+  *) fail "APPS must contain at least one of: landing web api idp auth design-docs sailor-docs (got: $APPS)" ;;
 esac
 
 mkdir -p "$DEPLOY_ROOT"
@@ -528,7 +528,7 @@ load_runtime_env() {
     log "no runtime env files found for $app"
   fi
 
-  if [ "$app" = "web" ] || [ "$app" = "api" ] || [ "$app" = "idp" ]; then
+  if [ "$app" = "web" ] || [ "$app" = "api" ] || [ "$app" = "idp" ] || [ "$app" = "auth" ]; then
     persist_database_runtime_env "$app_root"
     [ -f "$app_root/.env" ] && source_runtime_env_file "$app_root/.env"
   fi
@@ -553,6 +553,43 @@ load_runtime_env() {
     replace_env_assignment "$app_root/.env" HOSTNAME "127.0.0.1"
     replace_env_assignment "$app_root/.env" OIDC_ISSUER "$OIDC_ISSUER"
     replace_env_assignment "$app_root/.env" OIDC_ENABLE_CLIENT_CREDENTIALS "$OIDC_ENABLE_CLIENT_CREDENTIALS"
+    [ -f "$app_root/.env" ] && source_runtime_env_file "$app_root/.env"
+  fi
+
+  if [ "$app" = "auth" ]; then
+    # Login center: Better Auth authority for multi-app RPs.
+    BETTER_AUTH_URL="${BETTER_AUTH_URL:-https://auth.nebutra.com}"
+    NEXT_PUBLIC_AUTH_URL="${NEXT_PUBLIC_AUTH_URL:-https://auth.nebutra.com}"
+    AUTH_COOKIE_DOMAIN="${AUTH_COOKIE_DOMAIN:-.nebutra.com}"
+    NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL:-https://app.nebutra.com}"
+    NEXT_PUBLIC_SITE_URL="${NEXT_PUBLIC_SITE_URL:-https://nebutra.com}"
+    AUTH_PROVIDER="${AUTH_PROVIDER:-better-auth}"
+
+    local missing=()
+    [ -n "${DATABASE_URL:-}" ] || missing+=("DATABASE_URL")
+    [ -n "${BETTER_AUTH_SECRET:-}" ] || missing+=("BETTER_AUTH_SECRET")
+    if [ "${#missing[@]}" -gt 0 ]; then
+      load_existing_pm2_env "$pm2_name"
+      missing=()
+      [ -n "${DATABASE_URL:-}" ] || missing+=("DATABASE_URL")
+      [ -n "${BETTER_AUTH_SECRET:-}" ] || missing+=("BETTER_AUTH_SECRET")
+      if [ "${#missing[@]}" -gt 0 ]; then
+        fail "auth-center runtime env missing required keys: ${missing[*]}"
+      fi
+    fi
+
+    ensure_env_assignment "$app_root/.env" NODE_ENV "production"
+    replace_env_assignment "$app_root/.env" PORT "3101"
+    replace_env_assignment "$app_root/.env" HOSTNAME "127.0.0.1"
+    replace_env_assignment "$app_root/.env" AUTH_PROVIDER "$AUTH_PROVIDER"
+    replace_env_assignment "$app_root/.env" NEXT_PUBLIC_AUTH_PROVIDER "$AUTH_PROVIDER"
+    replace_env_assignment "$app_root/.env" BETTER_AUTH_URL "$BETTER_AUTH_URL"
+    replace_env_assignment "$app_root/.env" NEXT_PUBLIC_AUTH_URL "$NEXT_PUBLIC_AUTH_URL"
+    replace_env_assignment "$app_root/.env" AUTH_COOKIE_DOMAIN "$AUTH_COOKIE_DOMAIN"
+    replace_env_assignment "$app_root/.env" NEXT_PUBLIC_APP_URL "$NEXT_PUBLIC_APP_URL"
+    replace_env_assignment "$app_root/.env" NEXT_PUBLIC_SITE_URL "$NEXT_PUBLIC_SITE_URL"
+    persist_google_auth_runtime_env "$app_root"
+    persist_github_auth_runtime_env "$app_root"
     [ -f "$app_root/.env" ] && source_runtime_env_file "$app_root/.env"
   fi
 
@@ -1014,6 +1051,9 @@ for p in procs:
     idp)
       wait_for_local_http "idp" "$pm2_name" "http://127.0.0.1:3100/health" "^200$"
       ;;
+    auth-center|auth)
+      wait_for_local_http "auth-center" "$pm2_name" "http://127.0.0.1:3101/health" "^200$"
+      ;;
     design-docs)
       wait_for_local_http "design-docs" "$pm2_name" "http://127.0.0.1:3004/"
       ;;
@@ -1051,6 +1091,7 @@ pm2_name_for_app() {
     web)          printf '%s\n' "web" ;;
     api)          printf '%s\n' "api-gateway" ;;
     idp)          printf '%s\n' "idp" ;;
+    auth)         printf '%s\n' "auth-center" ;;
     design-docs)  printf '%s\n' "design-docs" ;;
     sailor-docs)  printf '%s\n' "sailor-docs" ;;
     *)            fail "unknown app: $1" ;;
@@ -1235,7 +1276,7 @@ verify_nginx_web_origin() {
 
 run_selected_apps() {
   local action="$1" app pm2_name
-  for app in api landing web idp design-docs sailor-docs; do
+  for app in api landing web idp auth design-docs sailor-docs; do
     case " $APPS " in
       *" $app "*) : ;;
       *) continue ;;
@@ -1253,7 +1294,7 @@ if [ "$MODE" = "rollback" ]; then
   exit 0
 fi
 
-for app in api landing web idp design-docs sailor-docs; do
+for app in api landing web idp auth design-docs sailor-docs; do
   case " $APPS " in
     *" $app "*) : ;;
     *) continue ;;
@@ -1264,6 +1305,7 @@ for app in api landing web idp design-docs sailor-docs; do
     web)          deploy_one web         web          ;;
     api)          deploy_one api         api-gateway  ;;
     idp)          deploy_one idp         idp          ;;
+    auth)         deploy_one auth        auth-center  ;;
     design-docs)  deploy_one design-docs design-docs  ;;
     sailor-docs)  deploy_one sailor-docs sailor-docs  ;;
     *)            fail "unknown app: $app"            ;;

--- a/infra/runtime/nginx/conf.d/auth.nebutra.com.conf
+++ b/infra/runtime/nginx/conf.d/auth.nebutra.com.conf
@@ -1,0 +1,44 @@
+# auth.nebutra.com — login center (Better Auth UX + session authority)
+# Copy to /etc/nginx/conf.d/ when not using monolithic nginx.conf
+
+upstream nebutra_auth {
+    server 127.0.0.1:3101;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    server_name auth.nebutra.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        try_files $uri =404;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name auth.nebutra.com;
+
+    ssl_certificate     /etc/ssl/nebutra/fullchain.pem;
+    ssl_certificate_key /etc/ssl/nebutra/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Cache-Control "no-store" always;
+
+    location / {
+        proxy_pass http://nebutra_auth;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+    }
+}

--- a/infra/runtime/nginx/nginx.conf
+++ b/infra/runtime/nginx/nginx.conf
@@ -127,6 +127,12 @@ http {
         keepalive 16;
     }
 
+    # Login center (Better Auth UX + session authority for multi-app RPs)
+    upstream nebutra_auth {
+        server 127.0.0.1:3101;
+        keepalive 16;
+    }
+
     # Python FastAPI microservices (internal — not directly exposed via public DNS)
     upstream nebutra_ai {
         server 127.0.0.1:8001;
@@ -434,6 +440,56 @@ http {
         location /_next/static/ {
             include /etc/nginx/conf.d/proxy_params.conf;
             proxy_pass http://nebutra_idp;
+            expires 1y;
+            add_header Cache-Control "public, immutable" always;
+        }
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+            try_files $uri =404;
+        }
+    }
+
+    # ===========================================================================
+    # SERVER BLOCK 5b: auth.nebutra.com (Login center — multi-app RP model)
+    # ===========================================================================
+    server {
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name auth.nebutra.com;
+
+        ssl_certificate     /etc/ssl/nebutra/fullchain.pem;
+        ssl_certificate_key /etc/ssl/nebutra/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 1d;
+        ssl_session_tickets off;
+
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cache-Control "no-store" always;
+
+        limit_req zone=auth_limit burst=30 nodelay;
+
+        location /api/auth {
+            include /etc/nginx/conf.d/proxy_params.conf;
+            proxy_pass http://nebutra_auth;
+            proxy_read_timeout 60s;
+        }
+
+        location / {
+            include /etc/nginx/conf.d/proxy_params.conf;
+            proxy_pass http://nebutra_auth;
+            proxy_read_timeout 60s;
+        }
+
+        location /_next/static/ {
+            include /etc/nginx/conf.d/proxy_params.conf;
+            proxy_pass http://nebutra_auth;
             expires 1y;
             add_header Cache-Control "public, immutable" always;
         }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:api": "pnpm --filter @nebutra/gateway dev",
     "dev:storybook": "pnpm --filter @nebutra/storybook dev",
     "dev:docs": "pnpm --filter @nebutra/sailor-docs dev",
+    "dev:auth": "pnpm --filter @nebutra/auth-center dev",
     "dev:theme-playground": "pnpm --filter @nebutra/web dev",
     "build": "pnpm brand:sync && turbo run build",
     "build:strict": "pnpm ui:verify-governance && pnpm brand:verify-tokens && pnpm run build",

--- a/packages/iam/auth/src/__tests__/auth-center.test.ts
+++ b/packages/iam/auth/src/__tests__/auth-center.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildAuthCenterSignInUrl,
+  buildAuthCenterSignUpUrl,
+  getAuthCenterOrigin,
+  getAuthReturnAllowedHosts,
+} from "../utils/auth-center";
+
+describe("auth center URL helpers", () => {
+  afterEach(() => {
+    for (const key of [
+      "NEXT_PUBLIC_AUTH_URL",
+      "BETTER_AUTH_URL",
+      "NEXT_PUBLIC_APP_URL",
+      "AUTH_RETURN_ALLOWED_HOSTS",
+    ]) {
+      delete process.env[key];
+    }
+  });
+
+  it("prefers NEXT_PUBLIC_AUTH_URL for the center origin", () => {
+    process.env.NEXT_PUBLIC_AUTH_URL = "https://auth.nebutra.com/";
+    process.env.BETTER_AUTH_URL = "https://app.nebutra.com";
+    expect(getAuthCenterOrigin()).toBe("https://auth.nebutra.com");
+  });
+
+  it("builds sign-in URL with returnTo", () => {
+    process.env.NEXT_PUBLIC_AUTH_URL = "https://auth.nebutra.com";
+    expect(buildAuthCenterSignInUrl("https://app.nebutra.com/dashboard")).toBe(
+      "https://auth.nebutra.com/sign-in?returnTo=https%3A%2F%2Fapp.nebutra.com%2Fdashboard",
+    );
+  });
+
+  it("builds sign-up URL", () => {
+    process.env.NEXT_PUBLIC_AUTH_URL = "https://auth.nebutra.com";
+    expect(buildAuthCenterSignUpUrl()).toBe("https://auth.nebutra.com/sign-up");
+  });
+
+  it("includes production hosts in return allowlist", () => {
+    const hosts = getAuthReturnAllowedHosts({
+      NEXT_PUBLIC_APP_URL: "https://app.nebutra.com",
+      AUTH_RETURN_ALLOWED_HOSTS: "console.nebutra.com",
+    });
+    expect(hosts).toContain("app.nebutra.com");
+    expect(hosts).toContain("auth.nebutra.com");
+    expect(hosts).toContain("console.nebutra.com");
+  });
+});

--- a/packages/iam/auth/src/index.ts
+++ b/packages/iam/auth/src/index.ts
@@ -54,13 +54,17 @@ export type {
   SignInMethod,
   User,
 } from "./types";
-// Utilities (returnUrl sanitization, Turnstile verification)
+// Utilities: login-center URLs, returnUrl sanitization, Turnstile
 export type {
   SanitizeReturnUrlOptions,
   VerifyTurnstileOptions,
   VerifyTurnstileResult,
 } from "./utils";
 export {
+  buildAuthCenterSignInUrl,
+  buildAuthCenterSignUpUrl,
+  getAuthCenterOrigin,
+  getAuthReturnAllowedHosts,
   getSanitizedReturnUrl,
   isTurnstileConfigured,
   sanitizeReturnUrl,

--- a/packages/iam/auth/src/providers/better-auth.test.ts
+++ b/packages/iam/auth/src/providers/better-auth.test.ts
@@ -106,6 +106,7 @@ describe("Better Auth trusted origins (cross-origin One Tap / OAuth)", () => {
   beforeEach(() => {
     for (const key of [
       "BETTER_AUTH_URL",
+      "NEXT_PUBLIC_AUTH_URL",
       "NEXT_PUBLIC_SITE_URL",
       "NEXT_PUBLIC_APP_URL",
       "NEBUTRA_LANDING_ORIGIN",
@@ -120,14 +121,16 @@ describe("Better Auth trusted origins (cross-origin One Tap / OAuth)", () => {
   });
 
   it("collects, trims, and dedupes first-party origins so the landing One Tap is trusted", () => {
-    process.env.BETTER_AUTH_URL = "https://app.nebutra.com";
+    process.env.BETTER_AUTH_URL = "https://auth.nebutra.com";
+    process.env.NEXT_PUBLIC_AUTH_URL = "https://auth.nebutra.com";
     process.env.NEXT_PUBLIC_SITE_URL = "https://nebutra.com";
-    process.env.NEXT_PUBLIC_APP_URL = "https://app.nebutra.com"; // duplicate of BETTER_AUTH_URL
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.nebutra.com";
     process.env.BETTER_AUTH_TRUSTED_ORIGINS = " https://staging.nebutra.com , ";
 
     expect(resolveBetterAuthTrustedOrigins()).toEqual([
-      "https://app.nebutra.com",
+      "https://auth.nebutra.com",
       "https://nebutra.com",
+      "https://app.nebutra.com",
       "https://staging.nebutra.com",
     ]);
   });

--- a/packages/iam/auth/src/providers/better-auth.ts
+++ b/packages/iam/auth/src/providers/better-auth.ts
@@ -12,11 +12,12 @@
  *
  * Environment variables:
  * - BETTER_AUTH_SECRET (required)
- * - BETTER_AUTH_URL (optional, base URL for auth endpoints)
+ * - BETTER_AUTH_URL (optional, base URL for auth endpoints — prefer auth center)
+ * - AUTH_COOKIE_DOMAIN (optional, e.g. `.nebutra.com` for multi-app SSO cookies)
  * - BETTER_AUTH_TRUSTED_ORIGINS (optional, comma-separated extra origins trusted
- *   for cross-origin auth; NEXT_PUBLIC_SITE_URL / NEXT_PUBLIC_APP_URL /
- *   NEBUTRA_LANDING_ORIGIN are also trusted — needed for the landing-page Google
- *   One Tap that posts cross-origin to the app's /api/auth)
+ *   for cross-origin auth; NEXT_PUBLIC_AUTH_URL / SITE / APP /
+ *   NEBUTRA_LANDING_ORIGIN are also trusted — needed for landing One Tap and
+ *   multi-app return_to flows against the auth center)
  * - GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET (optional, enables Google OAuth)
  * - GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET (optional, enables GitHub OAuth)
  * - APPLE_CLIENT_ID / APPLE_CLIENT_SECRET (optional, enables Sign in with Apple — App Store compliance for SaaS apps that ship Google/Facebook login)
@@ -287,10 +288,26 @@ export function createBetterAuthProvider(config: AuthConfig): AuthProvider {
       buildInvitationDatabaseHooks(),
     ) as Record<string, unknown>;
 
+    // Multi-app login center: share session cookies across first-party
+    // subdomains (auth. / app. / console.) when AUTH_COOKIE_DOMAIN is set.
+    // Leave unset for single-host / localhost so BA keeps host-only cookies.
+    const cookieDomain = process.env.AUTH_COOKIE_DOMAIN?.trim();
+    const crossSubDomainCookies = cookieDomain
+      ? {
+          advanced: {
+            crossSubDomainCookies: {
+              enabled: true as const,
+              domain: cookieDomain,
+            },
+          },
+        }
+      : {};
+
     const auth = betterAuth({
       secret,
       baseURL: process.env.BETTER_AUTH_URL,
       ...(trustedOrigins.length > 0 ? { trustedOrigins } : {}),
+      ...crossSubDomainCookies,
       emailAndPassword: { enabled: true },
       socialProviders,
       database: prismaAdapter(

--- a/packages/iam/auth/src/providers/better-auth/trusted-origins.ts
+++ b/packages/iam/auth/src/providers/better-auth/trusted-origins.ts
@@ -9,7 +9,8 @@
  * cross-origin One Tap / OAuth flow silently 403s.
  *
  * Sourced from env (trimmed, empties dropped, deduped, insertion order kept):
- *   - BETTER_AUTH_URL              the app's own base (also always trusted by BA)
+ *   - BETTER_AUTH_URL              auth center / BA base (always trusted by BA)
+ *   - NEXT_PUBLIC_AUTH_URL         public auth-center origin (login UX host)
  *   - NEXT_PUBLIC_SITE_URL         marketing / landing origin
  *   - NEXT_PUBLIC_APP_URL          dashboard origin
  *   - NEBUTRA_LANDING_ORIGIN       explicit landing origin override
@@ -23,6 +24,7 @@ export function resolveBetterAuthTrustedOrigins(): string[] {
     new Set(
       [
         process.env.BETTER_AUTH_URL,
+        process.env.NEXT_PUBLIC_AUTH_URL,
         process.env.NEXT_PUBLIC_SITE_URL,
         process.env.NEXT_PUBLIC_APP_URL,
         process.env.NEBUTRA_LANDING_ORIGIN,

--- a/packages/iam/auth/src/utils/auth-center.ts
+++ b/packages/iam/auth/src/utils/auth-center.ts
@@ -1,0 +1,86 @@
+/**
+ * Login-center URL helpers (auth.nebutra.com).
+ *
+ * Auth center owns Better Auth baseURL + sign-in UI. Product apps are RPs:
+ * they redirect unauthenticated users here with a safe returnTo.
+ */
+
+const LOCAL_AUTH_ORIGIN = "http://localhost:3101";
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+/**
+ * Public origin of the login center.
+ * Prefer NEXT_PUBLIC_AUTH_URL, then BETTER_AUTH_URL, then app URL (legacy).
+ */
+export function getAuthCenterOrigin(env: Record<string, string | undefined> = process.env): string {
+  const raw =
+    env.NEXT_PUBLIC_AUTH_URL?.trim() ||
+    env.BETTER_AUTH_URL?.trim() ||
+    env.NEXT_PUBLIC_APP_URL?.trim() ||
+    LOCAL_AUTH_ORIGIN;
+  return stripTrailingSlash(raw);
+}
+
+/**
+ * Hosts allowed as absolute returnTo targets after login.
+ * Always includes auth center + app; extend via AUTH_RETURN_ALLOWED_HOSTS.
+ */
+export function getAuthReturnAllowedHosts(
+  env: Record<string, string | undefined> = process.env,
+): string[] {
+  const hosts = new Set<string>();
+
+  for (const raw of [
+    env.NEXT_PUBLIC_AUTH_URL,
+    env.BETTER_AUTH_URL,
+    env.NEXT_PUBLIC_APP_URL,
+    env.NEXT_PUBLIC_SITE_URL,
+    env.NEBUTRA_LANDING_ORIGIN,
+    ...(env.AUTH_RETURN_ALLOWED_HOSTS?.split(",") ?? []),
+  ]) {
+    const value = raw?.trim();
+    if (!value) continue;
+    try {
+      hosts.add(new URL(value.includes("://") ? value : `https://${value}`).host.toLowerCase());
+    } catch {
+      // ignore malformed
+    }
+  }
+
+  // Multi-app defaults for local + production
+  hosts.add("localhost:3000");
+  hosts.add("localhost:3001");
+  hosts.add("localhost:3101");
+  hosts.add("app.nebutra.com");
+  hosts.add("auth.nebutra.com");
+  hosts.add("nebutra.com");
+
+  return Array.from(hosts);
+}
+
+export function buildAuthCenterSignInUrl(
+  returnTo?: string | null,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const origin = getAuthCenterOrigin(env);
+  const url = new URL("/sign-in", `${origin}/`);
+  if (returnTo && returnTo.trim()) {
+    url.searchParams.set("returnTo", returnTo.trim());
+  }
+  return url.toString();
+}
+
+export function buildAuthCenterSignUpUrl(
+  returnTo?: string | null,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const origin = getAuthCenterOrigin(env);
+  const url = new URL("/sign-up", `${origin}/`);
+  if (returnTo && returnTo.trim()) {
+    url.searchParams.set("returnTo", returnTo.trim());
+  }
+  return url.toString();
+}

--- a/packages/iam/auth/src/utils/index.ts
+++ b/packages/iam/auth/src/utils/index.ts
@@ -1,3 +1,9 @@
+export {
+  buildAuthCenterSignInUrl,
+  buildAuthCenterSignUpUrl,
+  getAuthCenterOrigin,
+  getAuthReturnAllowedHosts,
+} from "./auth-center";
 export type { SanitizeReturnUrlOptions } from "./return-url";
 export { getSanitizedReturnUrl, sanitizeReturnUrl } from "./return-url";
 export type { VerifyTurnstileOptions, VerifyTurnstileResult } from "./turnstile";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,61 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
+  apps/auth:
+    dependencies:
+      '@nebutra/auth':
+        specifier: workspace:*
+        version: link:../../packages/iam/auth
+      '@nebutra/brand':
+        specifier: workspace:*
+        version: link:../../packages/design/brand
+      '@nebutra/db':
+        specifier: workspace:*
+        version: link:../../packages/platform/db
+      '@nebutra/logger':
+        specifier: workspace:*
+        version: link:../../packages/platform/logger
+      '@nebutra/tokens':
+        specifier: workspace:*
+        version: link:../../packages/design/tokens
+      '@nebutra/ui':
+        specifier: workspace:*
+        version: link:../../packages/design/ui
+      next:
+        specifier: ^16.2.6
+        version: 16.2.6(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.2.1
+        version: 4.2.1
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.3.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+
   apps/design-docs:
     dependencies:
       '@ai-sdk/openai-compatible':
@@ -32324,7 +32379,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@2.0.5':
     dependencies:

--- a/tests/architecture/auth-center.test.ts
+++ b/tests/architecture/auth-center.test.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+function read(path: string): string {
+  return readFileSync(join(root, path), "utf8");
+}
+
+describe("auth center multi-app governance", () => {
+  it("ships apps/auth as the login center package", () => {
+    expect(existsSync(join(root, "apps/auth/package.json"))).toBe(true);
+    const pkg = JSON.parse(read("apps/auth/package.json")) as { name: string };
+    expect(pkg.name).toBe("@nebutra/auth-center");
+  });
+
+  it("documents auth.nebutra.com + permanent sso issuer", () => {
+    const domains = read("docs/DOMAINS.md");
+    expect(domains).toContain("auth.nebutra.com");
+    expect(domains).toContain("sso.nebutra.com");
+    expect(domains).toContain("OIDC_ISSUER=https://sso.nebutra.com");
+    expect(domains).toMatch(/Login center/i);
+  });
+
+  it("web proxy redirects product sign-in to the auth center", () => {
+    const proxy = read("apps/web/src/proxy.ts");
+    expect(proxy).toContain("buildAuthCenterSignInUrl");
+    expect(proxy).toContain("getAuthCenterOrigin");
+  });
+
+  it("nginx routes auth.nebutra.com to the auth-center upstream", () => {
+    const nginx = read("infra/runtime/nginx/nginx.conf");
+    expect(nginx).toContain("server_name auth.nebutra.com");
+    expect(nginx).toContain("nebutra_auth");
+    expect(nginx).toContain("127.0.0.1:3101");
+  });
+
+  it("Better Auth trusts NEXT_PUBLIC_AUTH_URL for cross-origin", () => {
+    const trusted = read("packages/iam/auth/src/providers/better-auth/trusted-origins.ts");
+    expect(trusted).toContain("NEXT_PUBLIC_AUTH_URL");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `apps/auth` as the **login center** (Better Auth session authority)
- Keep `sso.nebutra.com` as permanent **OIDC issuer**
- Product `app` redirects `/sign-in` `/sign-up` → auth center with safe `returnTo`
- Cross-subdomain cookies via `AUTH_COOKIE_DOMAIN=.nebutra.com`
- Nginx, ECS/PM2, deploy-ecs matrix, architecture governance tests

## Topology
`auth` = Auth UX · `sso` = IdP · `app*` = RPs · SSO = multi-RP pattern

## Test plan
- [x] `@nebutra/auth` unit tests
- [x] auth-center returnTo tests
- [x] architecture auth-center tests
- [x] typecheck green
- [ ] Deploy `auth` (+ web) to ECS
- [ ] DNS `auth.nebutra.com` → ECS
- [ ] Smoke `https://auth.nebutra.com/health` and `/sign-in`