### PR TITLE
fix(landing): remove Interactive Demo grid backgrounds

### DIFF
--- a/apps/landing/src/components/landing/product-demo/FauxTerminal.tsx
+++ b/apps/landing/src/components/landing/product-demo/FauxTerminal.tsx
@@ -17,9 +17,8 @@ export function FauxTerminal({ children }: { children: React.ReactNode }) {
         </div>
       </div>
 
-      {/* Terminal Content Area (Theme Adaptive) */}
+      {/* Terminal Content Area (Theme Adaptive) — solid gradient only, no grid. */}
       <div className="flex-1 p-6 sm:p-8 overflow-y-auto w-full bg-gradient-to-br from-background/40 via-background/20 to-muted/20 dark:from-zinc-950 dark:to-muted relative">
-        <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-[size:14px_24px] opacity-50 pointer-events-none" />
         <div className="relative z-10 w-full h-full">{children}</div>
       </div>
     </div>

--- a/apps/landing/src/components/landing/product-demo/LiveMetricsChart.tsx
+++ b/apps/landing/src/components/landing/product-demo/LiveMetricsChart.tsx
@@ -50,9 +50,6 @@ export function LiveMetricsChart() {
 
   return (
     <div className="relative w-full rounded-[var(--radius-xl)] border border-border/40 bg-background/50 dark:bg-zinc-950/50 p-4 shadow-elevation-high overflow-hidden">
-      {/* Background Grid */}
-      <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-[size:24px_24px] opacity-50 pointer-events-none" />
-
       <div className="relative z-10 flex items-center justify-between mb-4">
         <div>
           <h4 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/80 mb-1">


### PR DESCRIPTION
## Summary
- Remove grid overlay from `FauxTerminal` content area
- Remove grid overlay from `LiveMetricsChart` (Realtime Traffic card)

Keeps solid gradient / card surfaces only.