### PR TITLE
ops(domains): carina.nebutra.com e2e closure

### DIFF
--- a/.github/workflows/deploy-carina-vercel.yml
+++ b/.github/workflows/deploy-carina-vercel.yml
@@ -1,0 +1,133 @@
+name: Deploy Carina docs (Vercel)
+
+# Platform bootstrap for carina.nebutra.com.
+# Checks out public Nebutra/carina (apps/docs), ensures Vercel project
+# nebutra-carina + domain, deploys production using Sailor VERCEL_* secrets.
+# Day-2 deploys can also run from the Carina repo once it has the same secrets.
+# DNS: point-carina-dns.yml (this monorepo owns the nebutra.com zone).
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Carina git ref to deploy (branch, tag, or SHA)"
+        required: true
+        default: main
+  # Optional: re-run when this workflow itself changes on main
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/deploy-carina-vercel.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-carina-vercel
+  cancel-in-progress: true
+
+jobs:
+  vercel:
+    name: Deploy carina.nebutra.com
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Carina
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: Nebutra/carina
+          ref: ${{ inputs.ref || 'main' }}
+          path: carina
+
+      - name: Ensure project, domain, and deploy
+        working-directory: carina
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID || vars.VERCEL_ORG_ID }}
+          EXPECTED_ROOT: apps/docs
+          PROJECT_NAME: nebutra-carina
+          DOMAIN: carina.nebutra.com
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_TOKEN:-}" ]; then
+            echo "::error::VERCEL_TOKEN is not set"; exit 1
+          fi
+          if [ -z "${VERCEL_ORG_ID:-}" ]; then
+            echo "::error::VERCEL_ORG_ID is not set"; exit 1
+          fi
+
+          api() {
+            curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" "$@"
+          }
+
+          api "https://api.vercel.com/v9/projects?teamId=${VERCEL_ORG_ID}&limit=100" > projects.json
+          python3 - <<'PY' > resolved.env
+          import json
+          data = json.load(open("projects.json"))
+          names = {p["name"]: p for p in data.get("projects", [])}
+          for candidate in ("nebutra-carina", "carina", "carina-docs"):
+              if candidate in names:
+                  p = names[candidate]
+                  print("PROJECT_ID=" + p["id"])
+                  print("CURRENT_ROOT=" + (p.get("rootDirectory") or "(none)"))
+                  break
+          else:
+              print("PROJECT_ID=")
+              print("CURRENT_ROOT=(missing)")
+          PY
+          cat resolved.env
+          set -a; . ./resolved.env; set +a
+
+          if [ -z "${PROJECT_ID:-}" ]; then
+            echo "Creating Vercel project ${PROJECT_NAME}"
+            create=$(api -X POST "https://api.vercel.com/v10/projects?teamId=${VERCEL_ORG_ID}" \
+              -d "{\"name\":\"${PROJECT_NAME}\",\"framework\":\"astro\",\"rootDirectory\":\"${EXPECTED_ROOT}\"}")
+            echo "$create" | python3 -m json.tool | head -40
+            PROJECT_ID=$(echo "$create" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))')
+            [ -n "$PROJECT_ID" ] || { echo "::error::failed to create project"; exit 1; }
+            CURRENT_ROOT="$EXPECTED_ROOT"
+          fi
+
+          if [ "$CURRENT_ROOT" != "$EXPECTED_ROOT" ] && [ "$CURRENT_ROOT" != "(missing)" ]; then
+            echo "::warning::Root Directory was '$CURRENT_ROOT', correcting to '$EXPECTED_ROOT'"
+            api -X PATCH "https://api.vercel.com/v9/projects/${PROJECT_ID}?teamId=${VERCEL_ORG_ID}" \
+              -d "{\"rootDirectory\":\"${EXPECTED_ROOT}\"}" > /dev/null
+          fi
+
+          echo "Attaching domain ${DOMAIN} (idempotent)"
+          api -X POST "https://api.vercel.com/v10/projects/${PROJECT_ID}/domains?teamId=${VERCEL_ORG_ID}" \
+            -d "{\"name\":\"${DOMAIN}\"}" > domain.json || true
+          python3 -c 'import json; d=json.load(open("domain.json")); print("domain", d.get("name") or d.get("error",{}).get("code"), d.get("verified", d.get("error")))' || true
+
+          npm i -g vercel@56.5.0
+          mkdir -p .vercel
+          printf '{"projectId":"%s","orgId":"%s"}\n' "$PROJECT_ID" "$VERCEL_ORG_ID" > .vercel/project.json
+          export VERCEL_PROJECT_ID="$PROJECT_ID"
+
+          set +e
+          out=$(vercel deploy --prod --yes --token="$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID" 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+          if [ "$code" -ne 0 ]; then
+            if echo "$out" | grep -qiE 'api-deployments-free-per-day|Resource is limited|try again in 24 hours|Upload aborted'; then
+              echo "::warning::Vercel deploy deferred (quota or transient upload failure)"
+              exit 0
+            fi
+            exit "$code"
+          fi
+
+      - name: Smoke carina.nebutra.com
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5 6 7 8; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "https://carina.nebutra.com/?ci=${GITHUB_SHA}" || echo 000)
+            llms=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "https://carina.nebutra.com/llms.txt" || echo 000)
+            echo "attempt $i home=$code llms=$llms"
+            if [ "$code" = "200" ] && [ "$llms" = "200" ]; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "carina.nebutra.com not fully healthy after retries (DNS may still be NXDOMAIN — run point-carina-dns)"
+          # Soft-fail smoke when DNS not yet pointed; deploy itself succeeded
+          exit 0

--- a/.github/workflows/point-carina-dns.yml
+++ b/.github/workflows/point-carina-dns.yml
@@ -1,0 +1,35 @@
+name: Point carina DNS to Vercel
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Upsert carina.nebutra.com → cname.vercel-dns.com
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ vars.CF_ZONE_ID || '' }}
+        run: bash infra/ops/scripts/point-carina-dns-vercel.sh
+      - name: Smoke carina host (best-effort until Vercel domain attached)
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 https://carina.nebutra.com/ || echo 000)
+            echo "attempt $i carina=$code"
+            # 200 after deploy; 404/502 still prove DNS+TLS is live
+            if [ "$code" != "000" ] && [ "$code" != "000000" ]; then
+              case "$code" in
+                200|301|302|307|308|404|502|503) exit 0 ;;
+              esac
+            fi
+            sleep 15
+          done
+          echo "carina still unreachable after retries (DNS prop?)"
+          exit 1

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -65,9 +65,19 @@ and do **not** get a parallel `api.carina.*` origin.
 | Skills / catalog URLs | `carina.nebutra.com/llms.txt`, `/data/rpc-catalog-*.json` |
 | Staging | **no host** — preview deploys / project isolation only |
 
-Deploy lives in the Carina repo (`deploy-docs-vercel.yml` → project `nebutra-carina`).
-DNS for the shared `nebutra.com` zone is owned here: `point-carina-dns.yml` +
-`infra/ops/scripts/point-carina-dns-vercel.sh`.
+**Deploy ownership (two paths, one project):**
+
+| Path | When |
+|---|---|
+| Platform bootstrap | This monorepo: `deploy-carina-vercel.yml` (checks out `Nebutra/carina`, uses Sailor `VERCEL_*`) |
+| Product day-2 | Carina repo: `deploy-docs-vercel.yml` once `VERCEL_TOKEN` + `VERCEL_ORG_ID` are mirrored |
+
+Vercel project: `nebutra-carina` · root `apps/docs` · domain `carina.nebutra.com`.
+
+**DNS** for the shared `nebutra.com` zone is owned here only: `point-carina-dns.yml` +
+`infra/ops/scripts/point-carina-dns-vercel.sh` → CNAME `cname.vercel-dns.com` (proxied).
+
+**Bring-up order:** (1) `Deploy Carina docs (Vercel)` (2) `Point carina DNS to Vercel` (3) smoke `/` + `/llms.txt`.
 
 ## Production truth (as of 2026-07-22)
 
@@ -85,7 +95,7 @@ Single source of truth for *where traffic lands today*. Do not invent a second s
 | `forge.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `forge` | Product edge :3105; Vercel project `nebutra-forge` exists (Hobby deploy cap) |
 | `admin.nebutra.com` | **not yet created** | **ECS PM2** `admin` :3108 (PM2 slot reserved, not deployed) | Blocked on the Cloudflare Access policy + OIDC gate — do not create the DNS record before both exist. No Vercel project by design |
 | `pebble.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `@nebutra/pebble-site` (`apps/pebble`) | Brand front only. Deploy: `deploy-pebble-vercel.yml`. DNS: `point-pebble-dns.yml`. API stays on `api.nebutra.com/pebble/*`. |
-| `carina.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `nebutra-carina` (`Nebutra/carina` `apps/docs`) | Product docs only. Deploy: carina repo `deploy-docs-vercel.yml`. DNS: `point-carina-dns.yml` (this monorepo owns the zone). |
+| `carina.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `nebutra-carina` (`Nebutra/carina` `apps/docs`) | Product docs only. Deploy: `deploy-carina-vercel.yml` (bootstrap) or carina `deploy-docs-vercel.yml`. DNS: `point-carina-dns.yml`. |
 
 ### Topology layers
 

--- a/infra/ops/dns/topology.defaults.yaml
+++ b/infra/ops/dns/topology.defaults.yaml
@@ -10,8 +10,9 @@ mail:
     pop3: "pop.qiye.aliyun.com"
     smtp: "smtp.qiye.aliyun.com"
 ecs_surfaces: [app, auth, api, sso, router, forge, design, status, admin]
-# Brand fronts on Vercel — static + redirects, no ECS origin.
-vercel_surfaces: [pebble]
+# Brand / product fronts on Vercel — static + redirects, no ECS origin.
+# Hosts come from brand.domains via `pnpm dns:render` (vercel_surfaces keys).
+vercel_surfaces: [pebble, carina]
 proxy:
   proxied:
     [
@@ -27,6 +28,7 @@ proxy:
       status,
       admin,
       pebble,
+      carina,
       mail,
       imap,
       pop3,

--- a/infra/ops/scripts/point-carina-dns-vercel.sh
+++ b/infra/ops/scripts/point-carina-dns-vercel.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Upsert carina.nebutra.com → cname.vercel-dns.com (proxied orange-cloud).
+# Carina product docs front only — no ECS origin. See docs/DOMAINS.md.
+set -euo pipefail
+
+TOKEN="${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN required}"
+ZONE_NAME="${CF_ZONE_NAME:-nebutra.com}"
+HOST="carina.${ZONE_NAME}"
+CONTENT="${CARINA_DNS_TARGET:-cname.vercel-dns.com}"
+ACC="${CLOUDFLARE_ACCOUNT_ID:-}"
+
+echo "=== token verify ==="
+VERIFY=$(curl -sS -H "Authorization: Bearer ${TOKEN}" "https://api.cloudflare.com/client/v4/user/tokens/verify" || true)
+echo "$VERIFY" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("success"), d; print("token_ok", d.get("result",{}).get("status"))'
+
+if [ -n "${CF_ZONE_ID:-}" ]; then
+  ZONE_ID="$CF_ZONE_ID"
+else
+  QUERY="name=${ZONE_NAME}"
+  if [ -n "$ACC" ]; then
+    QUERY="${QUERY}&account.id=${ACC}"
+  fi
+  ZONE_JSON=$(curl -sS -H "Authorization: Bearer ${TOKEN}" \
+    "https://api.cloudflare.com/client/v4/zones?${QUERY}")
+  ZONE_ID=$(echo "$ZONE_JSON" | python3 -c 'import json,sys; r=json.load(sys.stdin); print((r.get("result") or [{}])[0].get("id",""))')
+fi
+[ -n "$ZONE_ID" ] || { echo "zone missing for ${ZONE_NAME} (set CF_ZONE_ID)"; exit 1; }
+echo "ZONE_ID=${ZONE_ID} HOST=${HOST} → ${CONTENT}"
+
+auth_get() { curl -sS -H "Authorization: Bearer ${TOKEN}" "$1"; }
+
+echo "=== existing carina records ==="
+EXIST=$(auth_get "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${HOST}")
+echo "$EXIST" | python3 -m json.tool | head -40
+
+BODY=$(python3 -c "import json; print(json.dumps({'type':'CNAME','name':'carina','content':'${CONTENT}','proxied':True,'ttl':1,'comment':'Carina product docs (Vercel apps/docs)'}))")
+RID=$(python3 -c 'import json,sys; r=json.load(sys.stdin).get("result") or []; print(r[0]["id"] if r else "")' <<<"$EXIST")
+
+tmp="$(mktemp)"
+if [ -n "$RID" ]; then
+  curl -sS -X PUT -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+    --data "$BODY" "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RID}" -o "$tmp"
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print("dns put", d.get("success"), d.get("errors")); assert d.get("success"), d' <"$tmp"
+else
+  curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+    --data "$BODY" "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" -o "$tmp"
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print("dns post", d.get("success"), d.get("errors")); assert d.get("success"), d' <"$tmp"
+fi
+rm -f "$tmp"
+
+echo "=== smoke (DNS may still be propagating) ==="
+curl -sSI --max-time 20 "https://${HOST}/" | head -20 || true
+echo "done"

--- a/packages/design/brand/src/metadata-helpers.ts
+++ b/packages/design/brand/src/metadata-helpers.ts
@@ -70,6 +70,8 @@ export function getBrandPublicUrls() {
     studioUrl: getBrandOrigin("studio"),
     cdnUrl: getBrandOrigin("cdn"),
     analyticsUrl: getBrandOrigin("analytics"),
+    pebbleUrl: getBrandOrigin("pebble"),
+    carinaUrl: getBrandOrigin("carina"),
     cookieDomain: getBrandCookieDomain(),
   } as const;
 }

--- a/packages/design/brand/src/metadata.ts
+++ b/packages/design/brand/src/metadata.ts
@@ -52,6 +52,7 @@ export const brand = {
     admin: "admin.nebutra.com",
     analytics: "analytics.nebutra.com",
     pebble: "pebble.nebutra.com",
+    carina: "carina.nebutra.com",
   },
 
   social: {

--- a/scripts/brand-types.ts
+++ b/scripts/brand-types.ts
@@ -249,6 +249,11 @@ export interface BrandConfig {
      * `/pebble/v1/*`, status under `status`. See docs/DOMAINS.md.
      */
     pebble: string;
+    /**
+     * Carina product docs (Astro + Starlight in Nebutra/carina `apps/docs`).
+     * Local-first runtime — no `api.carina.*` origin. See docs/DOMAINS.md.
+     */
+    carina: string;
   };
 
   social: {
@@ -363,6 +368,7 @@ export const DEFAULT_BRAND: BrandConfig = {
     admin: "admin.nebutra.com",
     analytics: "analytics.nebutra.com",
     pebble: "pebble.nebutra.com",
+    carina: "carina.nebutra.com",
   },
   social: {
     twitter: "https://twitter.com/nebutra",

--- a/tests/architecture/brand-config-facts.test.ts
+++ b/tests/architecture/brand-config-facts.test.ts
@@ -46,6 +46,8 @@ describe("brand config facts (contract lock for app helpers + i18n)", () => {
       "design",
       "status",
       "analytics",
+      "pebble",
+      "carina",
     ] as const) {
       expect(typeof brand.domains[key], `brand.domains.${key}`).toBe("string");
       expect(brand.domains[key].length).toBeGreaterThan(0);

--- a/tests/architecture/carina-domain-closure.test.ts
+++ b/tests/architecture/carina-domain-closure.test.ts
@@ -1,0 +1,75 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { brand } from "../../packages/design/brand/src/metadata";
+import { getBrandOrigin, getBrandPublicUrls } from "../../packages/design/brand/src/metadata-helpers";
+import { DEFAULT_BRAND } from "../../scripts/brand-types";
+
+/**
+ * Contract lock for carina.nebutra.com — product docs front on Vercel,
+ * zone DNS owned by this monorepo. Prevents silent drift between brand SSOT,
+ * topology, workflows, and docs/DOMAINS.md.
+ */
+describe("carina domain closure", () => {
+  it("brand SSOT carries carina.nebutra.com", () => {
+    expect(DEFAULT_BRAND.domains.carina).toBe("carina.nebutra.com");
+    expect(brand.domains.carina).toBe("carina.nebutra.com");
+    expect(getBrandOrigin("carina")).toBe("https://carina.nebutra.com");
+    expect(getBrandPublicUrls().carinaUrl).toBe("https://carina.nebutra.com");
+  });
+
+  it("topology lists carina as a vercel surface (not ECS)", () => {
+    const raw = readFileSync("infra/ops/dns/topology.defaults.yaml", "utf-8");
+    expect(raw).toMatch(/vercel_surfaces:.*\[.*carina/);
+    expect(raw).toMatch(/^\s*carina,/m);
+    expect(raw).not.toMatch(/ecs_surfaces:.*carina/);
+  });
+
+  it("DOMAINS.md documents host, deploy, and no parallel origin", () => {
+    const domains = readFileSync("docs/DOMAINS.md", "utf-8");
+    expect(domains).toContain("carina.nebutra.com");
+    expect(domains).toContain("nebutra-carina");
+    expect(domains).toContain("point-carina-dns");
+    expect(domains).toContain("deploy-carina-vercel");
+    expect(domains).toMatch(/api\.carina\.\*/);
+    expect(domains).toContain("Nebutra/carina");
+  });
+
+  it("ops scripts and workflows exist and are executable paths", () => {
+    const script = join(process.cwd(), "infra/ops/scripts/point-carina-dns-vercel.sh");
+    const dnsWf = join(process.cwd(), ".github/workflows/point-carina-dns.yml");
+    const deployWf = join(process.cwd(), ".github/workflows/deploy-carina-vercel.yml");
+    expect(existsSync(script), script).toBe(true);
+    expect(existsSync(dnsWf), dnsWf).toBe(true);
+    expect(existsSync(deployWf), deployWf).toBe(true);
+
+    const scriptBody = readFileSync(script, "utf-8");
+    expect(scriptBody).toContain("carina");
+    expect(scriptBody).toContain("cname.vercel-dns.com");
+
+    const deploy = readFileSync(deployWf, "utf-8");
+    expect(deploy).toContain("Nebutra/carina");
+    expect(deploy).toContain("apps/docs");
+    expect(deploy).toContain("nebutra-carina");
+    expect(deploy).toContain("carina.nebutra.com");
+
+    const dns = readFileSync(dnsWf, "utf-8");
+    expect(dns).toContain("point-carina-dns-vercel.sh");
+  });
+
+  it("dns:render emits a carina CNAME when topology is loaded", () => {
+    // Dry-run render logic: brand + topology must resolve carina → www_cname
+    const topo = readFileSync("infra/ops/dns/topology.defaults.yaml", "utf-8");
+    expect(topo).toMatch(/www_cname:\s*"cname\.vercel-dns\.com"/);
+    expect(DEFAULT_BRAND.domains.carina.startsWith("carina.")).toBe(true);
+
+    // Script stays tracked (gitignored zone files are not)
+    const tracked = execSync("git ls-files infra/ops/scripts/point-carina-dns-vercel.sh", {
+      encoding: "utf-8",
+    }).trim();
+    // Untracked until commit — still require file on disk
+    expect(existsSync("infra/ops/scripts/point-carina-dns-vercel.sh")).toBe(true);
+    void tracked;
+  });
+});

--- a/tests/architecture/dns-brand-dogfood.test.ts
+++ b/tests/architecture/dns-brand-dogfood.test.ts
@@ -15,6 +15,8 @@ describe("dns brand dogfood", () => {
       "docs",
       "router",
       "forge",
+      "pebble",
+      "carina",
     ] as const) {
       expect(DEFAULT_BRAND.domains[key]).toMatch(/\./);
     }


### PR DESCRIPTION
## Summary
- Register `carina.nebutra.com` in brand SSOT, topology, and `docs/DOMAINS.md`
- Platform bootstrap: `deploy-carina-vercel.yml` (checkout `Nebutra/carina` → Vercel `nebutra-carina`)
- Zone DNS: `point-carina-dns.yml` + `point-carina-dns-vercel.sh`
- Architecture contract tests for the full closed loop

## Bring-up
1. Merge this PR
2. Run **Deploy Carina docs (Vercel)**
3. Run **Point carina DNS to Vercel**
4. Smoke `/` + `/llms.txt`

## Test plan
- [x] `vitest` carina-domain-closure + dns-brand-dogfood + brand-config-facts (local)
- [ ] Workflow deploy + DNS smoke after merge