### PR TITLE
ops(carina): harden deploy/DNS fail-closed after bootstrap

### DIFF
--- a/.github/workflows/deploy-carina-vercel.yml
+++ b/.github/workflows/deploy-carina-vercel.yml
@@ -2,9 +2,11 @@ name: Deploy Carina docs (Vercel)
 
 # Platform bootstrap for carina.nebutra.com.
 # Checks out public Nebutra/carina (apps/docs), ensures Vercel project
-# nebutra-carina + domain, deploys production using Sailor VERCEL_* secrets.
+# nebutra-carina + domain + Git link, deploys production using Sailor VERCEL_*.
 # Day-2 deploys can also run from the Carina repo once it has the same secrets.
 # DNS: point-carina-dns.yml (this monorepo owns the nebutra.com zone).
+#
+# Project id (optional var): VERCEL_CARINA_PROJECT_ID=prj_JN4csIJFkFiz1qoQCSYPXucmuJRx
 
 on:
   workflow_dispatch:
@@ -13,7 +15,6 @@ on:
         description: "Carina git ref to deploy (branch, tag, or SHA)"
         required: true
         default: main
-  # Optional: re-run when this workflow itself changes on main
   push:
     branches: [main]
     paths:
@@ -38,14 +39,16 @@ jobs:
           ref: ${{ inputs.ref || 'main' }}
           path: carina
 
-      - name: Ensure project, domain, and deploy
+      - name: Ensure project, domain, git link, and deploy
         working-directory: carina
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID || vars.VERCEL_ORG_ID }}
+          KNOWN_PROJECT_ID: ${{ vars.VERCEL_CARINA_PROJECT_ID || '' }}
           EXPECTED_ROOT: apps/docs
           PROJECT_NAME: nebutra-carina
           DOMAIN: carina.nebutra.com
+          GIT_REPO: Nebutra/carina
         run: |
           set -euo pipefail
           if [ -z "${VERCEL_TOKEN:-}" ]; then
@@ -59,8 +62,15 @@ jobs:
             curl -sS -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" "$@"
           }
 
-          api "https://api.vercel.com/v9/projects?teamId=${VERCEL_ORG_ID}&limit=100" > projects.json
-          python3 - <<'PY' > resolved.env
+          PROJECT_ID="${KNOWN_PROJECT_ID:-}"
+          CURRENT_ROOT="(missing)"
+          if [ -n "$PROJECT_ID" ]; then
+            meta=$(api "https://api.vercel.com/v9/projects/${PROJECT_ID}?teamId=${VERCEL_ORG_ID}" || true)
+            CURRENT_ROOT=$(echo "$meta" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("rootDirectory") or "(none)")' 2>/dev/null || echo "(missing)")
+            echo "Using known PROJECT_ID=$PROJECT_ID root=$CURRENT_ROOT"
+          else
+            api "https://api.vercel.com/v9/projects?teamId=${VERCEL_ORG_ID}&limit=100" > projects.json
+            python3 - <<'PY' > resolved.env
           import json
           data = json.load(open("projects.json"))
           names = {p["name"]: p for p in data.get("projects", [])}
@@ -74,8 +84,9 @@ jobs:
               print("PROJECT_ID=")
               print("CURRENT_ROOT=(missing)")
           PY
-          cat resolved.env
-          set -a; . ./resolved.env; set +a
+            cat resolved.env
+            set -a; . ./resolved.env; set +a
+          fi
 
           if [ -z "${PROJECT_ID:-}" ]; then
             echo "Creating Vercel project ${PROJECT_NAME}"
@@ -85,18 +96,28 @@ jobs:
             PROJECT_ID=$(echo "$create" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))')
             [ -n "$PROJECT_ID" ] || { echo "::error::failed to create project"; exit 1; }
             CURRENT_ROOT="$EXPECTED_ROOT"
+            echo "::notice::Created project id=${PROJECT_ID} — set vars.VERCEL_CARINA_PROJECT_ID"
           fi
 
-          if [ "$CURRENT_ROOT" != "$EXPECTED_ROOT" ] && [ "$CURRENT_ROOT" != "(missing)" ]; then
+          if [ "$CURRENT_ROOT" != "$EXPECTED_ROOT" ] && [ "$CURRENT_ROOT" != "(missing)" ] && [ "$CURRENT_ROOT" != "(none)" ]; then
             echo "::warning::Root Directory was '$CURRENT_ROOT', correcting to '$EXPECTED_ROOT'"
             api -X PATCH "https://api.vercel.com/v9/projects/${PROJECT_ID}?teamId=${VERCEL_ORG_ID}" \
-              -d "{\"rootDirectory\":\"${EXPECTED_ROOT}\"}" > /dev/null
+              -d "{\"rootDirectory\":\"${EXPECTED_ROOT}\",\"framework\":\"astro\"}" > /dev/null
           fi
+
+          # Keep framework/root honest even on first create follow-ups
+          api -X PATCH "https://api.vercel.com/v9/projects/${PROJECT_ID}?teamId=${VERCEL_ORG_ID}" \
+            -d "{\"rootDirectory\":\"${EXPECTED_ROOT}\",\"framework\":\"astro\"}" > /dev/null || true
 
           echo "Attaching domain ${DOMAIN} (idempotent)"
           api -X POST "https://api.vercel.com/v10/projects/${PROJECT_ID}/domains?teamId=${VERCEL_ORG_ID}" \
             -d "{\"name\":\"${DOMAIN}\"}" > domain.json || true
           python3 -c 'import json; d=json.load(open("domain.json")); print("domain", d.get("name") or d.get("error",{}).get("code"), d.get("verified", d.get("error")))' || true
+
+          echo "Linking GitHub ${GIT_REPO} (idempotent best-effort)"
+          api -X POST "https://api.vercel.com/v9/projects/${PROJECT_ID}/link?teamId=${VERCEL_ORG_ID}" \
+            -d "{\"type\":\"github\",\"repo\":\"${GIT_REPO}\",\"productionBranch\":\"main\"}" > link.json || true
+          python3 -c 'import json; d=json.load(open("link.json")); print("git_link", d.get("link") or d.get("error") or list(d.keys())[:6])' || true
 
           npm i -g vercel@56.5.0
           mkdir -p .vercel
@@ -109,9 +130,16 @@ jobs:
           set -e
           echo "$out"
           if [ "$code" -ne 0 ]; then
-            if echo "$out" | grep -qiE 'api-deployments-free-per-day|Resource is limited|try again in 24 hours|Upload aborted'; then
-              echo "::warning::Vercel deploy deferred (quota or transient upload failure)"
-              exit 0
+            if echo "$out" | grep -qiE 'api-deployments-free-per-day|Resource is limited|try again in 24 hours'; then
+              echo "::error::Vercel Hobby daily deploy quota exhausted (api-deployments-free-per-day)."
+              echo "::error::Project ${PROJECT_NAME} (${PROJECT_ID}) and domain ${DOMAIN} are provisioned."
+              echo "::error::Re-run this workflow after the quota window resets (or upgrade the Vercel plan)."
+              echo "::error::DNS is independent: run Point carina DNS to Vercel when CLOUDFLARE_API_TOKEN has Zone DNS Edit."
+              exit 1
+            fi
+            if echo "$out" | grep -qiE 'Upload aborted'; then
+              echo "::warning::Transient upload failure — re-run workflow"
+              exit 1
             fi
             exit "$code"
           fi
@@ -128,6 +156,5 @@ jobs:
             fi
             sleep 15
           done
-          echo "carina.nebutra.com not fully healthy after retries (DNS may still be NXDOMAIN — run point-carina-dns)"
-          # Soft-fail smoke when DNS not yet pointed; deploy itself succeeded
-          exit 0
+          echo "::error::carina.nebutra.com not healthy after deploy. Check DNS (point-carina-dns) and Vercel domain."
+          exit 1

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -95,7 +95,7 @@ Single source of truth for *where traffic lands today*. Do not invent a second s
 | `forge.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `forge` | Product edge :3105; Vercel project `nebutra-forge` exists (Hobby deploy cap) |
 | `admin.nebutra.com` | **not yet created** | **ECS PM2** `admin` :3108 (PM2 slot reserved, not deployed) | Blocked on the Cloudflare Access policy + OIDC gate — do not create the DNS record before both exist. No Vercel project by design |
 | `pebble.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `@nebutra/pebble-site` (`apps/pebble`) | Brand front only. Deploy: `deploy-pebble-vercel.yml`. DNS: `point-pebble-dns.yml`. API stays on `api.nebutra.com/pebble/*`. |
-| `carina.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `nebutra-carina` (`Nebutra/carina` `apps/docs`) | Product docs only. Deploy: `deploy-carina-vercel.yml` (bootstrap) or carina `deploy-docs-vercel.yml`. DNS: `point-carina-dns.yml`. |
+| `carina.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `nebutra-carina` (`prj_JN4csIJFkFiz1qoQCSYPXucmuJRx`, `Nebutra/carina` `apps/docs`) | Product docs only. Deploy: `deploy-carina-vercel.yml` (bootstrap) or carina `deploy-docs-vercel.yml`. DNS: `point-carina-dns.yml`. Requires CF token **Zone DNS Edit**; Hobby deploys hit `api-deployments-free-per-day`. |
 
 ### Topology layers
 


### PR DESCRIPTION
Follow-up to #350: project+domain provisioned; fail closed on Vercel Hobby quota and CF DNS Edit auth errors.