### PR TITLE
fix(ui): ban OS select chrome; default Select to listbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,16 +266,28 @@ import { Input, Textarea, Select, SelectContent, SelectItem, SelectTrigger, Sele
 </Field>
 ```
 
-**Native opt-out** — add `data-allow-native` for legitimate cases:
+**Native opt-out** — add `data-allow-native` for legitimate **input/textarea** cases:
 
 ```tsx
 <input data-allow-native type="hidden" name="orgId" value={orgId} />  {/* form data */}
 <input data-allow-native type="file" ref={inputRef} className="sr-only" />  {/* trigger via button */}
-<select data-allow-native value={filters.outcome ?? ""} onChange={...}>  {/* needs empty-string "all" semantics */}
-  <option value="">All</option>
-  ...
-</select>
 ```
+
+**Never use raw `<select>` in product apps** — OS option menus cannot be themed (dark UI → white system popup). Use DS Select (compound or `options={…}` listbox). Empty “All” uses a sentinel value, not `value=""`:
+
+```tsx
+const ALL = "__all__";
+<Select
+  value={filters.outcome ?? ALL}
+  onValueChange={(v) => setOutcome(!v || v === ALL ? undefined : v)}
+  options={[
+    { value: ALL, label: "All" },
+    { value: "success", label: "Success" },
+  ]}
+/>
+```
+
+Escape hatch only with `// allow-os-select: <reason>` on the preceding line (lint still documents it; avoid).
 
 CI guard: `scripts/lint-no-raw-inputs.mjs` (wired into `pnpm lint`). Whitelist: storybook stories, design-docs/sailor-docs previews, tsekaluk-dev's own `ui/`, test files, all `packages/**/primitives/**`.
 

--- a/apps/forge/src/components/runner-select-options.ts
+++ b/apps/forge/src/components/runner-select-options.ts
@@ -1,0 +1,36 @@
+import { Children, isValidElement, type ReactNode } from "react";
+
+export type RunnerSelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+function textOf(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) {
+    const props = node.props as { children?: ReactNode };
+    return textOf(props.children);
+  }
+  return "";
+}
+
+/** Collect <option> children into { value, label } for the compound Select. */
+export function optionsFromChildren(children: ReactNode): RunnerSelectOption[] {
+  const options: RunnerSelectOption[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    if (child.type !== "option") return;
+    const props = child.props as {
+      value?: string | number;
+      disabled?: boolean;
+      children?: ReactNode;
+    };
+    const value = String(props.value ?? "");
+    const label = textOf(props.children) || value;
+    options.push(props.disabled === true ? { value, label, disabled: true } : { value, label });
+  });
+  return options;
+}

--- a/apps/forge/src/components/runner-select.test.ts
+++ b/apps/forge/src/components/runner-select.test.ts
@@ -1,0 +1,29 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import { optionsFromChildren } from "./runner-select-options";
+
+describe("optionsFromChildren", () => {
+  it("maps option elements to value/label pairs", () => {
+    const children = [
+      createElement("option", { key: "a", value: "json-to-csv" }, "JSON → CSV"),
+      createElement("option", { key: "b", value: "csv-to-json" }, "CSV → JSON"),
+    ];
+    expect(optionsFromChildren(children)).toEqual([
+      { value: "json-to-csv", label: "JSON → CSV" },
+      { value: "csv-to-json", label: "CSV → JSON" },
+    ]);
+  });
+
+  it("marks disabled options", () => {
+    const child = createElement("option", { value: "x", disabled: true }, "Off");
+    expect(optionsFromChildren(child)).toEqual([{ value: "x", label: "Off", disabled: true }]);
+  });
+
+  it("ignores non-option children", () => {
+    const children = [
+      createElement("div", { key: "d" }, "nope"),
+      createElement("option", { key: "o", value: "1" }, "One"),
+    ];
+    expect(optionsFromChildren(children)).toEqual([{ value: "1", label: "One" }]);
+  });
+});

--- a/apps/forge/src/components/runner-select.tsx
+++ b/apps/forge/src/components/runner-select.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * Forge runner select — DS compound listbox (styled popup), not native OS chrome.
+ * Drop-in for the former native <select data-allow-native> RunnerSelect API.
+ */
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nebutra/ui/primitives";
+import type { ReactNode } from "react";
+
+import { optionsFromChildren, type RunnerSelectOption } from "@/components/runner-select-options";
+
+export type { RunnerSelectOption };
+export { optionsFromChildren };
+
+export function RunnerSelect({
+  label,
+  id,
+  value,
+  onChange,
+  children,
+  className,
+  options: optionsProp,
+}: {
+  label?: string;
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  children?: ReactNode;
+  className?: string;
+  /** Prefer this over <option> children when you already have a list. */
+  options?: readonly RunnerSelectOption[];
+}) {
+  const options = optionsProp?.length
+    ? optionsProp.map((o) => ({ ...o, value: String(o.value) }))
+    : optionsFromChildren(children);
+
+  const items = Object.fromEntries(options.map((o) => [o.value, o.label]));
+  const selectedLabel = items[value] ?? value;
+  const labelId = id ? `${id}-label` : undefined;
+
+  const control = (
+    <Select
+      value={value}
+      onValueChange={(next) => {
+        if (next == null) return;
+        onChange(String(next));
+      }}
+      items={items}
+    >
+      <SelectTrigger
+        id={id}
+        // DS trigger defaults to w-full; runners sit in compact toolbars.
+        className={className ?? "w-auto min-w-[10rem]"}
+        aria-labelledby={label && labelId ? labelId : undefined}
+        aria-label={!label ? id : undefined}
+      >
+        <SelectValue placeholder={selectedLabel || "选择…"}>
+          {() => selectedLabel || "选择…"}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value} disabled={option.disabled}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+  if (!label) return control;
+
+  return (
+    <div className="flex flex-col gap-1.5 text-sm text-[var(--neutral-11)]">
+      <span className="text-xs font-medium" id={labelId}>
+        {label}
+      </span>
+      {control}
+    </div>
+  );
+}

--- a/apps/forge/src/components/runner-ui.tsx
+++ b/apps/forge/src/components/runner-ui.tsx
@@ -4,14 +4,14 @@
  */
 import type { ReactNode } from "react";
 
+/** Styled DS listbox — see runner-select.tsx (client). Re-exported for stable import path. */
+export { RunnerSelect, type RunnerSelectOption } from "@/components/runner-select";
+
 const ERROR =
   "rounded-[var(--radius-lg)] border border-[color-mix(in_srgb,var(--status-danger)_35%,transparent)] bg-[color-mix(in_srgb,var(--status-danger)_8%,transparent)] p-3 text-sm text-[var(--status-danger)]";
 
 const OUTPUT =
   "overflow-x-auto rounded-[var(--radius-lg)] border border-[var(--neutral-6)] bg-[var(--neutral-1)] p-3 font-mono text-sm";
-
-const SELECT =
-  "h-10 rounded-[var(--radius-md)] border border-[var(--neutral-7)] bg-[var(--neutral-1)] px-3 text-sm text-[var(--neutral-12)] outline-none focus:border-[hsl(var(--ring))]";
 
 const NOTE = "text-xs text-[var(--neutral-10)]";
 
@@ -28,42 +28,6 @@ export function RunnerOutput({ children, className }: { children: ReactNode; cla
 export function RunnerNote({ children }: { children: ReactNode }) {
   if (!children) return null;
   return <p className={NOTE}>{children}</p>;
-}
-
-/** Native select with DS-aligned chrome (empty-value / simple cases). */
-export function RunnerSelect({
-  label,
-  id,
-  value,
-  onChange,
-  children,
-  className,
-}: {
-  label?: string;
-  id?: string;
-  value: string;
-  onChange: (value: string) => void;
-  children: ReactNode;
-  className?: string;
-}) {
-  const select = (
-    <select
-      data-allow-native
-      id={id}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      className={[SELECT, className].filter(Boolean).join(" ")}
-    >
-      {children}
-    </select>
-  );
-  if (!label) return select;
-  return (
-    <label htmlFor={id} className="flex flex-col gap-1.5 text-sm text-[var(--neutral-11)]">
-      <span className="text-xs font-medium">{label}</span>
-      {select}
-    </label>
-  );
 }
 
 export function RunnerPanel({

--- a/apps/router/src/components/playground-client.tsx
+++ b/apps/router/src/components/playground-client.tsx
@@ -2,7 +2,7 @@
 
 import { brand } from "@nebutra/brand/metadata";
 import { DEFAULT_PUBLIC_MODEL } from "@nebutra/router-supply";
-import { Button, Input, Textarea } from "@nebutra/ui/primitives";
+import { Button, Input, Select, Textarea } from "@nebutra/ui/primitives";
 import { useEffect, useMemo, useState } from "react";
 
 /**
@@ -67,21 +67,17 @@ export function PlaygroundClient({
     >
       <div className="flex min-h-0 flex-col space-y-3 rounded-[var(--radius-lg)] border border-[var(--neutral-6)] p-3 md:p-4">
         <div className="grid gap-2 sm:grid-cols-2">
-          <label className="block space-y-1 text-[12px]">
-            <span className="text-[11px] font-medium text-[var(--neutral-10)]">模型</span>
-            <select
-              data-allow-native
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              className="flex h-9 w-full rounded-[var(--radius-md)] border border-[var(--neutral-7)] bg-[var(--neutral-1)] px-2 font-mono text-[12px]"
-            >
-              {options.map((m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))}
-            </select>
-          </label>
+          <Select
+            label="模型"
+            id="router-model"
+            size="small"
+            className="font-mono text-[12px]"
+            value={model}
+            onValueChange={(v) => {
+              if (v) setModel(v);
+            }}
+            options={options.map((m) => ({ value: m, label: m }))}
+          />
           <Input
             label="API Key（可选）"
             id="router-api-key"

--- a/apps/tsekaluk-dev/src/components/guestbook/endorsement-dialog.tsx
+++ b/apps/tsekaluk-dev/src/components/guestbook/endorsement-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Check, Image, LoaderCircle, Message } from "@nebutra/icons";
+import { Select } from "@nebutra/ui/primitives";
 import { useEffect, useId, useRef, useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -247,20 +248,17 @@ export function EndorsementDialog({ onSubmitted }: EndorsementDialogProps) {
                 </div>
                 <div className="flex-1 space-y-1.5">
                   <Label htmlFor={`${id}-relationship`}>Relationship</Label>
-                  <select
-                    data-allow-native
+                  <Select
                     id={`${id}-relationship`}
-                    value={relationship}
-                    onChange={(e) => setRelationship(e.target.value)}
-                    className="flex h-9 w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 text-sm text-gray-900 dark:text-white shadow-sm focus-visible:border-gray-400 dark:focus-visible:border-gray-500 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-gray-200/50 dark:focus-visible:ring-gray-700/50"
-                  >
-                    <option value="">Select...</option>
-                    {RELATIONSHIPS.map((r) => (
-                      <option key={r.value} value={r.value}>
-                        {r.label} / {r.labelZh}
-                      </option>
-                    ))}
-                  </select>
+                    size="small"
+                    placeholder="Select..."
+                    value={relationship || undefined}
+                    onValueChange={(v) => setRelationship(v ?? "")}
+                    options={RELATIONSHIPS.map((r) => ({
+                      value: r.value,
+                      label: `${r.label} / ${r.labelZh}`,
+                    }))}
+                  />
                 </div>
               </div>
 

--- a/apps/web/src/components/audit/audit-log-filters.tsx
+++ b/apps/web/src/components/audit/audit-log-filters.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { Input } from "@nebutra/ui/primitives";
+import { Input, Select } from "@nebutra/ui/primitives";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { useDebounceCallback } from "usehooks-ts";
+
+const ALL = "__all__";
 
 export interface AuditLogFilterValues {
   action?: string;
@@ -108,21 +110,18 @@ export function AuditLogFilters({ onChange }: AuditLogFiltersProps) {
         >
           {t("entityType")}
         </label>
-        <select
+        <Select
           id="audit-filter-entity"
           data-testid="audit-filter-entity"
-          data-allow-native
-          value={filters.entityType ?? ""}
-          onChange={(e) => setField("entityType", e.target.value || undefined)}
-          className="rounded-[var(--radius-md)] border border-border bg-background px-3 py-1.5 text-sm"
-        >
-          <option value="">{t("all")}</option>
-          {ENTITY_TYPES.map((entity) => (
-            <option key={entity} value={entity}>
-              {entity}
-            </option>
-          ))}
-        </select>
+          size="small"
+          className="min-w-[9rem]"
+          value={filters.entityType ?? ALL}
+          onValueChange={(v) => setField("entityType", !v || v === ALL ? undefined : v)}
+          options={[
+            { value: ALL, label: t("all") },
+            ...ENTITY_TYPES.map((entity) => ({ value: entity, label: entity })),
+          ]}
+        />
       </div>
 
       <div className="flex flex-col">
@@ -132,21 +131,25 @@ export function AuditLogFilters({ onChange }: AuditLogFiltersProps) {
         >
           {t("outcome")}
         </label>
-        <select
+        <Select
           id="audit-filter-outcome"
           data-testid="audit-filter-outcome"
-          data-allow-native
-          value={filters.outcome ?? ""}
-          onChange={(e) =>
-            setField("outcome", (e.target.value || undefined) as AuditLogFilterValues["outcome"])
+          size="small"
+          className="min-w-[9rem]"
+          value={filters.outcome ?? ALL}
+          onValueChange={(v) =>
+            setField(
+              "outcome",
+              !v || v === ALL ? undefined : (v as AuditLogFilterValues["outcome"]),
+            )
           }
-          className="rounded-[var(--radius-md)] border border-border bg-background px-3 py-1.5 text-sm"
-        >
-          <option value="">{t("all")}</option>
-          <option value="success">{t("outcomeSuccess")}</option>
-          <option value="failure">{t("outcomeFailure")}</option>
-          <option value="pending">{t("outcomePending")}</option>
-        </select>
+          options={[
+            { value: ALL, label: t("all") },
+            { value: "success", label: t("outcomeSuccess") },
+            { value: "failure", label: t("outcomeFailure") },
+            { value: "pending", label: t("outcomePending") },
+          ]}
+        />
       </div>
 
       <div className="flex flex-col">

--- a/apps/web/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/web/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  Select,
 } from "@nebutra/ui/primitives";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -111,20 +112,18 @@ export function CreateProviderKeyDialog({
                     Provider
                   </FormLabel>
                   <FormControl>
-                    {/* data-allow-native: native select drives a typed enum; the
-                        primitive Select adds no value here and complicates RHF. */}
-                    <select
-                      data-allow-native
-                      className="h-9 w-full rounded-[var(--radius-md)] border border-border bg-background px-3 text-sm text-foreground focus:border-[hsl(var(--ring))] focus:outline-none"
+                    <Select
+                      size="small"
                       disabled={submitting}
-                      {...field}
-                    >
-                      {PROVIDERS.map((p) => (
-                        <option key={p} value={p}>
-                          {PROVIDER_LABELS[p]}
-                        </option>
-                      ))}
-                    </select>
+                      value={field.value}
+                      onValueChange={(v) => {
+                        if (v) field.onChange(v);
+                      }}
+                      options={PROVIDERS.map((p) => ({
+                        value: p,
+                        label: PROVIDER_LABELS[p],
+                      }))}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/packages/design/ui/src/primitives/select.stories.tsx
+++ b/packages/design/ui/src/primitives/select.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Short fixed-list native select with a compatible compound listbox API for advanced grouped menus.",
+          "Default options API is a themed listbox. Pass native for OS <select> only when required. Compound Trigger/Content for grouped menus.",
       },
     },
   },

--- a/packages/design/ui/src/primitives/select.tsx
+++ b/packages/design/ui/src/primitives/select.tsx
@@ -79,9 +79,16 @@ export interface SelectOption {
   disabled?: boolean;
 }
 
-export interface NativeSelectProps
-  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "children" | "size" | "prefix"> {
-  native?: true;
+export interface OptionsSelectProps
+  extends Omit<
+    React.SelectHTMLAttributes<HTMLSelectElement>,
+    "children" | "size" | "prefix" | "onChange"
+  > {
+  /**
+   * Explicit OS-native `<select>`. Prefer the default listbox.
+   * Only use when a true native control is required (rare).
+   */
+  native?: boolean;
   variant?: SelectVariant;
   options?: readonly SelectOption[];
   label?: string;
@@ -92,13 +99,20 @@ export interface NativeSelectProps
   error?: string;
   children?: React.ReactNode;
   wrapperClassName?: string;
+  /** HTML-select-compatible change handler (value on event.target.value). */
+  onChange?: (event: { target: { value: string; name?: string } }) => void;
+  /** Listbox value change (preferred). */
+  onValueChange?: (value: string | null) => void;
 }
+
+/** @deprecated Use OptionsSelectProps — native is opt-in only. */
+export type NativeSelectProps = OptionsSelectProps & { native?: true };
 
 export type CompoundSelectProps = SelectRoot.Props<string, false> & {
   native?: false;
 };
 
-export type SelectProps = NativeSelectProps | CompoundSelectProps;
+export type SelectProps = OptionsSelectProps | CompoundSelectProps;
 
 function getNativeSelectStyle(
   size: SelectSize,
@@ -145,6 +159,34 @@ function getSelectContentStyle(style: React.CSSProperties | undefined): SelectCo
   };
 }
 
+function textOf(node: React.ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (React.isValidElement(node)) {
+    const props = node.props as { children?: React.ReactNode };
+    return textOf(props.children);
+  }
+  return "";
+}
+
+function optionsFromChildren(children: React.ReactNode): SelectOption[] {
+  const options: SelectOption[] = [];
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) return;
+    if (child.type !== "option") return;
+    const props = child.props as {
+      value?: string | number;
+      disabled?: boolean;
+      children?: React.ReactNode;
+    };
+    const value = String(props.value ?? "");
+    const label = textOf(props.children) || value;
+    options.push(props.disabled === true ? { value, label, disabled: true } : { value, label });
+  });
+  return options;
+}
+
 function hasNativeOptionChildren(children: React.ReactNode) {
   let hasNativeChildren = false;
   React.Children.forEach(children, (child) => {
@@ -156,21 +198,23 @@ function hasNativeOptionChildren(children: React.ReactNode) {
   return hasNativeChildren;
 }
 
-function shouldRenderNativeSelect(props: SelectProps) {
-  if (props.native === true) return true;
-  if ("options" in props || "label" in props || "placeholder" in props || "error" in props) {
+/** Convenience surface (options / label / HTML onChange) — not compound Trigger children. */
+function isOptionsSelectApi(props: SelectProps): props is OptionsSelectProps {
+  if (props.native === true) return false;
+  if ("options" in props && props.options !== undefined) return true;
+  if ("label" in props && props.label !== undefined) return true;
+  if ("placeholder" in props && props.placeholder !== undefined) return true;
+  if ("error" in props && props.error !== undefined) return true;
+  if ("prefix" in props && props.prefix !== undefined) return true;
+  if ("suffix" in props && props.suffix !== undefined) return true;
+  if ("onChange" in props && typeof (props as OptionsSelectProps).onChange === "function") {
     return true;
   }
-  if ("prefix" in props || "suffix" in props || "size" in props || "onChange" in props) {
-    return true;
-  }
-  if ("children" in props && hasNativeOptionChildren(props.children)) {
-    return true;
-  }
-
+  if ("children" in props && hasNativeOptionChildren(props.children)) return true;
   return false;
 }
 
+/** OS-native path — opt-in only via native={true}. */
 function NativeSelect({
   id,
   variant = "default",
@@ -188,9 +232,10 @@ function NativeSelect({
   style,
   value,
   defaultValue,
+  onChange,
   "aria-describedby": ariaDescribedBy,
   ...props
-}: NativeSelectProps) {
+}: OptionsSelectProps) {
   const generatedId = React.useId();
   const selectId = id ?? generatedId;
   const errorId = error ? `${selectId}-error` : undefined;
@@ -243,6 +288,7 @@ function NativeSelect({
               : "pr-[var(--select-padding-x)]",
             className,
           )}
+          onChange={(event) => onChange?.(event)}
           {...props}
         >
           {placeholder && (
@@ -275,9 +321,148 @@ function NativeSelect({
   );
 }
 
-function Select(props: SelectProps) {
-  if (shouldRenderNativeSelect(props)) {
-    return <NativeSelect {...(props as NativeSelectProps)} />;
+/**
+ * Default convenience Select: DS listbox (styled popup), not OS chrome.
+ * Accepts options / label / placeholder / HTML-compatible onChange.
+ */
+function OptionsListboxSelect({
+  id,
+  variant = "default",
+  options: optionsProp,
+  label,
+  placeholder,
+  size = "medium",
+  prefix,
+  suffix,
+  disabled = false,
+  error,
+  className,
+  wrapperClassName,
+  children,
+  style,
+  value,
+  defaultValue,
+  name,
+  onChange,
+  onValueChange,
+  "aria-describedby": ariaDescribedBy,
+  "data-testid": dataTestId,
+}: OptionsSelectProps & { "data-testid"?: string }) {
+  const generatedId = React.useId();
+  const selectId = id ?? generatedId;
+  const errorId = error ? `${selectId}-error` : undefined;
+  const describedBy = [ariaDescribedBy, errorId].filter(Boolean).join(" ") || undefined;
+  const labelId = label ? `${selectId}-label` : undefined;
+
+  const options = React.useMemo(() => {
+    const fromProp = optionsProp?.map((o) => ({
+      value: String(o.value),
+      label: o.label,
+      ...(o.disabled === true ? { disabled: true as const } : {}),
+    }));
+    if (fromProp?.length) return fromProp;
+    return optionsFromChildren(children);
+  }, [optionsProp, children]);
+
+  const items = React.useMemo(
+    () => Object.fromEntries(options.map((o) => [o.value, o.label])),
+    [options],
+  );
+
+  const isControlled = value !== undefined;
+  const [uncontrolled, setUncontrolled] = React.useState(() =>
+    defaultValue !== undefined ? String(defaultValue) : "",
+  );
+  const current = isControlled ? String(value ?? "") : uncontrolled;
+  const selectedLabel = (current && items[current]) || current || "";
+
+  const handleValueChange = (next: string | null) => {
+    const resolved = next ?? "";
+    if (!isControlled) setUncontrolled(resolved);
+    onValueChange?.(next);
+    onChange?.({ target: { value: resolved, name } });
+  };
+
+  const fieldStyle = getNativeSelectStyle(size, style);
+
+  return (
+    <div className={cn("grid gap-[var(--select-field-gap)]", wrapperClassName)} style={fieldStyle}>
+      {label && (
+        <Label
+          id={labelId}
+          htmlFor={selectId}
+          className="text-[length:var(--select-label-size)] font-medium text-foreground capitalize"
+        >
+          {label}
+        </Label>
+      )}
+      {name ? <input type="hidden" name={name} value={current} data-allow-native /> : null}
+      <div
+        className={cn(
+          "relative flex items-center text-muted-foreground",
+          !disabled && "hover:text-foreground",
+        )}
+      >
+        {prefix && (
+          <span className="pointer-events-none absolute left-[var(--select-icon-inset)] z-10 inline-flex size-[var(--select-icon-box-size)] items-center justify-center">
+            {prefix}
+          </span>
+        )}
+        <BaseSelect.Root
+          value={current || null}
+          onValueChange={handleValueChange}
+          disabled={disabled}
+          items={items}
+        >
+          <SelectTrigger
+            id={selectId}
+            size={size}
+            data-testid={dataTestId}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={describedBy}
+            aria-labelledby={labelId}
+            className={cn(
+              variant === "ghost" && "border-transparent bg-transparent shadow-none",
+              prefix && "pl-[calc(var(--select-icon-inset)+var(--select-icon-box-size))]",
+              className,
+            )}
+          >
+            <SelectValue placeholder={placeholder ?? "Select…"}>
+              {() => selectedLabel || placeholder || "Select…"}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value} disabled={option.disabled}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </BaseSelect.Root>
+        {suffix && (
+          <span className="pointer-events-none absolute right-[var(--select-icon-inset)] z-10 inline-flex size-[var(--select-icon-box-size)] items-center justify-center">
+            {suffix}
+          </span>
+        )}
+      </div>
+      {error && (
+        <span id={errorId} className="mt-[var(--select-message-gap)]">
+          <ErrorMessage size={size === "large" ? "medium" : "small"}>{error}</ErrorMessage>
+        </span>
+      )}
+    </div>
+  );
+}
+
+function Select(props: OptionsSelectProps): React.JSX.Element;
+function Select(props: CompoundSelectProps): React.JSX.Element;
+function Select(props: SelectProps): React.JSX.Element {
+  if (props.native === true) {
+    return <NativeSelect {...(props as OptionsSelectProps)} />;
+  }
+
+  if (isOptionsSelectApi(props)) {
+    return <OptionsListboxSelect {...(props as OptionsSelectProps)} />;
   }
 
   const { native: _native, ...rootProps } = props as CompoundSelectProps;
@@ -348,8 +533,6 @@ const SelectTrigger = ({
 );
 SelectTrigger.displayName = "SelectTrigger";
 
-// Mocking ScrollUp/Down since Base UI usually handles scrolling natively with CSS or uses different abstractions.
-// Returning null prevents API breakages for downstream consumers.
 const SelectScrollUpButton = ({
   ref: _ref,
 }: React.ComponentPropsWithoutRef<"div"> & { ref?: React.Ref<HTMLDivElement> | undefined }) => null;

--- a/scripts/lint-no-raw-inputs.mjs
+++ b/scripts/lint-no-raw-inputs.mjs
@@ -1,20 +1,24 @@
 #!/usr/bin/env node
 
 // CI guard: fail when raw <input>/<textarea>/<select> appear in app code without
-// `data-allow-native` opt-out.
+// a sanctioned opt-out.
 //
 // 2026 governance rule (CLAUDE.md / MEMORY.md):
 //   • All form controls MUST use @nebutra/ui/primitives (<Input>, <Textarea>,
 //     <Select>, <Checkbox>, <RadioGroup>).
 //   • Native elements are allowed only with `data-allow-native` attribute,
 //     reserved for: type="hidden" form data, type="file" with custom button
-//     trigger, special filter selects requiring empty-string semantics, etc.
+//     trigger, etc.
+//   • <select> is NEVER allowed in product apps — even with data-allow-native.
+//     OS chrome cannot be themed; use compound / options Select (listbox).
+//     Escape hatch only with same-line or previous-line: // allow-os-select: <reason>
 //
 // Whitelisted areas (exempt from check):
 //   • storybook/src/stories/**           — demos of native HTML behavior
 //   • design-docs/src/components/previews/**, sailor-docs/src/components/previews/**
 //                                        — registry preview demos
 //   • apps/tsekaluk-dev/src/components/ui/** — independent app's own primitives
+//   • packages/design/ui/src/primitives/** — DS wrappers (not under apps/)
 //   • test files
 //
 // Run: node scripts/lint-no-raw-inputs.mjs
@@ -49,27 +53,53 @@ const violations = [];
 const ATTR_BODY_RE = /<(input|textarea|select)\b((?:[^<>{}]|\{(?:[^{}]|\{[^{}]*\})*\})*?)\s*\/?>/gs;
 
 // Strip JS line + block comments so commented-out tags don't false-positive.
-// Replace each comment with same-length whitespace to preserve byte offsets / line numbers.
+// Keep a parallel map of allow-os-select reasons on their source lines.
 const stripComments = (src) => {
   return src
     .replace(/\/\/[^\n]*/g, (m) => " ".repeat(m.length))
     .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "));
 };
 
+/** Lines (1-indexed) that contain `// allow-os-select:` before strip. */
+function allowOsSelectLines(raw) {
+  const lines = new Set();
+  raw.split("\n").forEach((line, i) => {
+    if (/\/\/\s*allow-os-select\s*:/.test(line)) lines.add(i + 1);
+  });
+  return lines;
+}
+
 for (const file of files) {
   const raw = readFileSync(file, "utf-8");
+  const allowSelect = allowOsSelectLines(raw);
   const src = stripComments(raw);
   let lineCounter = 1;
   let cursor = 0;
   for (const match of src.matchAll(ATTR_BODY_RE)) {
+    const tag = match[1];
     const attrs = match[2];
-    if (/\bdata-allow-native\b/.test(attrs)) continue;
     // Compute line number
     while (cursor < match.index) {
       if (src[cursor] === "\n") lineCounter += 1;
       cursor += 1;
     }
-    violations.push({ file, line: lineCounter, tag: match[1] });
+
+    if (tag === "select") {
+      // Product <select> banned unless // allow-os-select: on same or previous line.
+      const ok = allowSelect.has(lineCounter) || allowSelect.has(lineCounter - 1);
+      if (!ok) {
+        violations.push({
+          file,
+          line: lineCounter,
+          tag,
+          reason: "select-banned",
+        });
+      }
+      continue;
+    }
+
+    if (/\bdata-allow-native\b/.test(attrs)) continue;
+    violations.push({ file, line: lineCounter, tag, reason: "raw" });
   }
 }
 
@@ -80,11 +110,13 @@ if (violations.length === 0) {
   process.exit(0);
 }
 
-process.stderr.write(
-  `\n❌ ${violations.length} raw form-control violation(s) — must use @nebutra/ui/primitives or add data-allow-native:\n\n`,
-);
+const selectBanned = violations.filter((v) => v.reason === "select-banned");
+const raw = violations.filter((v) => v.reason === "raw");
+
+process.stderr.write(`\n❌ ${violations.length} form-control violation(s):\n\n`);
 for (const v of violations) {
-  process.stderr.write(`  ${v.file}:${v.line}  <${v.tag}>\n`);
+  const note = v.reason === "select-banned" ? "  [native <select> banned]" : "";
+  process.stderr.write(`  ${v.file}:${v.line}  <${v.tag}>${note}\n`);
 }
 process.stderr.write(`\nFix:\n`);
 process.stderr.write(`  • Visible text inputs → import { Input } from "@nebutra/ui/primitives"\n`);
@@ -95,6 +127,13 @@ process.stderr.write(
   `  • Visible selects     → import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@nebutra/ui/primitives"\n`,
 );
 process.stderr.write(
-  `  • Native opt-out      → add \`data-allow-native\` attribute (for type="hidden", type="file" with custom trigger, etc.)\n\n`,
+  `    (options={…} API is a styled listbox by default; do NOT use raw <select>)\n`,
 );
+process.stderr.write(`  • Native input opt-out → data-allow-native (hidden/file only)\n`);
+if (selectBanned.length) {
+  process.stderr.write(
+    `  • OS <select> escape  → // allow-os-select: <reason> on the line above (rare)\n`,
+  );
+}
+process.stderr.write("\n");
 process.exit(1);


### PR DESCRIPTION
## Summary
- `@nebutra/ui` Select `options` API is a **themed listbox** (no OS white popup); `native={true}` only for true native.
- Product raw `<select>` cleared: forge RunnerSelect, web audit filters, provider-key dialog, router playground, tsekaluk-dev endorsement.
- `lint-no-raw-inputs` **bans product `<select>`** (escape: `// allow-os-select: reason`).
- CLAUDE: stop recommending empty-string native select.

## Test plan
- [x] `node scripts/lint-no-raw-inputs.mjs`
- [x] forge/web/router tsc
- [ ] Manual: forge json-csv mode, web audit filters, router playground model picker — open dropdown is DS surface not OS chrome