### PR TITLE
feat(pebble): brand front on ECS (A → origin)

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -44,7 +44,7 @@ on:
   workflow_dispatch:
     inputs:
       apps:
-        description: "Apps to deploy (space-separated subset of: landing web api idp auth design-docs sailor-docs router forge admin). Empty = auto-detect."
+        description: "Apps to deploy (space-separated subset of: landing web api idp auth design-docs pebble sailor-docs router forge admin). Empty = auto-detect."
         required: false
         default: ""
       reason:
@@ -96,6 +96,7 @@ jobs:
       idp:         ${{ steps.resolve.outputs.idp }}
       auth:        ${{ steps.resolve.outputs.auth }}
       design-docs: ${{ steps.resolve.outputs['design-docs'] }}
+      pebble:      ${{ steps.resolve.outputs.pebble }}
       sailor-docs: ${{ steps.resolve.outputs['sailor-docs'] }}
       router:      ${{ steps.resolve.outputs.router }}
       forge:       ${{ steps.resolve.outputs.forge }}
@@ -168,6 +169,9 @@ jobs:
               - 'infra/ops/scripts/ecs-deploy-remote.sh'
               - 'infra/runtime/nginx/**'
               - '.github/workflows/deploy-ecs.yml'
+            pebble:
+              - 'apps/pebble/**'
+              - 'infra/runtime/nginx/**'
             sailor-docs:
               - 'apps/sailor-docs/**'
               - 'packages/**'
@@ -221,6 +225,7 @@ jobs:
           F_IDP:          ${{ steps.filter.outputs.idp }}
           F_AUTH:         ${{ steps.filter.outputs.auth }}
           F_DESIGN_DOCS:  ${{ steps.filter.outputs['design-docs'] }}
+          F_PEBBLE:       ${{ steps.filter.outputs.pebble }}
           F_SAILOR_DOCS:  ${{ steps.filter.outputs['sailor-docs'] }}
           F_ROUTER:       ${{ steps.filter.outputs.router }}
           F_FORGE:        ${{ steps.filter.outputs.forge }}
@@ -247,6 +252,7 @@ jobs:
               echo "idp=false"
               echo "auth=false"
               echo "design-docs=false"
+              echo "pebble=false"
               echo "sailor-docs=false"
               echo "router=false"
               echo "forge=true"
@@ -263,13 +269,13 @@ jobs:
             unknown_apps=""
             for app in $normalized_apps; do
               case "$app" in
-                landing|web|api|idp|auth|design-docs|sailor-docs|router|forge|admin) ;;
+                landing|web|api|idp|auth|design-docs|pebble|sailor-docs|router|forge|admin) ;;
                 *) unknown_apps="$unknown_apps $app" ;;
               esac
             done
 
             if [ -n "$unknown_apps" ]; then
-              echo "::error::Unsupported apps: $(echo "$unknown_apps" | xargs). Allowed: landing web api idp auth design-docs sailor-docs router forge admin"
+              echo "::error::Unsupported apps: $(echo "$unknown_apps" | xargs). Allowed: landing web api idp auth design-docs pebble sailor-docs router forge admin"
               exit 1
             fi
           fi
@@ -282,6 +288,7 @@ jobs:
               echo "idp=$(contains_app "$normalized_apps" idp)"
               echo "auth=$(contains_app "$normalized_apps" auth)"
               echo "design-docs=$(contains_app "$normalized_apps" design-docs)"
+              echo "pebble=$(contains_app "$normalized_apps" pebble)"
               echo "sailor-docs=$(contains_app "$normalized_apps" sailor-docs)"
               echo "router=$(contains_app "$normalized_apps" router)"
               echo "forge=$(contains_app "$normalized_apps" forge)"
@@ -294,11 +301,12 @@ jobs:
               echo "idp=$F_IDP"
               echo "auth=$F_AUTH"
               echo "design-docs=$F_DESIGN_DOCS"
+              echo "pebble=$F_PEBBLE"
               echo "sailor-docs=$F_SAILOR_DOCS"
               echo "router=$F_ROUTER"
               echo "forge=$F_FORGE"
               echo "admin=$F_ADMIN"
-              echo "any=$([[ "$F_LANDING" == "true" || "$F_WEB" == "true" || "$F_API" == "true" || "$F_IDP" == "true" || "$F_AUTH" == "true" || "$F_DESIGN_DOCS" == "true" || "$F_SAILOR_DOCS" == "true" || "$F_ROUTER" == "true" || "$F_FORGE" == "true" || "$F_ADMIN" == "true" ]] && echo true || echo false)"
+              echo "any=$([[ "$F_LANDING" == "true" || "$F_WEB" == "true" || "$F_API" == "true" || "$F_IDP" == "true" || "$F_AUTH" == "true" || "$F_DESIGN_DOCS" == "true" || "$F_PEBBLE" == "true" || "$F_SAILOR_DOCS" == "true" || "$F_ROUTER" == "true" || "$F_FORGE" == "true" || "$F_ADMIN" == "true" ]] && echo true || echo false)"
             fi
           } >> "$GITHUB_OUTPUT"
 
@@ -320,6 +328,7 @@ jobs:
       needs.detect-changes.outputs.idp == 'true' ||
       needs.detect-changes.outputs.auth == 'true' ||
       needs.detect-changes.outputs['design-docs'] == 'true' ||
+      needs.detect-changes.outputs.pebble == 'true' ||
       needs.detect-changes.outputs['sailor-docs'] == 'true' ||
       needs.detect-changes.outputs.router == 'true' ||
       needs.detect-changes.outputs.forge == 'true' ||
@@ -365,6 +374,13 @@ jobs:
             build_command: "build"
             condition: ${{ needs.detect-changes.outputs['design-docs'] }}
             site_url: "https://design.nebutra.com"
+          - app: pebble
+            package: "@nebutra/pebble-site"
+            workspace: apps/pebble
+            kind: "next-standalone"
+            build_command: "build"
+            condition: ${{ needs.detect-changes.outputs.pebble }}
+            site_url: "https://pebble.nebutra.com"
           - app: sailor-docs
             package: "@nebutra/sailor-docs"
             workspace: apps/sailor-docs
@@ -676,6 +692,13 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bundle-design-docs
+          path: ${{ runner.temp }}/bundles
+
+      - name: Download pebble bundle
+        if: needs.detect-changes.outputs.pebble == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: bundle-pebble
           path: ${{ runner.temp }}/bundles
 
       - name: Download sailor-docs bundle
@@ -1192,6 +1215,7 @@ jobs:
           [ "${{ needs.detect-changes.outputs.idp }}"            = "true" ] && targets[idp]="https://sso.nebutra.com/.well-known/openid-configuration"
           [ "${{ needs.detect-changes.outputs.auth }}"           = "true" ] && targets[auth]="https://auth.nebutra.com/health"
           [ "${{ needs.detect-changes.outputs['design-docs'] }}" = "true" ] && targets[design-docs]="https://design.nebutra.com"
+          [ "${{ needs.detect-changes.outputs.pebble }}" = "true" ] && targets[pebble]="https://pebble.nebutra.com"
           [ "${{ needs.detect-changes.outputs['sailor-docs'] }}" = "true" ] && targets[sailor-docs]="https://docs.nebutra.com"
           [ "${{ needs.detect-changes.outputs.router }}"         = "true" ] && targets[router]="https://router.nebutra.com"
           [ "${{ needs.detect-changes.outputs.forge }}"          = "true" ] && targets[forge]="https://forge.nebutra.com"
@@ -1200,6 +1224,7 @@ jobs:
           declare -A origin_hosts=()
           [ "${{ needs.detect-changes.outputs.router }}" = "true" ] && origin_hosts[router]="router.nebutra.com"
           [ "${{ needs.detect-changes.outputs.forge }}"  = "true" ] && origin_hosts[forge]="forge.nebutra.com"
+          [ "${{ needs.detect-changes.outputs.pebble }}" = "true" ] && origin_hosts[pebble]="pebble.nebutra.com"
           ECS_ORIGIN_IP="${ECS_HOST:-${{ vars.ECS_HOST || vars.VM_HOST || '106.15.4.31' }}}"
           # Follow redirects and require the request to still be on the host it
           # was aimed at. Accepting a bare 301 as success is what made this smoke
@@ -1336,6 +1361,7 @@ jobs:
           [ "${{ needs.detect-changes.outputs.api }}"            = "true" ] && emit_deployment_verified api "https://api.nebutra.com/api/misc/health"
           [ "${{ needs.detect-changes.outputs.idp }}"            = "true" ] && emit_deployment_verified idp "https://sso.nebutra.com/.well-known/openid-configuration"
           [ "${{ needs.detect-changes.outputs['design-docs'] }}" = "true" ] && emit_deployment_verified design-docs "https://design.nebutra.com"
+          [ "${{ needs.detect-changes.outputs.pebble }}" = "true" ] && emit_deployment_verified pebble "https://pebble.nebutra.com"
           [ "${{ needs.detect-changes.outputs['sailor-docs'] }}" = "true" ] && emit_deployment_verified sailor-docs "https://docs.nebutra.com"
 
       - name: Rollback Cloud VM on deploy or smoke failure

--- a/apps/pebble/README.md
+++ b/apps/pebble/README.md
@@ -2,27 +2,38 @@
 
 Brand front for **https://pebble.nebutra.com**.
 
-## Role
+## Production topology (2026-07-30)
+
+| Layer | Value |
+|-------|--------|
+| DNS | Cloudflare **A** `pebble` → `106.15.4.31` (Proxied) — same pattern as `app` / `api` |
+| Origin | ECS PM2 process `pebble` on `127.0.0.1:3017` |
+| Edge | `infra/runtime/nginx/conf.d/pebble.nebutra.com.conf` |
+
+Vercel is **not** the production path for this host (Hobby deploy caps; owner chose unified ECS origin).
+
+## Routes
 
 | Surface | Behavior |
 |---------|----------|
-| `/`, `/download` | Marketing / download (static) |
-| `/whats-new/*.json`, `/media/*` | Machine-consumed static feeds — **no redirects** |
-| `/docs/*` | 301 → `https://docs.nebutra.com/pebble/*` |
-| `POST /v1/feedback`, `/diagnostics/*` | Vercel rewrite → `api.nebutra.com/pebble/*` (legacy clients only) |
+| `/`, `/download` | Next app (marketing / download) |
+| `/whats-new/*.json`, `/media/*` | Static feeds from the app — **no client redirects** |
+| `/docs/*` | nginx 301 → `https://docs.nebutra.com/pebble/*` |
+| `POST /v1/feedback`, `/diagnostics/*` | nginx reverse-proxy → `api-gateway` `/pebble/*` (legacy clients) |
 
-This app has **no database and no first-party API**. Canonical feedback and diagnostics live on the shared gateway under `/pebble`.
-
-Topology: Sailor `docs/DOMAINS.md` · Pebble `docs/reference/infra-index.md`.
+Canonical machine endpoints remain `https://api.nebutra.com/pebble/*`.
 
 ## Local
 
 ```bash
-pnpm --filter @nebutra/pebble-site dev
+pnpm --filter @nebutra/pebble-site dev   # :3017
 ```
 
 ## Deploy
 
-- DNS: `CNAME pebble → cname.vercel-dns.com` (proxied) via `point-pebble-dns.yml`
-- Vercel project: `nebutra-pebble` · root `apps/pebble` · domain `pebble.nebutra.com`
-- Workflow: `.github/workflows/deploy-pebble-vercel.yml`
+```bash
+# From Nebutra-Sailor, after merge to main:
+gh workflow run "Deploy ECS" -R Nebutra/Nebutra-Sailor -f apps=pebble
+```
+
+Requires `NEXT_OUTPUT=standalone` at build time (set by `deploy-ecs.yml`).

--- a/apps/pebble/next.config.ts
+++ b/apps/pebble/next.config.ts
@@ -1,17 +1,20 @@
 import type { NextConfig } from "next";
 
 /**
- * Pebble brand front — static marketing + download + machine-consumed feeds.
+ * Pebble brand front — landing / download / static feeds.
  *
- * Product API lives on api.nebutra.com/pebble/* (ECS). This origin only
- * reverse-proxies legacy POST paths for one release cycle of desktop clients
- * that still target pebble.nebutra.com/v1/feedback (see vercel.json rewrites).
+ * Production topology (owner choice, 2026-07-30): CF A → ECS 106.15.4.31.
+ * nginx `pebble.nebutra.com` proxies here (PM2 :3017) and reverse-proxies
+ * legacy POST /v1/feedback + /diagnostics/* to api-gateway `/pebble/*`.
+ * Docs stay on docs.nebutra.com/pebble/* (nginx 301 from /docs/*).
  *
- * Docs are canonical on docs.nebutra.com/pebble/*; /docs/* permanently redirects.
+ * `output: "standalone"` is gated so local/Vercel builds skip the trace cost;
+ * ECS deploy sets NEXT_OUTPUT=standalone.
  */
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
+  output: process.env.NEXT_OUTPUT === "standalone" ? "standalone" : undefined,
 };
 
 export default nextConfig;

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -17,7 +17,7 @@
 | `router.nebutra.com` | router | **Nebutra Router** — model fabric / OpenAI-compatible product edge (ECS PM2) |
 | `forge.nebutra.com` | forge | **Nebutra Forge** — tool station + Agent tool API (Vercel; ECS PM2 fallback :3105) |
 | `admin.nebutra.com` | admin | **Ecosystem control plane** — staff-only (Cloudflare Access + `sso` OIDC + platform-staff role). Never tenant-visible. See [PRD](./plans/2026-07-28-nebutra-admin-control-plane-design.md) |
-| `pebble.nebutra.com` | (external repo `Nebutra/pebble`) | **Pebble brand front** — landing / download / docs redirect only. No backend of its own. |
+| `pebble.nebutra.com` | `apps/pebble` + external repo `Nebutra/pebble` | **Pebble brand front** — landing / download / feeds on ECS; product API on shared gateway |
 | `carina.nebutra.com` | (external repo `Nebutra/carina` → `apps/docs`) | **Carina product docs** — Astro + Starlight static site. No backend of its own. |
 
 > Router/Forge: product hosts; supply engines (New-API, Sub2API) stay **internal** — see `infra/nebutra-router/`.
@@ -29,7 +29,7 @@ brand front gets a host; everything transactional runs on the shared platform ho
 
 | Capability | Host + path |
 |---|---|
-| Landing / download | `pebble.nebutra.com` (CF CNAME, static/redirect only) |
+| Landing / download | `pebble.nebutra.com` (CF A → ECS PM2 `pebble` :3017) |
 | Docs | `docs.nebutra.com/pebble/*` — canonical; `pebble.nebutra.com/docs/*` redirects here |
 | Feedback | `POST api.nebutra.com/pebble/v1/feedback` |
 | Diagnostics | `POST api.nebutra.com/pebble/diagnostics/{token,upload,delete/:ticketId}` |
@@ -94,7 +94,7 @@ Single source of truth for *where traffic lands today*. Do not invent a second s
 | `router.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `router` | Product edge :3106; Vercel project `nebutra-router` exists for future cutover |
 | `forge.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `forge` | Product edge :3105; Vercel project `nebutra-forge` exists (Hobby deploy cap) |
 | `admin.nebutra.com` | **not yet created** | **ECS PM2** `admin` :3108 (PM2 slot reserved, not deployed) | Blocked on the Cloudflare Access policy + OIDC gate — do not create the DNS record before both exist. No Vercel project by design |
-| `pebble.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `@nebutra/pebble-site` (`apps/pebble`) | Brand front only. Deploy: `deploy-pebble-vercel.yml`. DNS: `point-pebble-dns.yml`. API stays on `api.nebutra.com/pebble/*`. |
+| `pebble.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `pebble` :3017 | Brand front. Owner topology 2026-07-30: same ECS A pattern as app/api (not Vercel). nginx `conf.d/pebble.nebutra.com.conf`. Deploy: `deploy-ecs.yml` apps=`pebble`. Legacy `POST /v1/feedback` + `/diagnostics/*` reverse-proxy to api-gateway `/pebble/*`. |
 | `carina.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `nebutra-carina` (`prj_JN4csIJFkFiz1qoQCSYPXucmuJRx`, `Nebutra/carina` `apps/docs`) | Product docs only. Deploy: `deploy-carina-vercel.yml` (bootstrap) or carina `deploy-docs-vercel.yml`. DNS: `point-carina-dns.yml`. Requires CF token **Zone DNS Edit**; Hobby deploys hit `api-deployments-free-per-day`. |
 
 ### Topology layers
@@ -143,7 +143,7 @@ A       router    106.15.4.31              ✅           ECS PM2 @nebutra/router
 A       forge     106.15.4.31              ✅           ECS PM2 @nebutra/forge
 A       admin     106.15.4.31              ✅           ECS PM2 @nebutra/admin — create ONLY together with the Cloudflare Access policy
 CNAME   docs      nebutra-sailor-docs.nebutra.workers.dev  ✅  # OpenNext Worker; Vercel grey-cloud is fallback only
-CNAME   pebble    cname.vercel-dns.com     ✅           Pebble brand front (landing/download); no backend
+A       pebble    106.15.4.31              ✅           Pebble brand front (ECS PM2 :3017); not Vercel
 CNAME   carina    cname.vercel-dns.com     ✅           Carina product docs (Nebutra/carina apps/docs); no backend
 ```
 
@@ -187,7 +187,7 @@ Unauthenticated product routes: `auth.nebutra.com/sign-in?returnTo=https://app.n
 |---------|------|-----------|
 | landing | `apps/landing` | `nebutra.com`, `www` |
 | docs | `apps/sailor-docs` | `docs.nebutra.com` |
-| nebutra-pebble | `apps/pebble` | `pebble.nebutra.com` |
+| ~~nebutra-pebble~~ | `apps/pebble` | Superseded by ECS PM2 (kept only if Hobby quota is free for experiments) |
 | nebutra-auth | `apps/auth` | `auth.nebutra.com` (ready; DNS may still be ECS) |
 | nebutra-web | `apps/web` | `app.nebutra.com` (ready; DNS may still be ECS) |
 

--- a/infra/iac/ecs/ecosystem.config.cjs
+++ b/infra/iac/ecs/ecosystem.config.cjs
@@ -8,6 +8,7 @@
 //   $DEPLOY_ROOT/idp/current/apps/idp/server.js                  (Next standalone)
 //   $DEPLOY_ROOT/auth/current/apps/auth/server.js                (Next standalone login center)
 //   $DEPLOY_ROOT/design-docs/current/apps/design-docs/server.js  (Next standalone)
+//   $DEPLOY_ROOT/pebble/current/apps/pebble/server.js            (Next standalone brand front)
 //   $DEPLOY_ROOT/sailor-docs/current/apps/sailor-docs/server.js  (Next standalone)
 //   $DEPLOY_ROOT/router/current/apps/router/server.js            (Next standalone)
 //   $DEPLOY_ROOT/forge/current/apps/forge/server.js              (Next standalone)
@@ -61,6 +62,25 @@ module.exports = {
         HOSTNAME: "127.0.0.1",
       },
       max_memory_restart: "400M",
+      instances: 1,
+      exec_mode: "fork",
+      autorestart: true,
+      max_restarts: 10,
+      kill_timeout: 8000,
+      listen_timeout: 10000,
+    },
+    {
+      // Pebble brand front — marketing / download / whats-new feeds.
+      // Fronted by nginx conf.d/pebble.nebutra.com.conf (A → ECS, CF proxied).
+      name: "pebble",
+      cwd: "/var/www/nebutra/pebble/current",
+      script: "apps/pebble/server.js",
+      env: {
+        NODE_ENV: "production",
+        PORT: 3017,
+        HOSTNAME: "127.0.0.1",
+      },
+      max_memory_restart: "300M",
       instances: 1,
       exec_mode: "fork",
       autorestart: true,

--- a/infra/ops/dns/topology.defaults.yaml
+++ b/infra/ops/dns/topology.defaults.yaml
@@ -9,10 +9,11 @@ mail:
     imap: "imap.qiye.aliyun.com"
     pop3: "pop.qiye.aliyun.com"
     smtp: "smtp.qiye.aliyun.com"
-ecs_surfaces: [app, auth, api, sso, router, forge, design, status, admin]
-# Brand / product fronts on Vercel — static + redirects, no ECS origin.
+# Pebble brand front is ECS (same A pattern as app/api) — owner topology 2026-07-30.
+ecs_surfaces: [app, auth, api, sso, router, forge, design, status, admin, pebble]
+# Remaining brand/docs fronts on Vercel (no ECS origin).
 # Hosts come from brand.domains via `pnpm dns:render` (vercel_surfaces keys).
-vercel_surfaces: [pebble, carina]
+vercel_surfaces: [carina]
 proxy:
   proxied:
     [

--- a/infra/ops/scripts/ecs-deploy-remote.sh
+++ b/infra/ops/scripts/ecs-deploy-remote.sh
@@ -26,7 +26,7 @@ DEPLOY_ROOT="${DEPLOY_ROOT:-/var/www/nebutra}"
 # invocation deploys, and the control plane should move only when someone names
 # it — it reads across every tenant, so an accidental redeploy is not the same
 # kind of event as one for a product app.
-APPS="${APPS:-landing web api idp auth design-docs sailor-docs router forge}"
+APPS="${APPS:-landing web api idp auth design-docs pebble sailor-docs router forge}"
 # Keep 2 releases per app for one-step rollback. Pre/post prune only touch
 # THAT app's releases/ dir (never other apps). Override with VM_KEEP_RELEASES
 # / ECS_KEEP_RELEASES on small disks if needed.
@@ -89,8 +89,8 @@ log()  { echo "[$(date -u +%H:%M:%S)] $*"; }
 fail() { echo "::error:: $*" >&2; exit 1; }
 
 case "$APPS" in
-  *landing*|*web*|*api*|*idp*|*auth*|*design-docs*|*sailor-docs*|*router*|*forge*|*admin*) : ;;
-  *) fail "APPS must contain at least one of: landing web api idp auth design-docs sailor-docs router forge admin (got: $APPS)" ;;
+  *landing*|*web*|*api*|*idp*|*auth*|*design-docs*|*pebble*|*sailor-docs*|*router*|*forge*|*admin*) : ;;
+  *) fail "APPS must contain at least one of: landing web api idp auth design-docs pebble sailor-docs router forge admin (got: $APPS)" ;;
 esac
 
 mkdir -p "$DEPLOY_ROOT"
@@ -1230,6 +1230,9 @@ for p in procs:
     design-docs)
       wait_for_local_http "design-docs" "$pm2_name" "http://127.0.0.1:3004/"
       ;;
+    pebble)
+      wait_for_local_http "pebble" "$pm2_name" "http://127.0.0.1:3017/"
+      ;;
     sailor-docs)
       wait_for_local_http "sailor-docs" "$pm2_name" "http://127.0.0.1:3005/"
       ;;
@@ -1281,6 +1284,7 @@ pm2_name_for_app() {
     idp)          printf '%s\n' "idp" ;;
     auth)         printf '%s\n' "auth-center" ;;
     design-docs)  printf '%s\n' "design-docs" ;;
+    pebble)       printf '%s\n' "pebble" ;;
     sailor-docs)  printf '%s\n' "sailor-docs" ;;
     router)       printf '%s\n' "router" ;;
     forge)        printf '%s\n' "forge" ;;
@@ -1543,7 +1547,7 @@ verify_nginx_web_origin() {
 
 run_selected_apps() {
   local action="$1" app pm2_name
-  for app in api landing web idp auth design-docs sailor-docs router forge admin; do
+  for app in api landing web idp auth design-docs pebble sailor-docs router forge admin; do
     case " $APPS " in
       *" $app "*) : ;;
       *) continue ;;
@@ -1561,7 +1565,7 @@ if [ "$MODE" = "rollback" ]; then
   exit 0
 fi
 
-for app in api landing web idp auth design-docs sailor-docs router forge admin; do
+for app in api landing web idp auth design-docs pebble sailor-docs router forge admin; do
   case " $APPS " in
     *" $app "*) : ;;
     *) continue ;;
@@ -1574,6 +1578,7 @@ for app in api landing web idp auth design-docs sailor-docs router forge admin; 
     idp)          deploy_one idp         idp          ;;
     auth)         deploy_one auth        auth-center  ;;
     design-docs)  deploy_one design-docs design-docs  ;;
+    pebble)       deploy_one pebble      pebble       ;;
     sailor-docs)  deploy_one sailor-docs sailor-docs  ;;
     router)       deploy_one router      router       ;;
     forge)        deploy_one forge       forge        ;;

--- a/infra/runtime/nginx/conf.d/pebble.nebutra.com.conf
+++ b/infra/runtime/nginx/conf.d/pebble.nebutra.com.conf
@@ -1,0 +1,123 @@
+# pebble.nebutra.com — Pebble brand front (landing / download / static feeds)
+# Origin: PM2 app `pebble` on 127.0.0.1:3017
+#
+# DNS is A → ECS (same as app/api/auth), CF orange-cloud. Without this vhost the
+# Host falls through to the default 443 block and 301s to nebutra.com even when
+# the brand app would be healthy on :3017.
+#
+# Legacy desktop clients still POST /v1/feedback and /diagnostics/* on this host;
+# those paths reverse-proxy to the platform API namespace without client-visible
+# redirects. Canonical machine endpoints are api.nebutra.com/pebble/*.
+
+upstream nebutra_pebble {
+    server 127.0.0.1:3017;
+    keepalive 16;
+}
+
+upstream nebutra_pebble_api {
+    server 127.0.0.1:3002;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name pebble.nebutra.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        try_files $uri =404;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name pebble.nebutra.com;
+
+    ssl_certificate     /etc/ssl/nebutra/fullchain.pem;
+    ssl_certificate_key /etc/ssl/nebutra/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    # Do NOT redirect this host to nebutra.com — it is the Pebble product origin.
+
+    # Human docs: permanent redirect to platform docs namespace (preserve suffix).
+    location = /docs {
+        return 301 https://docs.nebutra.com/pebble;
+    }
+    location /docs/ {
+        rewrite ^/docs/(.*)$ https://docs.nebutra.com/pebble/$1 permanent;
+    }
+
+    # Legacy support intake — method + body preserved, no client redirect.
+    location = /v1/feedback {
+        proxy_pass http://nebutra_pebble_api/pebble/v1/feedback;
+        proxy_http_version 1.1;
+        proxy_set_header Host api.nebutra.com;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Connection "";
+        proxy_read_timeout 30s;
+        client_max_body_size 256k;
+    }
+
+    location /diagnostics/ {
+        proxy_pass http://nebutra_pebble_api/pebble/diagnostics/;
+        proxy_http_version 1.1;
+        proxy_set_header Host api.nebutra.com;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Connection "";
+        proxy_read_timeout 60s;
+        client_max_body_size 5m;
+    }
+
+    location /_next/static/ {
+        proxy_pass http://nebutra_pebble;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+    }
+
+    # Machine-consumed feeds — short cache, no redirect.
+    location /whats-new/ {
+        proxy_pass http://nebutra_pebble;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        add_header Cache-Control "public, max-age=60, s-maxage=300, stale-while-revalidate=600" always;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /media/ {
+        proxy_pass http://nebutra_pebble;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+    }
+
+    location / {
+        proxy_pass http://nebutra_pebble;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Connection "";
+        proxy_read_timeout 60s;
+        add_header Cache-Control "public, s-maxage=60, stale-while-revalidate=120" always;
+    }
+}

--- a/infra/runtime/nginx/nginx-ecs-current.conf
+++ b/infra/runtime/nginx/nginx-ecs-current.conf
@@ -613,4 +613,8 @@ http {
     include /etc/nginx/conf.d/router.nebutra.com.conf;
     # Nebutra Sailor Docs (PM2 :3005)
     include /etc/nginx/conf.d/docs.nebutra.com.conf;
+    # Design system docs (PM2 :3004)
+    include /etc/nginx/conf.d/design.nebutra.com.conf;
+    # Pebble brand front (PM2 :3017) — A record → ECS, not Vercel
+    include /etc/nginx/conf.d/pebble.nebutra.com.conf;
 }

--- a/infra/runtime/nginx/nginx.conf
+++ b/infra/runtime/nginx/nginx.conf
@@ -670,7 +670,11 @@ http {
     }
 
     # Product vhosts shipped as conf.d fragments (deploy must scp + install them).
-    # Without this include, forge.nebutra.com falls through to the default 443
-    # server and 301s to nebutra.com even when PM2 :3105 is healthy.
+    # Without this include, product hosts fall through to the default 443
+    # server and 301s to nebutra.com even when PM2 is healthy.
     include /etc/nginx/conf.d/forge.nebutra.com.conf;
+    include /etc/nginx/conf.d/router.nebutra.com.conf;
+    include /etc/nginx/conf.d/docs.nebutra.com.conf;
+    include /etc/nginx/conf.d/design.nebutra.com.conf;
+    include /etc/nginx/conf.d/pebble.nebutra.com.conf;
 }


### PR DESCRIPTION
## Summary
Owner topology: `pebble.nebutra.com` is **A → 106.15.4.31** (same as app/api), not Vercel CNAME.

- nginx `conf.d/pebble.nebutra.com.conf` → PM2 `pebble` :3017
- Legacy `/v1/feedback` + `/diagnostics/*` reverse-proxy to api-gateway `/pebble/*`
- `/docs/*` → 301 docs.nebutra.com/pebble/*
- `deploy-ecs.yml` + ecosystem + remote helper know app `pebble`
- DOMAINS + topology.defaults updated

## Deploy
```bash
gh workflow run "Deploy to Cloud VM (PM2 Manual Fallback)" -f apps=pebble
```