### PR TITLE
feat(pebble): brand front + DNS + docs + feedback normalize

### DIFF
--- a/.github/workflows/deploy-pebble-vercel.yml
+++ b/.github/workflows/deploy-pebble-vercel.yml
@@ -1,0 +1,126 @@
+name: Deploy Pebble brand front (Vercel)
+
+# Creates/updates the nebutra-pebble Vercel project (root apps/pebble), attaches
+# pebble.nebutra.com, then deploys production. Complements point-pebble-dns.yml
+# which owns the Cloudflare CNAME.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/pebble/**"
+      - ".github/workflows/deploy-pebble-vercel.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-pebble-vercel
+  cancel-in-progress: true
+
+jobs:
+  vercel:
+    name: Deploy pebble brand front
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Ensure project, domain, and deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID || vars.VERCEL_ORG_ID }}
+          EXPECTED_ROOT: apps/pebble
+          PROJECT_NAME: nebutra-pebble
+          DOMAIN: pebble.nebutra.com
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_TOKEN:-}" ]; then
+            echo "::error::VERCEL_TOKEN is not set"; exit 1
+          fi
+          if [ -z "${VERCEL_ORG_ID:-}" ]; then
+            echo "::error::VERCEL_ORG_ID is not set"; exit 1
+          fi
+
+          api() {
+            curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" "$@"
+          }
+
+          api "https://api.vercel.com/v9/projects?teamId=${VERCEL_ORG_ID}&limit=100" > projects.json
+          python3 - <<'PY' > resolved.env
+          import json
+          data = json.load(open("projects.json"))
+          names = {p["name"]: p for p in data.get("projects", [])}
+          for candidate in ("nebutra-pebble", "pebble", "pebble-site"):
+              if candidate in names:
+                  p = names[candidate]
+                  print("PROJECT_ID=" + p["id"])
+                  print("CURRENT_ROOT=" + (p.get("rootDirectory") or "(none)"))
+                  break
+          else:
+              print("PROJECT_ID=")
+              print("CURRENT_ROOT=(missing)")
+          PY
+          cat resolved.env
+          set -a; . ./resolved.env; set +a
+
+          if [ -z "${PROJECT_ID:-}" ]; then
+            echo "Creating Vercel project ${PROJECT_NAME}"
+            create=$(api -X POST "https://api.vercel.com/v10/projects?teamId=${VERCEL_ORG_ID}" \
+              -d "{\"name\":\"${PROJECT_NAME}\",\"framework\":\"nextjs\",\"rootDirectory\":\"${EXPECTED_ROOT}\"}")
+            echo "$create" | python3 -m json.tool | head -40
+            PROJECT_ID=$(echo "$create" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))')
+            [ -n "$PROJECT_ID" ] || { echo "::error::failed to create project"; exit 1; }
+            CURRENT_ROOT="$EXPECTED_ROOT"
+          fi
+
+          if [ "$CURRENT_ROOT" != "$EXPECTED_ROOT" ] && [ "$CURRENT_ROOT" != "(missing)" ]; then
+            echo "::warning::Root Directory was '$CURRENT_ROOT', correcting to '$EXPECTED_ROOT'"
+            api -X PATCH "https://api.vercel.com/v9/projects/${PROJECT_ID}?teamId=${VERCEL_ORG_ID}" \
+              -d "{\"rootDirectory\":\"${EXPECTED_ROOT}\"}" > /dev/null
+          fi
+
+          echo "Attaching domain ${DOMAIN} (idempotent)"
+          api -X POST "https://api.vercel.com/v10/projects/${PROJECT_ID}/domains?teamId=${VERCEL_ORG_ID}" \
+            -d "{\"name\":\"${DOMAIN}\"}" > domain.json || true
+          python3 -c 'import json; d=json.load(open("domain.json")); print("domain", d.get("name") or d.get("error",{}).get("code"), d.get("verified", d.get("error")))' || true
+
+          npm i -g vercel@56.5.0
+          mkdir -p .vercel
+          printf '{"projectId":"%s","orgId":"%s"}\n' "$PROJECT_ID" "$VERCEL_ORG_ID" > .vercel/project.json
+          export VERCEL_PROJECT_ID="$PROJECT_ID"
+
+          set +e
+          out=$(vercel deploy --prod --yes --token="$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID" 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+          if [ "$code" -ne 0 ]; then
+            if echo "$out" | grep -qiE 'api-deployments-free-per-day|Resource is limited|try again in 24 hours|Upload aborted'; then
+              echo "::warning::Vercel deploy deferred (quota or transient upload failure)"
+              exit 0
+            fi
+            exit "$code"
+          fi
+
+      - name: Smoke pebble.nebutra.com
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5 6 7 8; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "https://pebble.nebutra.com/?ci=${GITHUB_SHA}" || echo 000)
+            feed=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "https://pebble.nebutra.com/whats-new/changelog.json" || echo 000)
+            docs=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 -L --max-redirs 0 "https://pebble.nebutra.com/docs/mobile" || echo 000)
+            echo "attempt $i home=$code changelog=$feed docs_redirect=$docs"
+            if [ "$code" = "200" ] && [ "$feed" = "200" ]; then
+              # docs should be a permanent redirect (3xx), not a rewrite
+              case "$docs" in
+                301|308|302|307) exit 0 ;;
+                000) exit 0 ;; # allow if curl -L --max-redirs 0 quirks
+              esac
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "pebble brand front not healthy after retries"
+          exit 1

--- a/.github/workflows/point-pebble-dns.yml
+++ b/.github/workflows/point-pebble-dns.yml
@@ -1,0 +1,35 @@
+name: Point pebble DNS to Vercel
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Upsert pebble.nebutra.com → cname.vercel-dns.com
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ vars.CF_ZONE_ID || '' }}
+        run: bash infra/ops/scripts/point-pebble-dns-vercel.sh
+      - name: Smoke pebble host (best-effort until Vercel domain attached)
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 https://pebble.nebutra.com/ || echo 000)
+            echo "attempt $i pebble=$code"
+            # 200 after deploy; 404/502 still prove DNS+TLS is live
+            if [ "$code" != "000" ] && [ "$code" != "000000" ]; then
+              case "$code" in
+                200|301|302|307|308|404|502|503) exit 0 ;;
+              esac
+            fi
+            sleep 15
+          done
+          echo "pebble still unreachable after retries (DNS prop?)"
+          exit 1

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -43,6 +43,18 @@
       ]
     }
   ],
+  "redirects": [
+    {
+      "source": "/pebble",
+      "destination": "https://pebble.nebutra.com",
+      "permanent": true
+    },
+    {
+      "source": "/pebble/:path*",
+      "destination": "https://pebble.nebutra.com/:path*",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/api/:path*",

--- a/apps/pebble/README.md
+++ b/apps/pebble/README.md
@@ -1,0 +1,28 @@
+# `@nebutra/pebble-site`
+
+Brand front for **https://pebble.nebutra.com**.
+
+## Role
+
+| Surface | Behavior |
+|---------|----------|
+| `/`, `/download` | Marketing / download (static) |
+| `/whats-new/*.json`, `/media/*` | Machine-consumed static feeds — **no redirects** |
+| `/docs/*` | 301 → `https://docs.nebutra.com/pebble/*` |
+| `POST /v1/feedback`, `/diagnostics/*` | Vercel rewrite → `api.nebutra.com/pebble/*` (legacy clients only) |
+
+This app has **no database and no first-party API**. Canonical feedback and diagnostics live on the shared gateway under `/pebble`.
+
+Topology: Sailor `docs/DOMAINS.md` · Pebble `docs/reference/infra-index.md`.
+
+## Local
+
+```bash
+pnpm --filter @nebutra/pebble-site dev
+```
+
+## Deploy
+
+- DNS: `CNAME pebble → cname.vercel-dns.com` (proxied) via `point-pebble-dns.yml`
+- Vercel project: `nebutra-pebble` · root `apps/pebble` · domain `pebble.nebutra.com`
+- Workflow: `.github/workflows/deploy-pebble-vercel.yml`

--- a/apps/pebble/next-env.d.ts
+++ b/apps/pebble/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited — see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/pebble/next.config.ts
+++ b/apps/pebble/next.config.ts
@@ -1,0 +1,17 @@
+import type { NextConfig } from "next";
+
+/**
+ * Pebble brand front — static marketing + download + machine-consumed feeds.
+ *
+ * Product API lives on api.nebutra.com/pebble/* (ECS). This origin only
+ * reverse-proxies legacy POST paths for one release cycle of desktop clients
+ * that still target pebble.nebutra.com/v1/feedback (see vercel.json rewrites).
+ *
+ * Docs are canonical on docs.nebutra.com/pebble/*; /docs/* permanently redirects.
+ */
+const nextConfig: NextConfig = {
+  poweredByHeader: false,
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/apps/pebble/package.json
+++ b/apps/pebble/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@nebutra/pebble-site",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pebble brand front — landing, download, static feeds; no product API",
+  "scripts": {
+    "dev": "next dev --port 3017",
+    "build": "next build",
+    "start": "next start --port 3017",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "FSL-1.1-ALv2"
+}

--- a/apps/pebble/public/whats-new/changelog.json
+++ b/apps/pebble/public/whats-new/changelog.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-30T00:00:00.000Z",
+  "entries": [
+    {
+      "version": "0.0.0",
+      "tag": "placeholder",
+      "title": "Changelog feed is live",
+      "summary": "This feed is served from the Pebble brand front. Release notes continue to originate on GitHub Releases; desktop clients read this JSON without redirects.",
+      "releaseNotesUrl": "https://github.com/Nebutra/pebble/releases",
+      "publishedAt": "2026-07-30T00:00:00.000Z"
+    }
+  ]
+}

--- a/apps/pebble/public/whats-new/nudge.json
+++ b/apps/pebble/public/whats-new/nudge.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-30T00:00:00.000Z",
+  "nudge": null
+}

--- a/apps/pebble/src/app/download/page.tsx
+++ b/apps/pebble/src/app/download/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { DOWNLOADS, GITHUB_RELEASES } from "@/lib/releases";
+
+export const metadata: Metadata = {
+  title: "Download",
+  description: "Download Pebble for macOS, Windows, and Linux.",
+};
+
+const rows = [
+  { label: "macOS Universal", href: DOWNLOADS.macosUniversal, badge: ".dmg" },
+  { label: "Windows x64", href: DOWNLOADS.windowsX64, badge: ".exe" },
+  { label: "Linux x64 AppImage", href: DOWNLOADS.linuxX64AppImage, badge: "AppImage" },
+  { label: "Linux arm64 AppImage", href: DOWNLOADS.linuxArm64AppImage, badge: "AppImage" },
+] as const;
+
+export default function DownloadPage() {
+  return (
+    <main>
+      <section className="hero">
+        <h1>Download Pebble</h1>
+        <p className="lead">
+          Installers ship from GitHub Releases — the product origin never becomes the artifact
+          authority. Homebrew and AUR packages are available from the README.
+        </p>
+        <div className="actions">
+          <a className="btn btn-primary" href={GITHUB_RELEASES}>
+            Latest release on GitHub
+          </a>
+        </div>
+      </section>
+
+      <ul className="list">
+        {rows.map((row) => (
+          <li key={row.label}>
+            <a href={row.href}>
+              <span>{row.label}</span>
+              <span className="badge">{row.badge}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+
+      <p className="muted" style={{ marginTop: "1.5rem" }}>
+        Prefer package managers? <code>brew install --cask nebutra/pebble/pebble</code> or see the
+        repository README for AUR and mobile builds.
+      </p>
+    </main>
+  );
+}

--- a/apps/pebble/src/app/globals.css
+++ b/apps/pebble/src/app/globals.css
@@ -1,0 +1,209 @@
+:root {
+  color-scheme: dark light;
+  --bg: #0b0d12;
+  --bg-elevated: #12151c;
+  --fg: #f4f1eb;
+  --fg-muted: #a8a29a;
+  --accent: #0bf1c3;
+  --accent-2: #5c7cfa;
+  --border: rgba(244, 241, 235, 0.12);
+  --radius: 14px;
+  --font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f7f4ef;
+    --bg-elevated: #ffffff;
+    --fg: #12141a;
+    --fg-muted: #5c5a56;
+    --border: rgba(18, 20, 26, 0.1);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: radial-gradient(1200px 600px at 10% -10%, rgba(11, 241, 195, 0.12), transparent),
+    radial-gradient(900px 500px at 90% 0%, rgba(92, 124, 250, 0.14), transparent), var(--bg);
+  color: var(--fg);
+  font-family: var(--font);
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  width: min(960px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2.5rem 0 4rem;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: min(960px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1.25rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.brand-mark {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.65rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08) inset;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+}
+
+.nav-links a:hover {
+  color: var(--fg);
+}
+
+.hero {
+  display: grid;
+  gap: 1.25rem;
+  padding: 2rem 0 1rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.lead {
+  margin: 0;
+  max-width: 42rem;
+  color: var(--fg-muted);
+  font-size: 1.1rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  font-weight: 600;
+  transition: transform 120ms ease, border-color 120ms ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent), color-mix(in srgb, var(--accent-2) 70%, white));
+  color: #041016;
+  border-color: transparent;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.card {
+  padding: 1.1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.card h2,
+.card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.card p {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+}
+
+.footer {
+  width: min(960px, calc(100% - 2rem));
+  margin: 3rem auto 2rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  justify-content: space-between;
+}
+
+.muted {
+  color: var(--fg-muted);
+}
+
+.list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.list a {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.95rem 1.1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+}
+
+.list a:hover {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}
+
+.badge {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+}

--- a/apps/pebble/src/app/layout.tsx
+++ b/apps/pebble/src/app/layout.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { DOCS_BASE, GITHUB_REPO, STATUS_URL } from "@/lib/releases";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://pebble.nebutra.com"),
+  title: {
+    default: "Pebble — AI Orchestrator for 100x builders",
+    template: "%s · Pebble",
+  },
+  description:
+    "Run Codex, Claude Code, OpenCode and more side-by-side — each in its own worktree, tracked in one place.",
+  openGraph: {
+    title: "Pebble",
+    description: "The AI Orchestrator for 100x builders.",
+    url: "https://pebble.nebutra.com",
+    siteName: "Pebble",
+    type: "website",
+  },
+  alternates: {
+    canonical: "https://pebble.nebutra.com",
+  },
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="nav">
+          <a className="brand" href="/">
+            <span className="brand-mark" aria-hidden />
+            Pebble
+          </a>
+          <nav className="nav-links" aria-label="Primary">
+            <a href="/download">Download</a>
+            <a href={DOCS_BASE}>Docs</a>
+            <a href={GITHUB_REPO}>GitHub</a>
+            <a href={STATUS_URL}>Status</a>
+          </nav>
+        </header>
+        {children}
+        <footer className="footer">
+          <span>© {new Date().getFullYear()} Nebutra · Pebble</span>
+          <span>
+            <a href={DOCS_BASE}>docs.nebutra.com/pebble</a>
+            {" · "}
+            <a href="https://nebutra.com">nebutra.com</a>
+          </span>
+        </footer>
+      </body>
+    </html>
+  );
+}

--- a/apps/pebble/src/app/page.tsx
+++ b/apps/pebble/src/app/page.tsx
@@ -1,0 +1,67 @@
+import { DOCS_BASE, DOWNLOADS, GITHUB_REPO } from "@/lib/releases";
+
+export default function HomePage() {
+  return (
+    <main>
+      <section className="hero">
+        <p className="muted">Nebutra product · brand front</p>
+        <h1>The AI orchestrator for 100x builders.</h1>
+        <p className="lead">
+          Run Codex, Claude Code, OpenCode, and more side-by-side — each in its own git worktree,
+          tracked in one desktop surface. Mobile companion, terminal splits, Design Mode, and native
+          GitHub/Linear workflows.
+        </p>
+        <div className="actions">
+          <a className="btn btn-primary" href="/download">
+            Download Pebble
+          </a>
+          <a className="btn" href={DOCS_BASE}>
+            Read the docs
+          </a>
+          <a className="btn" href={GITHUB_REPO}>
+            Star on GitHub
+          </a>
+        </div>
+      </section>
+
+      <section className="grid" aria-label="Highlights">
+        <article className="card">
+          <h2>Parallel worktrees</h2>
+          <p>Fan one prompt across agents in isolated checkouts, then merge the winner.</p>
+        </article>
+        <article className="card">
+          <h2>Mobile companion</h2>
+          <p>Steer agents from your phone and get notified when a run finishes.</p>
+        </article>
+        <article className="card">
+          <h2>Native integrations</h2>
+          <p>GitHub and Linear boards stay in-app so reviews never leave the flow.</p>
+        </article>
+      </section>
+
+      <section style={{ marginTop: "2.5rem" }}>
+        <h2 style={{ letterSpacing: "-0.03em" }}>Quick links</h2>
+        <ul className="list">
+          <li>
+            <a href="/download">
+              <span>Download desktop builds</span>
+              <span className="badge">macOS · Windows · Linux</span>
+            </a>
+          </li>
+          <li>
+            <a href={`${DOCS_BASE}/mobile`}>
+              <span>Mobile companion docs</span>
+              <span className="badge">iOS · Android</span>
+            </a>
+          </li>
+          <li>
+            <a href={DOWNLOADS.all}>
+              <span>All GitHub release assets</span>
+              <span className="badge">canonical artifacts</span>
+            </a>
+          </li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/apps/pebble/src/lib/releases.test.ts
+++ b/apps/pebble/src/lib/releases.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { DOCS_BASE, DOWNLOADS, GITHUB_RELEASES } from "./releases";
+
+describe("pebble brand front release links", () => {
+  it("points download artifacts at GitHub Releases, not the brand origin", () => {
+    expect(GITHUB_RELEASES).toContain("github.com/Nebutra/pebble/releases");
+    for (const url of Object.values(DOWNLOADS)) {
+      expect(url.startsWith("https://github.com/")).toBe(true);
+    }
+  });
+
+  it("keeps docs on the platform docs host under /pebble", () => {
+    expect(DOCS_BASE).toBe("https://docs.nebutra.com/pebble");
+  });
+});

--- a/apps/pebble/src/lib/releases.ts
+++ b/apps/pebble/src/lib/releases.ts
@@ -1,0 +1,14 @@
+/** GitHub Releases artifact URLs for the download surface. */
+export const GITHUB_RELEASES = "https://github.com/Nebutra/pebble/releases/latest";
+
+export const DOWNLOADS = {
+  macosUniversal: `${GITHUB_RELEASES}/download/pebble-macos-universal.dmg`,
+  windowsX64: `${GITHUB_RELEASES}/download/pebble-windows-x86_64-setup.exe`,
+  linuxX64AppImage: `${GITHUB_RELEASES}/download/pebble-linux-x86_64.AppImage`,
+  linuxArm64AppImage: `${GITHUB_RELEASES}/download/pebble-linux-aarch64.AppImage`,
+  all: GITHUB_RELEASES,
+} as const;
+
+export const DOCS_BASE = "https://docs.nebutra.com/pebble";
+export const STATUS_URL = "https://status.nebutra.com";
+export const GITHUB_REPO = "https://github.com/Nebutra/pebble";

--- a/apps/pebble/tsconfig.json
+++ b/apps/pebble/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/pebble/vercel.json
+++ b/apps/pebble/vercel.json
@@ -1,0 +1,63 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "pnpm turbo build --filter=@nebutra/pebble-site",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-build.sh apps/pebble",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "outputDirectory": ".next",
+  "regions": ["iad1"],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    },
+    {
+      "source": "/whats-new/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=60, s-maxage=300, stale-while-revalidate=600"
+        },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    },
+    {
+      "source": "/media/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/docs",
+      "destination": "https://docs.nebutra.com/pebble",
+      "permanent": true
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://docs.nebutra.com/pebble/:path*",
+      "permanent": true
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/v1/feedback",
+      "destination": "https://api.nebutra.com/pebble/v1/feedback"
+    },
+    {
+      "source": "/diagnostics/:path*",
+      "destination": "https://api.nebutra.com/pebble/diagnostics/:path*"
+    }
+  ]
+}

--- a/apps/pebble/vitest.config.ts
+++ b/apps/pebble/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/apps/sailor-docs/content/docs/en/pebble/agents/supported.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/agents/supported.mdx
@@ -1,0 +1,8 @@
+---
+title: Supported agents
+description: CLI agents Pebble can orchestrate
+---
+
+# Supported agents
+
+Pebble orchestrates local coding agents (Codex, Claude Code, OpenCode, Cursor CLI, and many more). The live matrix ships with the app and is expanded regularly — see the repository README for the current list.

--- a/apps/sailor-docs/content/docs/en/pebble/agents/usage-tracking.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/agents/usage-tracking.mdx
@@ -1,0 +1,8 @@
+---
+title: Account switcher & usage
+description: Claude and Codex usage meters and account hot-swap
+---
+
+# Account switcher & usage tracking
+
+See Claude and Codex usage and rate-limit resets, and hot-swap accounts without re-logging in for every provider that exposes a local session.

--- a/apps/sailor-docs/content/docs/en/pebble/browser/design-mode.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/browser/design-mode.mdx
@@ -1,0 +1,10 @@
+---
+title: Design Mode
+description: Click UI elements in a Chromium window into the agent prompt
+---
+
+# Design Mode
+
+Click any UI element in a real Chromium window to send its HTML, CSS, and a cropped screenshot straight into your agent's prompt.
+
+Design Mode is for visual product work — annotate what you see, not a static mock.

--- a/apps/sailor-docs/content/docs/en/pebble/cli/computer-use.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/cli/computer-use.mdx
@@ -1,0 +1,8 @@
+---
+title: Computer Use
+description: Let agents operate desktop apps and visible UI
+---
+
+# Computer Use
+
+Computer Use lets agents operate desktop apps and visible UI when a workflow needs real interaction beyond the terminal and editor.

--- a/apps/sailor-docs/content/docs/en/pebble/cli/overview.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/cli/overview.mdx
@@ -1,0 +1,12 @@
+---
+title: CLI overview
+description: Script Pebble from the command line
+---
+
+# CLI overview
+
+The `pebble` CLI scripts workspaces, agents, and automation from the terminal. Install paths and packaging follow the desktop release channel (Homebrew cask, AppImage, etc.).
+
+```bash
+pebble --help
+```

--- a/apps/sailor-docs/content/docs/en/pebble/editing/file-explorer.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/editing/file-explorer.mdx
@@ -1,0 +1,8 @@
+---
+title: File explorer
+description: Drag files and images into agent prompts
+---
+
+# File explorer
+
+Browse the workspace tree and drag files or images straight into an agent prompt. Previews cover Markdown, images, PDFs, and common repo docs.

--- a/apps/sailor-docs/content/docs/en/pebble/editing/markdown.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/editing/markdown.mdx
@@ -1,0 +1,8 @@
+---
+title: Rich previews
+description: Preview Markdown, images, PDFs, and repo docs
+---
+
+# Rich repo previews
+
+Preview Markdown, images, PDFs, and repo docs in the workspace without opening an external app.

--- a/apps/sailor-docs/content/docs/en/pebble/index.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Pebble
+description: AI orchestrator desktop product — docs namespace on the Nebutra platform
+---
+
+# Pebble
+
+Pebble is Nebutra's AI orchestrator for builders: run Codex, Claude Code, OpenCode, and more side-by-side in isolated git worktrees from one desktop surface.
+
+## Where things live
+
+| Surface | Host |
+|---------|------|
+| Product / download | [pebble.nebutra.com](https://pebble.nebutra.com) |
+| **These docs** | [docs.nebutra.com/pebble](https://docs.nebutra.com/pebble) |
+| Feedback & diagnostics API | `https://api.nebutra.com/pebble/*` |
+| Status | [status.nebutra.com](https://status.nebutra.com) |
+| Source & releases | [github.com/Nebutra/pebble](https://github.com/Nebutra/pebble) |
+
+`pebble.nebutra.com` is a **brand front only** (landing, download, static update feeds). It has no product database. Machine endpoints use the shared platform API under the `/pebble` prefix so other Nebutra products can coexist on `api.nebutra.com`.
+
+## Start here
+
+- [Download](https://pebble.nebutra.com/download)
+- [Mobile companion](/pebble/mobile)
+- [Parallel worktrees](/pebble/model/worktrees)
+- [Terminal](/pebble/terminal)
+- [Privacy & telemetry](/pebble/telemetry)
+
+## Platform topology
+
+See the Pebble repository's [`docs/reference/infra-index.md`](https://github.com/Nebutra/pebble/blob/main/docs/reference/infra-index.md) for the frozen host map (Cloudflare → Vercel brand front + ECS API origin).

--- a/apps/sailor-docs/content/docs/en/pebble/mobile.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/mobile.mdx
@@ -1,0 +1,17 @@
+---
+title: Mobile companion
+description: Monitor and steer Pebble agents from iOS and Android
+---
+
+# Mobile companion
+
+Monitor and steer agents from your phone — get notified when a run finishes and send follow-ups from anywhere.
+
+- **iOS:** [App Store](https://apps.apple.com/us/app/pebble-ide/id6766130217) · [TestFlight](https://testflight.apple.com/join/YjeGMQBA)
+- **Android:** APK builds ship on [GitHub Releases](https://github.com/Nebutra/pebble/releases)
+
+Pairing uses the local Pebble runtime on your machine (`pebble serve`, default port **6768** on `127.0.0.1`). Public mobile traffic never exposes that port; reach remote desktops over SSH tunnels when needed.
+
+```bash
+ssh -L 6768:127.0.0.1:6768 user@host
+```

--- a/apps/sailor-docs/content/docs/en/pebble/model/quick-open.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/model/quick-open.mdx
@@ -1,0 +1,8 @@
+---
+title: Quick open
+description: Search worktrees, files, agents, and commands
+---
+
+# Quick open
+
+Search across worktrees, files, agents, commands, and repo context without leaving your flow.

--- a/apps/sailor-docs/content/docs/en/pebble/model/worktrees.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/model/worktrees.mdx
@@ -1,0 +1,10 @@
+---
+title: Parallel worktrees
+description: Fan one prompt across agents in isolated git worktrees
+---
+
+# Parallel worktrees
+
+Fan one prompt across multiple agents, each in its own isolated git worktree — compare results and merge the winner.
+
+Worktrees keep experiments off your primary checkout so you can run several agents without stomping each other. Pebble tracks each worktree as a first-class workspace card in the desktop UI.

--- a/apps/sailor-docs/content/docs/en/pebble/notifications.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/notifications.mdx
@@ -1,0 +1,8 @@
+---
+title: Notifications
+description: Agent finish and unread-state notifications
+---
+
+# Notifications and unread state
+
+Know when an agent finishes or needs attention, then mark threads unread to come back later. Mobile push delivery follows the companion app platform (APNs / FCM) when enabled.

--- a/apps/sailor-docs/content/docs/en/pebble/privacy.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/privacy.mdx
@@ -1,0 +1,10 @@
+---
+title: Privacy
+description: Privacy summary for Pebble product surfaces
+---
+
+# Privacy
+
+Pebble does not require a Nebutra account for desktop use. Support intake (feedback / diagnostics) is unauthenticated and bounded by rate limits, body caps, and retention — not by identity.
+
+Full detail: [Privacy & telemetry](/pebble/telemetry).

--- a/apps/sailor-docs/content/docs/en/pebble/review/annotate-ai-diff.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/review/annotate-ai-diff.mdx
@@ -1,0 +1,8 @@
+---
+title: Annotate AI diffs
+description: Review and annotate agent-generated diffs in-app
+---
+
+# Annotate AI diffs
+
+Review agent-generated diffs with inline annotations without leaving the desktop surface. Export or push comments through your usual GitHub review flow when ready.

--- a/apps/sailor-docs/content/docs/en/pebble/review/linear.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/review/linear.mdx
@@ -1,0 +1,10 @@
+---
+title: GitHub & Linear
+description: Browse PRs, issues, and boards without leaving Pebble
+---
+
+# GitHub & Linear
+
+Browse PRs, issues, and project boards in-app — open a worktree from any task and review without a context switch.
+
+Native integrations use your local `gh` CLI / Linear credentials; Pebble does not re-host your issue tracker.

--- a/apps/sailor-docs/content/docs/en/pebble/ssh.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/ssh.mdx
@@ -1,0 +1,20 @@
+---
+title: SSH worktrees
+description: Remote worktrees over SSH
+---
+
+# SSH worktrees
+
+Run agents against remote machines over SSH without exposing Pebble's local control ports to the public internet.
+
+Local runtime ports stay on `127.0.0.1`:
+
+| Service | Port |
+|---------|------|
+| `pebble-runtime` | 17777 |
+| `pebble serve` / pairing | 6768 |
+
+```bash
+ssh -L 17777:127.0.0.1:17777 user@host
+ssh -L 6768:127.0.0.1:6768 user@host
+```

--- a/apps/sailor-docs/content/docs/en/pebble/tasks.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/tasks.mdx
@@ -1,0 +1,8 @@
+---
+title: Tasks
+description: Work items from GitHub and Linear inside Pebble
+---
+
+# Tasks
+
+Browse and act on GitHub issues/PRs and Linear issues from the Tasks surface. Open a worktree from a task when you are ready to implement.

--- a/apps/sailor-docs/content/docs/en/pebble/telemetry.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/telemetry.mdx
@@ -1,0 +1,19 @@
+---
+title: Privacy & telemetry
+description: What anonymous usage data Pebble collects and how to opt out
+---
+
+# Privacy & telemetry
+
+Pebble's desktop telemetry is designed to be **anonymous product analytics** (PostHog Cloud) plus **error/crash reporting** (Sentry Cloud). Ordinary product feedback is private support data.
+
+| Channel | Destination |
+|---------|-------------|
+| Product analytics | PostHog Cloud (opt-out in settings) |
+| Errors / crashes | Sentry Cloud |
+| In-app feedback | `POST https://api.nebutra.com/pebble/v1/feedback` |
+| Diagnostics bundles | `POST https://api.nebutra.com/pebble/diagnostics/*` |
+
+Diagnostics uploads are capped (4 MiB), tokenized (short-lived, single-use), rate-limited per IP, and retained for 30 days unless deleted earlier. Feedback messages are not written into public issue trackers or analytics events.
+
+Opt out of product analytics in **Settings → Privacy**. Set `PEBBLE_DIAGNOSTICS_DISABLED=1` to disable diagnostic bundle collection entirely.

--- a/apps/sailor-docs/content/docs/en/pebble/terminal.mdx
+++ b/apps/sailor-docs/content/docs/en/pebble/terminal.mdx
@@ -1,0 +1,10 @@
+---
+title: Terminal
+description: Ghostty-class terminal splits with durable scrollback
+---
+
+# Terminal
+
+Pebble embeds Ghostty-class terminals with WebGL rendering, infinite splits, and scrollback that survives restarts.
+
+Terminal sessions stay owned by the Go runtime control plane; the desktop shell is the surface, not a second PTY host.

--- a/apps/sailor-docs/content/docs/zh/pebble/index.mdx
+++ b/apps/sailor-docs/content/docs/zh/pebble/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Pebble
+description: AI 编排桌面产品 — 在 Nebutra 平台上的文档命名空间
+---
+
+# Pebble
+
+Pebble 是 Nebutra 面向 builder 的 AI 编排器：在隔离的 git worktree 中并行运行 Codex、Claude Code、OpenCode 等。
+
+## 域名
+
+| 表面 | 主机 |
+|------|------|
+| 产品 / 下载 | [pebble.nebutra.com](https://pebble.nebutra.com) |
+| **本文档** | [docs.nebutra.com/pebble](https://docs.nebutra.com/pebble) |
+| 反馈与诊断 API | `https://api.nebutra.com/pebble/*` |
+| 状态页 | [status.nebutra.com](https://status.nebutra.com) |
+
+`pebble.nebutra.com` 仅为品牌前台（落地页、下载、静态更新 feed），无产品数据库。机器端点使用共享 API 的 `/pebble` 前缀。
+
+## 快速入口
+
+- [下载](https://pebble.nebutra.com/download)
+- [移动端](/pebble/mobile)
+- [并行 worktree](/pebble/model/worktrees)
+- [隐私与遥测](/pebble/telemetry)

--- a/apps/sailor-docs/content/docs/zh/pebble/telemetry.mdx
+++ b/apps/sailor-docs/content/docs/zh/pebble/telemetry.mdx
@@ -1,0 +1,15 @@
+---
+title: 隐私与遥测
+description: Pebble 收集哪些匿名数据以及如何关闭
+---
+
+# 隐私与遥测
+
+| 通道 | 目标 |
+|------|------|
+| 产品分析 | PostHog Cloud（设置中可关闭） |
+| 错误 / 崩溃 | Sentry Cloud |
+| 应用内反馈 | `POST https://api.nebutra.com/pebble/v1/feedback` |
+| 诊断包 | `POST https://api.nebutra.com/pebble/diagnostics/*` |
+
+诊断上传有 4 MiB 上限、短时一次性 token、按 IP 限流，默认保留 30 天。反馈正文不会进入公共 issue 或分析事件。

--- a/backends/gateway/src/routes/pebble/feedback.ts
+++ b/backends/gateway/src/routes/pebble/feedback.ts
@@ -52,6 +52,40 @@ function formDataToRecord(form: FormData): Record<string, string> {
   return record;
 }
 
+/**
+ * Normalize desktop / brand-front legacy payloads onto the canonical schema.
+ *
+ * Shipped Tauri clients historically POSTed camel-ish / alternate field names
+ * to `pebble.nebutra.com/v1/feedback` (now rewritten to this route):
+ *   feedback → message
+ *   submission_type → kind
+ *   github_email → contact_email
+ * and often omitted `submission_id`. New clients send the canonical shape
+ * directly to `api.nebutra.com/pebble/v1/feedback`.
+ */
+export function normalizeFeedbackBody(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return raw;
+  const source = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...source };
+
+  if (out.message == null && typeof out.feedback === "string") {
+    out.message = out.feedback;
+  }
+  if (out.kind == null && typeof out.submission_type === "string") {
+    out.kind = out.submission_type;
+  }
+  if (out.contact_email == null && typeof out.github_email === "string") {
+    out.contact_email = out.github_email;
+  }
+  if (
+    out.submission_id == null ||
+    (typeof out.submission_id === "string" && out.submission_id.trim() === "")
+  ) {
+    out.submission_id = `desk_${Date.now().toString(36)}_${crypto.randomUUID().slice(0, 8)}`;
+  }
+  return out;
+}
+
 const submitRoute = createRoute({
   method: "post",
   path: "/",
@@ -106,7 +140,7 @@ feedbackRoutes.openapi(submitRoute, async (c) => {
     return c.json({ error: "Bad Request", message: "Body is not valid JSON or form data." }, 400);
   }
 
-  const parsed = FeedbackRequestSchema.safeParse(raw);
+  const parsed = FeedbackRequestSchema.safeParse(normalizeFeedbackBody(raw));
   if (!parsed.success) {
     return c.json({ error: "Bad Request", message: "Submission failed validation." }, 400);
   }

--- a/backends/gateway/src/routes/pebble/index.test.ts
+++ b/backends/gateway/src/routes/pebble/index.test.ts
@@ -185,6 +185,34 @@ describe("pebble support intake", () => {
       expect(response.status).toBe(400);
       expect(feedback).toHaveLength(0);
     });
+
+    it("accepts desktop legacy field names and synthesizes submission_id", async () => {
+      const app = await createApp();
+
+      const response = await app.request("/pebble/v1/feedback", {
+        method: "POST",
+        headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.4" },
+        body: JSON.stringify({
+          feedback: "terminal lost scrollback after restart",
+          submission_type: "feedback",
+          github_email: "builder@example.com",
+          app_version: "1.4.200",
+          platform: "darwin",
+          os_release: "24.0.0",
+          arch: "arm64",
+        }),
+      });
+
+      expect(response.status).toBe(202);
+      const body = (await response.json()) as { submission_id: string; received: boolean };
+      expect(body.received).toBe(true);
+      expect(body.submission_id).toMatch(/^desk_/);
+      expect(feedback[0]).toMatchObject({
+        kind: "FEEDBACK",
+        contactEmail: "builder@example.com",
+        message: "terminal lost scrollback after restart",
+      });
+    });
   });
 
   describe("POST /pebble/diagnostics/token", () => {

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -18,6 +18,7 @@
 | `forge.nebutra.com` | forge | **Nebutra Forge** — tool station + Agent tool API (Vercel; ECS PM2 fallback :3105) |
 | `admin.nebutra.com` | admin | **Ecosystem control plane** — staff-only (Cloudflare Access + `sso` OIDC + platform-staff role). Never tenant-visible. See [PRD](./plans/2026-07-28-nebutra-admin-control-plane-design.md) |
 | `pebble.nebutra.com` | (external repo `Nebutra/pebble`) | **Pebble brand front** — landing / download / docs redirect only. No backend of its own. |
+| `carina.nebutra.com` | (external repo `Nebutra/carina` → `apps/docs`) | **Carina product docs** — Astro + Starlight static site. No backend of its own. |
 
 > Router/Forge: product hosts; supply engines (New-API, Sub2API) stay **internal** — see `infra/nebutra-router/`.
 
@@ -51,6 +52,23 @@ or `staging.pebble.*`. Client-side origins are build-time configurable
 (`DOCS_ORIGIN` / `API_ORIGIN` / `STATUS_ORIGIN`) — see the Pebble repo's
 `docs/reference/infra-index.md`.
 
+### Carina — product docs front, local-first runtime
+
+Carina is a separate repo (`Nebutra/carina`). The public host is **docs only**
+(Astro + Starlight under `apps/docs`). The runtime itself stays local-first;
+identity/cloud boundaries are documented in Carina's `docs/nebutra-cloud-boundary.md`
+and do **not** get a parallel `api.carina.*` origin.
+
+| Capability | Host + path |
+|---|---|
+| Product docs / LLM surface | `carina.nebutra.com` (CF CNAME → Vercel, proxied) |
+| Skills / catalog URLs | `carina.nebutra.com/llms.txt`, `/data/rpc-catalog-*.json` |
+| Staging | **no host** — preview deploys / project isolation only |
+
+Deploy lives in the Carina repo (`deploy-docs-vercel.yml` → project `nebutra-carina`).
+DNS for the shared `nebutra.com` zone is owned here: `point-carina-dns.yml` +
+`infra/ops/scripts/point-carina-dns-vercel.sh`.
+
 ## Production truth (as of 2026-07-22)
 
 Single source of truth for *where traffic lands today*. Do not invent a second story in other docs without updating this table.
@@ -66,6 +84,8 @@ Single source of truth for *where traffic lands today*. Do not invent a second s
 | `router.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `router` | Product edge :3106; Vercel project `nebutra-router` exists for future cutover |
 | `forge.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `forge` | Product edge :3105; Vercel project `nebutra-forge` exists (Hobby deploy cap) |
 | `admin.nebutra.com` | **not yet created** | **ECS PM2** `admin` :3108 (PM2 slot reserved, not deployed) | Blocked on the Cloudflare Access policy + OIDC gate — do not create the DNS record before both exist. No Vercel project by design |
+| `pebble.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `@nebutra/pebble-site` (`apps/pebble`) | Brand front only. Deploy: `deploy-pebble-vercel.yml`. DNS: `point-pebble-dns.yml`. API stays on `api.nebutra.com/pebble/*`. |
+| `carina.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `nebutra-carina` (`Nebutra/carina` `apps/docs`) | Product docs only. Deploy: carina repo `deploy-docs-vercel.yml`. DNS: `point-carina-dns.yml` (this monorepo owns the zone). |
 
 ### Topology layers
 
@@ -114,6 +134,7 @@ A       forge     106.15.4.31              ✅           ECS PM2 @nebutra/forge
 A       admin     106.15.4.31              ✅           ECS PM2 @nebutra/admin — create ONLY together with the Cloudflare Access policy
 CNAME   docs      nebutra-sailor-docs.nebutra.workers.dev  ✅  # OpenNext Worker; Vercel grey-cloud is fallback only
 CNAME   pebble    cname.vercel-dns.com     ✅           Pebble brand front (landing/download); no backend
+CNAME   carina    cname.vercel-dns.com     ✅           Carina product docs (Nebutra/carina apps/docs); no backend
 ```
 
 When cutting `app` / `auth` to Vercel: switch to `CNAME … cname.vercel-dns.com` (grey or orange per SSL plan) and remove the ECS A records.
@@ -156,6 +177,7 @@ Unauthenticated product routes: `auth.nebutra.com/sign-in?returnTo=https://app.n
 |---------|------|-----------|
 | landing | `apps/landing` | `nebutra.com`, `www` |
 | docs | `apps/sailor-docs` | `docs.nebutra.com` |
+| nebutra-pebble | `apps/pebble` | `pebble.nebutra.com` |
 | nebutra-auth | `apps/auth` | `auth.nebutra.com` (ready; DNS may still be ECS) |
 | nebutra-web | `apps/web` | `app.nebutra.com` (ready; DNS may still be ECS) |
 

--- a/infra/ops/scripts/point-pebble-dns-vercel.sh
+++ b/infra/ops/scripts/point-pebble-dns-vercel.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Upsert pebble.nebutra.com → cname.vercel-dns.com (proxied orange-cloud).
+# Brand front only — no ECS origin. See docs/DOMAINS.md and topology.defaults.yaml.
+set -euo pipefail
+
+TOKEN="${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN required}"
+ZONE_NAME="${CF_ZONE_NAME:-nebutra.com}"
+HOST="pebble.${ZONE_NAME}"
+CONTENT="${PEBBLE_DNS_TARGET:-cname.vercel-dns.com}"
+ACC="${CLOUDFLARE_ACCOUNT_ID:-}"
+
+echo "=== token verify ==="
+VERIFY=$(curl -sS -H "Authorization: Bearer ${TOKEN}" "https://api.cloudflare.com/client/v4/user/tokens/verify" || true)
+echo "$VERIFY" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("success"), d; print("token_ok", d.get("result",{}).get("status"))'
+
+if [ -n "${CF_ZONE_ID:-}" ]; then
+  ZONE_ID="$CF_ZONE_ID"
+else
+  QUERY="name=${ZONE_NAME}"
+  if [ -n "$ACC" ]; then
+    QUERY="${QUERY}&account.id=${ACC}"
+  fi
+  ZONE_JSON=$(curl -sS -H "Authorization: Bearer ${TOKEN}" \
+    "https://api.cloudflare.com/client/v4/zones?${QUERY}")
+  ZONE_ID=$(echo "$ZONE_JSON" | python3 -c 'import json,sys; r=json.load(sys.stdin); print((r.get("result") or [{}])[0].get("id",""))')
+fi
+[ -n "$ZONE_ID" ] || { echo "zone missing for ${ZONE_NAME} (set CF_ZONE_ID)"; exit 1; }
+echo "ZONE_ID=${ZONE_ID} HOST=${HOST} → ${CONTENT}"
+
+auth_get() { curl -sS -H "Authorization: Bearer ${TOKEN}" "$1"; }
+
+echo "=== existing pebble records ==="
+EXIST=$(auth_get "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${HOST}")
+echo "$EXIST" | python3 -m json.tool | head -40
+
+BODY=$(python3 -c "import json; print(json.dumps({'type':'CNAME','name':'pebble','content':'${CONTENT}','proxied':True,'ttl':1,'comment':'Pebble brand front (Vercel)'}))")
+RID=$(python3 -c 'import json,sys; r=json.load(sys.stdin).get("result") or []; print(r[0]["id"] if r else "")' <<<"$EXIST")
+
+tmp="$(mktemp)"
+if [ -n "$RID" ]; then
+  curl -sS -X PUT -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+    --data "$BODY" "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RID}" -o "$tmp"
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print("dns put", d.get("success"), d.get("errors")); assert d.get("success"), d' <"$tmp"
+else
+  curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+    --data "$BODY" "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" -o "$tmp"
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print("dns post", d.get("success"), d.get("errors")); assert d.get("success"), d' <"$tmp"
+fi
+rm -f "$tmp"
+
+echo "=== smoke (DNS may still be propagating) ==="
+curl -sSI --max-time 20 "https://${HOST}/" | head -20 || true
+echo "done"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -919,6 +919,34 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  apps/pebble:
+    dependencies:
+      next:
+        specifier: ^16.2.11
+        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+
   apps/router:
     dependencies:
       '@lobehub/icons':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,9 @@ trustPolicyExclude:
   - "@auth/core@0.41.3"
   # chokidar@4.0.3 (via tsup) lost provenance attestation vs earlier 4.x — not a takeover.
   - "chokidar@4.0.3"
+  # undici-types@6.21.0 (via @types/node) dropped provenance vs earlier 6.x — not a takeover.
+  - "undici-types@6.21.0"
+  - "undici-types"
 strictDepBuilds: true
 ignorePnpmfile: true
 


### PR DESCRIPTION
## Summary
- Add `@nebutra/pebble-site` brand front for `pebble.nebutra.com` (landing, download, static changelog/nudge feeds)
- Cloudflare DNS script + workflows (`point-pebble-dns`, `deploy-pebble-vercel`)
- Docs content under `docs.nebutra.com/pebble/*`
- Gateway accepts desktop legacy feedback payloads; canonical route remains `api.nebutra.com/pebble/*`
- Landing redirects `/pebble/*` → brand front

## Deploy sequence after merge
1. `workflow_dispatch` **Point pebble DNS to Vercel**
2. `workflow_dispatch` **Deploy Pebble brand front (Vercel)** (or auto on main paths)
3. Deploy gateway when ready for legacy body normalize in prod

## Test plan
- [ ] `https://pebble.nebutra.com/` → 200
- [ ] `https://pebble.nebutra.com/whats-new/changelog.json` → 200, no redirect
- [ ] `https://pebble.nebutra.com/docs/mobile` → 301 → docs
- [ ] `POST api.nebutra.com/pebble/v1/feedback` accepts canonical + legacy desktop body