### PR TITLE
chore(ci): mark design-docs UI governance steps as advisory

### DIFF
--- a/.github/workflows/ui-governance.yml
+++ b/.github/workflows/ui-governance.yml
@@ -1,3 +1,16 @@
+# UI Governance — hybrid hard / advisory gate
+#
+# Hard (must pass): policy schema, brand token sync, theme quality, UI rules.
+# Advisory (continue-on-error): design-docs registry + IA demos + build.
+#
+# Why advisory for design-docs:
+# - Not a required status check on main (branch protection = CodeQL only).
+# - design-docs ComponentPreview ↔ generated demos has chronic drift on main,
+#   so the job was de-facto zombie noise for unrelated packages/design PRs.
+# - Rebaseline demos in a dedicated design-docs PR, then flip these steps
+#   back to hard fail (remove continue-on-error) and optionally add as required.
+#
+# Do not "fix green" by bulk-editing demos on skins/i18n/forge PRs.
 name: UI Governance
 
 on:
@@ -50,6 +63,7 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
 
+      # ── Hard gates (product token / theme / static UI rules) ─────────────
       - name: Validate UI Governance Policy Schema
         run: pnpm exec tsx scripts/validate-ui-governance-policy.ts
 
@@ -62,13 +76,17 @@ jobs:
       - name: Verify UI Governance Rules
         run: pnpm exec tsx scripts/verify-ui-governance.ts
 
-      - name: Refresh Design Docs Registry
+      # ── Advisory: design-docs (chronic demo/registry drift; non-blocking) ─
+      - name: Refresh Design Docs Registry (advisory)
+        continue-on-error: true
         run: pnpm --config.verify-deps-before-run=false --filter @nebutra/design-docs prebuild
 
-      - name: Verify Design Docs Governance
+      - name: Verify Design Docs Governance (advisory)
+        continue-on-error: true
         run: pnpm --config.verify-deps-before-run=false --filter @nebutra/design-docs docs:governance
 
-      - name: Verify Design Docs Registry Freshness
+      - name: Verify Design Docs Registry Freshness (advisory)
+        continue-on-error: true
         run: |
           git diff --exit-code -- \
             apps/design-docs/public/r \
@@ -79,7 +97,8 @@ jobs:
             apps/design-docs/src/__registry__/index.tsx \
             apps/design-docs/src/__registry__/file-map.json
 
-      - name: Verify Design Docs Runtime Contract
+      - name: Verify Design Docs Runtime Contract (advisory)
+        continue-on-error: true
         run: |
           pnpm --config.verify-deps-before-run=false --filter @nebutra/design-docs typecheck
           pnpm --config.verify-deps-before-run=false --filter @nebutra/design-docs build


### PR DESCRIPTION
## Summary

- **Hard** (still fail the job): policy schema, brand token sync, theme quality, UI governance rules
- **Advisory** (`continue-on-error`): design-docs prebuild / `docs:governance` / registry freshness / typecheck+build

## Why

- UI Governance is **not** a required status check on `main` (only CodeQL is)
- design-docs ComponentPreview ↔ generated demos has **chronic drift**, so main + unrelated `packages/design/**` PRs stay red and create merge noise
- Aligns CI with reality: soft gate until demos are rebaselined in a **dedicated** design-docs PR

## Follow-up (not this PR)

- Rebaseline design-docs demos / registry
- Then remove `continue-on-error` and optionally add as required check

## Test plan

- [x] Workflow YAML only; no app code
- [ ] CI: hard steps still run; design-docs steps may warn but job stays green when hard steps pass