### PR TITLE
ops(carina): ECS A-record topology + static nginx docs

### DIFF
--- a/.github/workflows/deploy-carina-ecs.yml
+++ b/.github/workflows/deploy-carina-ecs.yml
@@ -1,0 +1,106 @@
+name: Deploy Carina docs (ECS)
+
+# Owner topology 2026-07-30: carina.nebutra.com is A → ECS (CF proxied), same
+# pattern as pebble — not Vercel. Builds Nebutra/carina apps/docs and rsyncs
+# static dist/ to the box; nginx serves /var/www/nebutra/carina/current.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Carina git ref to deploy"
+        required: true
+        default: main
+  push:
+    branches: [main]
+    paths:
+      - "infra/ops/scripts/deploy-carina-docs-ecs.sh"
+      - "infra/runtime/nginx/conf.d/carina.nebutra.com.conf"
+      - "infra/runtime/nginx/nginx-ecs-current.conf"
+      - ".github/workflows/deploy-carina-ecs.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-carina-ecs
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build + rsync carina docs to ECS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sailor (scripts + nginx)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Checkout Carina
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: Nebutra/carina
+          ref: ${{ inputs.ref || 'main' }}
+          path: carina
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.13.1 --activate
+
+      - name: Configure SSH
+        env:
+          ECS_SSH_PRIVATE_KEY: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
+          ECS_SSH_KNOWN_HOSTS: ${{ secrets.ECS_SSH_KNOWN_HOSTS }}
+          ECS_HOST: ${{ vars.ECS_HOST || '106.15.4.31' }}
+          ECS_USER: ${{ vars.ECS_USER || 'root' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ECS_SSH_PRIVATE_KEY:-}" ]; then
+            echo "::error::ECS_SSH_PRIVATE_KEY is not set"; exit 1
+          fi
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$ECS_SSH_PRIVATE_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          if [ -n "${ECS_SSH_KNOWN_HOSTS:-}" ]; then
+            printf '%s\n' "$ECS_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan -H "$ECS_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          fi
+          cat >> ~/.ssh/config <<EOF
+          Host carina-ecs
+            HostName ${ECS_HOST}
+            User ${ECS_USER}
+            IdentityFile ~/.ssh/id_deploy
+            StrictHostKeyChecking accept-new
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Deploy
+        env:
+          CARINA_REPO_DIR: ${{ github.workspace }}/carina
+          REMOTE_HOST: carina-ecs
+        run: bash infra/ops/scripts/deploy-carina-docs-ecs.sh
+
+      - name: Smoke public host
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5 6 7 8; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "https://carina.nebutra.com/?ci=${GITHUB_SHA}" || echo 000)
+            llms=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "https://carina.nebutra.com/llms.txt" || echo 000)
+            loc=$(curl -sSI --max-time 15 "https://carina.nebutra.com/" 2>/dev/null | tr -d '\r' | awk 'tolower($1)=="location:"{print $2; exit}')
+            echo "attempt $i home=$code llms=$llms location=${loc:-none}"
+            if [ "$code" = "200" ] && [ "$llms" = "200" ]; then
+              case "${loc:-}" in
+                https://nebutra.com/*|https://nebutra.com) echo "::error::still redirecting to apex"; exit 1 ;;
+              esac
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::carina.nebutra.com not healthy (need nginx vhost + dist on ECS)"
+          exit 1

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -61,23 +61,23 @@ and do **not** get a parallel `api.carina.*` origin.
 
 | Capability | Host + path |
 |---|---|
-| Product docs / LLM surface | `carina.nebutra.com` (CF CNAME → Vercel, proxied) |
+| Product docs / LLM surface | `carina.nebutra.com` (**CF A → ECS** `106.15.4.31`, proxied — same pattern as pebble) |
 | Skills / catalog URLs | `carina.nebutra.com/llms.txt`, `/data/rpc-catalog-*.json` |
 | Staging | **no host** — preview deploys / project isolation only |
 
-**Deploy ownership (two paths, one project):**
+**Owner topology (2026-07-30):** DNS **A** record is correct — do **not** point carina at Vercel CNAME.
+nginx `conf.d/carina.nebutra.com.conf` serves static files from
+`/var/www/nebutra/carina/current`. Without that vhost the Host falls through to
+the default 443 block and 301s to `nebutra.com`.
 
-| Path | When |
-|---|---|
-| Platform bootstrap | This monorepo: `deploy-carina-vercel.yml` (checks out `Nebutra/carina`, uses Sailor `VERCEL_*`) |
-| Product day-2 | Carina repo: `deploy-docs-vercel.yml` once `VERCEL_TOKEN` + `VERCEL_ORG_ID` are mirrored |
+**Deploy:** `deploy-carina-ecs.yml` / `infra/ops/scripts/deploy-carina-docs-ecs.sh`
+(checks out `Nebutra/carina`, builds `apps/docs`, rsyncs `dist/`, reloads nginx).
 
-Vercel project: `nebutra-carina` · root `apps/docs` · domain `carina.nebutra.com`.
+Legacy Vercel experiment (`nebutra-carina`, `deploy-carina-vercel.yml`) is
+superseded — keep only if Hobby quota is free for experiments.
 
-**DNS** for the shared `nebutra.com` zone is owned here only: `point-carina-dns.yml` +
-`infra/ops/scripts/point-carina-dns-vercel.sh` → CNAME `cname.vercel-dns.com` (proxied).
-
-**Bring-up order:** (1) `Deploy Carina docs (Vercel)` (2) `Point carina DNS to Vercel` (3) smoke `/` + `/llms.txt`.
+**Bring-up order:** (1) DNS A → ECS (already true) (2) Deploy Carina docs (ECS)
+(3) smoke `/` + `/llms.txt` (must not 301 to apex).
 
 ## Production truth (as of 2026-07-22)
 
@@ -95,7 +95,7 @@ Single source of truth for *where traffic lands today*. Do not invent a second s
 | `forge.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `forge` | Product edge :3105; Vercel project `nebutra-forge` exists (Hobby deploy cap) |
 | `admin.nebutra.com` | **not yet created** | **ECS PM2** `admin` :3108 (PM2 slot reserved, not deployed) | Blocked on the Cloudflare Access policy + OIDC gate — do not create the DNS record before both exist. No Vercel project by design |
 | `pebble.nebutra.com` | A `106.15.4.31` proxied | **ECS PM2** `pebble` :3017 | Brand front. Owner topology 2026-07-30: same ECS A pattern as app/api (not Vercel). nginx `conf.d/pebble.nebutra.com.conf`. Deploy: `deploy-ecs.yml` apps=`pebble`. Legacy `POST /v1/feedback` + `/diagnostics/*` reverse-proxy to api-gateway `/pebble/*`. |
-| `carina.nebutra.com` | CNAME → `cname.vercel-dns.com` proxied | **Vercel** `nebutra-carina` (`prj_JN4csIJFkFiz1qoQCSYPXucmuJRx`, `Nebutra/carina` `apps/docs`) | Product docs only. Deploy: `deploy-carina-vercel.yml` (bootstrap) or carina `deploy-docs-vercel.yml`. DNS: `point-carina-dns.yml`. Requires CF token **Zone DNS Edit**; Hobby deploys hit `api-deployments-free-per-day`. |
+| `carina.nebutra.com` | A `106.15.4.31` proxied | **ECS nginx static** `/var/www/nebutra/carina/current` | Product docs (Astro). Owner topology 2026-07-30: same ECS A as pebble. nginx `conf.d/carina.nebutra.com.conf`. Deploy: `deploy-carina-ecs.yml`. |
 
 ### Topology layers
 
@@ -144,7 +144,7 @@ A       forge     106.15.4.31              ✅           ECS PM2 @nebutra/forge
 A       admin     106.15.4.31              ✅           ECS PM2 @nebutra/admin — create ONLY together with the Cloudflare Access policy
 CNAME   docs      nebutra-sailor-docs.nebutra.workers.dev  ✅  # OpenNext Worker; Vercel grey-cloud is fallback only
 A       pebble    106.15.4.31              ✅           Pebble brand front (ECS PM2 :3017); not Vercel
-CNAME   carina    cname.vercel-dns.com     ✅           Carina product docs (Nebutra/carina apps/docs); no backend
+A       carina    106.15.4.31              ✅           Carina product docs (ECS nginx static); not Vercel
 ```
 
 When cutting `app` / `auth` to Vercel: switch to `CNAME … cname.vercel-dns.com` (grey or orange per SSL plan) and remove the ECS A records.

--- a/infra/ops/dns/topology.defaults.yaml
+++ b/infra/ops/dns/topology.defaults.yaml
@@ -10,10 +10,11 @@ mail:
     pop3: "pop.qiye.aliyun.com"
     smtp: "smtp.qiye.aliyun.com"
 # Pebble brand front is ECS (same A pattern as app/api) — owner topology 2026-07-30.
-ecs_surfaces: [app, auth, api, sso, router, forge, design, status, admin, pebble]
-# Remaining brand/docs fronts on Vercel (no ECS origin).
-# Hosts come from brand.domains via `pnpm dns:render` (vercel_surfaces keys).
-vercel_surfaces: [carina]
+# Brand product fronts on ECS (same A pattern as app/api) — owner 2026-07-30.
+# pebble: PM2 Next; carina: nginx static Astro from Nebutra/carina apps/docs.
+ecs_surfaces: [app, auth, api, sso, router, forge, design, status, admin, pebble, carina]
+# No product brand fronts on Vercel.
+vercel_surfaces: []
 proxy:
   proxied:
     [

--- a/infra/ops/scripts/deploy-carina-docs-ecs.sh
+++ b/infra/ops/scripts/deploy-carina-docs-ecs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Deploy Carina product docs (static Astro) to ECS for carina.nebutra.com.
+#
+# Topology (owner 2026-07-30): DNS A → 106.15.4.31 (CF proxied), same as pebble.
+#
+#   REMOTE_HOST=root@106.15.4.31 bash infra/ops/scripts/deploy-carina-docs-ecs.sh
+set -euo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:-root@106.15.4.31}"
+REMOTE_APP_DIR="${REMOTE_APP_DIR:-/var/www/nebutra/carina}"
+RELEASE_ID="${RELEASE_ID:-$(date +%Y%m%d%H%M%S)}"
+DEPLOY_NGINX_CONF="${DEPLOY_NGINX_CONF:-1}"
+
+# infra/ops/scripts → ../../../ = monorepo root
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+NGINX_CONF="$ROOT_DIR/infra/runtime/nginx/conf.d/carina.nebutra.com.conf"
+
+if [ -n "${CARINA_REPO_DIR:-}" ]; then
+  CARINA_DIR="$CARINA_REPO_DIR"
+elif [ -d "${GITHUB_WORKSPACE:-}/carina/apps/docs" ]; then
+  CARINA_DIR="${GITHUB_WORKSPACE}/carina"
+elif [ -d "$ROOT_DIR/../carina/apps/docs" ]; then
+  CARINA_DIR="$(cd "$ROOT_DIR/../carina" && pwd)"
+else
+  echo "Set CARINA_REPO_DIR to a Nebutra/carina checkout with apps/docs" >&2
+  exit 1
+fi
+
+DOCS_DIR="$CARINA_DIR/apps/docs"
+STAGE_DIR="$ROOT_DIR/.deploy/carina-docs"
+
+log() { printf '[carina-docs] %s\n' "$1"; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing: $1" >&2; exit 1; }
+}
+
+require_cmd pnpm
+require_cmd rsync
+require_cmd ssh
+[ -d "$DOCS_DIR" ] || { echo "missing $DOCS_DIR" >&2; exit 1; }
+[ -f "$NGINX_CONF" ] || { echo "missing $NGINX_CONF" >&2; exit 1; }
+
+log "Building Carina docs in $DOCS_DIR"
+(
+  cd "$DOCS_DIR"
+  corepack enable 2>/dev/null || true
+  pnpm install --frozen-lockfile
+  pnpm run build
+)
+
+if [ ! -f "$DOCS_DIR/dist/index.html" ]; then
+  echo "no dist/index.html" >&2
+  exit 1
+fi
+
+log "Staging dist"
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+rsync -a --delete "$DOCS_DIR/dist/" "$STAGE_DIR/"
+
+log "Preparing remote $REMOTE_APP_DIR/releases/$RELEASE_ID"
+ssh "$REMOTE_HOST" "mkdir -p '$REMOTE_APP_DIR/releases/$RELEASE_ID'"
+
+log "Uploading"
+rsync -az --delete "$STAGE_DIR/" "$REMOTE_HOST:$REMOTE_APP_DIR/releases/$RELEASE_ID/"
+
+log "Activate release"
+ssh "$REMOTE_HOST" bash -s -- "$REMOTE_APP_DIR" "$RELEASE_ID" <<'REMOTE'
+set -euo pipefail
+REMOTE_APP_DIR="$1"
+RELEASE_ID="$2"
+ln -sfn "$REMOTE_APP_DIR/releases/$RELEASE_ID" "$REMOTE_APP_DIR/current"
+cd "$REMOTE_APP_DIR/releases"
+ls -1dt */ 2>/dev/null | tail -n +6 | xargs -r rm -rf
+echo "active=$(readlink -f "$REMOTE_APP_DIR/current")"
+REMOTE
+
+if [ "$DEPLOY_NGINX_CONF" = "1" ]; then
+  log "Install nginx vhost"
+  scp -q "$NGINX_CONF" "$REMOTE_HOST:/etc/nginx/conf.d/carina.nebutra.com.conf"
+  ssh "$REMOTE_HOST" 'nginx -t && (systemctl reload nginx || nginx -s reload)'
+fi
+
+log "Local smoke on origin"
+ssh "$REMOTE_HOST" "curl -sS -o /dev/null -w 'origin_http=%{http_code}\n' -H 'Host: carina.nebutra.com' --max-time 10 http://127.0.0.1/ || true"
+log "done — https://carina.nebutra.com/ (A → ECS)"

--- a/infra/runtime/nginx/conf.d/carina.nebutra.com.conf
+++ b/infra/runtime/nginx/conf.d/carina.nebutra.com.conf
@@ -1,0 +1,81 @@
+# carina.nebutra.com — Carina product docs (Astro + Starlight static)
+# Origin: nginx static root (no PM2). Built from Nebutra/carina apps/docs.
+#
+# DNS is A → ECS (same as app/api/pebble), CF orange-cloud. Without this vhost
+# the Host falls through to the default 443 block and 301s to nebutra.com.
+#
+# Deploy: infra/ops/scripts/deploy-carina-docs-ecs.sh (or deploy-carina-ecs.yml).
+# Site root on box: /var/www/nebutra/carina/current
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name carina.nebutra.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        try_files $uri =404;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name carina.nebutra.com;
+
+    ssl_certificate     /etc/ssl/nebutra/fullchain.pem;
+    ssl_certificate_key /etc/ssl/nebutra/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    # Do NOT redirect this host to nebutra.com — it is the Carina docs origin.
+    root /var/www/nebutra/carina/current;
+    index index.html;
+
+    location /_astro/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+        access_log off;
+    }
+
+    location /fonts/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable" always;
+        access_log off;
+    }
+
+    location = /llms.txt {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=300, s-maxage=600" always;
+        add_header Access-Control-Allow-Origin "*" always;
+        default_type text/plain;
+    }
+
+    location = /llms-full.txt {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=300, s-maxage=600" always;
+        add_header Access-Control-Allow-Origin "*" always;
+        default_type text/plain;
+    }
+
+    location /data/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=300, s-maxage=600" always;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location / {
+        try_files $uri $uri/ $uri/index.html =404;
+        add_header Cache-Control "public, s-maxage=60, stale-while-revalidate=300" always;
+    }
+
+    error_page 404 /404.html;
+    location = /404.html {
+        internal;
+    }
+}

--- a/infra/runtime/nginx/nginx-ecs-current.conf
+++ b/infra/runtime/nginx/nginx-ecs-current.conf
@@ -617,4 +617,6 @@ http {
     include /etc/nginx/conf.d/design.nebutra.com.conf;
     # Pebble brand front (PM2 :3017) — A record → ECS, not Vercel
     include /etc/nginx/conf.d/pebble.nebutra.com.conf;
+    # Carina product docs (static Astro) — A record → ECS, not Vercel
+    include /etc/nginx/conf.d/carina.nebutra.com.conf;
 }

--- a/tests/architecture/carina-domain-closure.test.ts
+++ b/tests/architecture/carina-domain-closure.test.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -7,9 +6,8 @@ import { getBrandOrigin, getBrandPublicUrls } from "../../packages/design/brand/
 import { DEFAULT_BRAND } from "../../scripts/brand-types";
 
 /**
- * Contract lock for carina.nebutra.com — product docs front on Vercel,
- * zone DNS owned by this monorepo. Prevents silent drift between brand SSOT,
- * topology, workflows, and docs/DOMAINS.md.
+ * Contract lock for carina.nebutra.com — product docs on ECS (A record),
+ * nginx static root. Owner topology 2026-07-30 (same pattern as pebble).
  */
 describe("carina domain closure", () => {
   it("brand SSOT carries carina.nebutra.com", () => {
@@ -19,57 +17,46 @@ describe("carina domain closure", () => {
     expect(getBrandPublicUrls().carinaUrl).toBe("https://carina.nebutra.com");
   });
 
-  it("topology lists carina as a vercel surface (not ECS)", () => {
+  it("topology lists carina as an ECS surface (not Vercel)", () => {
     const raw = readFileSync("infra/ops/dns/topology.defaults.yaml", "utf-8");
-    expect(raw).toMatch(/vercel_surfaces:.*\[.*carina/);
+    expect(raw).toMatch(/ecs_surfaces:.*\[.*carina/);
     expect(raw).toMatch(/^\s*carina,/m);
-    expect(raw).not.toMatch(/ecs_surfaces:.*carina/);
+    // vercel_surfaces must not claim carina
+    const vercelLine = raw.split("\n").find((l) => l.startsWith("vercel_surfaces:"));
+    expect(vercelLine ?? "").not.toMatch(/carina/);
   });
 
-  it("DOMAINS.md documents host, deploy, and no parallel origin", () => {
+  it("DOMAINS.md documents ECS A topology and no parallel origin", () => {
     const domains = readFileSync("docs/DOMAINS.md", "utf-8");
     expect(domains).toContain("carina.nebutra.com");
-    expect(domains).toContain("nebutra-carina");
-    expect(domains).toContain("point-carina-dns");
-    expect(domains).toContain("deploy-carina-vercel");
+    expect(domains).toContain("106.15.4.31");
+    expect(domains).toContain("deploy-carina-ecs");
     expect(domains).toMatch(/api\.carina\.\*/);
     expect(domains).toContain("Nebutra/carina");
+    expect(domains).toMatch(/A.*carina|carina.*ECS/i);
   });
 
-  it("ops scripts and workflows exist and are executable paths", () => {
-    const script = join(process.cwd(), "infra/ops/scripts/point-carina-dns-vercel.sh");
-    const dnsWf = join(process.cwd(), ".github/workflows/point-carina-dns.yml");
-    const deployWf = join(process.cwd(), ".github/workflows/deploy-carina-vercel.yml");
+  it("nginx vhost + deploy script + workflow exist", () => {
+    const conf = join(process.cwd(), "infra/runtime/nginx/conf.d/carina.nebutra.com.conf");
+    const script = join(process.cwd(), "infra/ops/scripts/deploy-carina-docs-ecs.sh");
+    const deployWf = join(process.cwd(), ".github/workflows/deploy-carina-ecs.yml");
+    const mainNginx = join(process.cwd(), "infra/runtime/nginx/nginx-ecs-current.conf");
+
+    expect(existsSync(conf), conf).toBe(true);
     expect(existsSync(script), script).toBe(true);
-    expect(existsSync(dnsWf), dnsWf).toBe(true);
     expect(existsSync(deployWf), deployWf).toBe(true);
 
-    const scriptBody = readFileSync(script, "utf-8");
-    expect(scriptBody).toContain("carina");
-    expect(scriptBody).toContain("cname.vercel-dns.com");
+    const confBody = readFileSync(conf, "utf-8");
+    expect(confBody).toContain("server_name carina.nebutra.com");
+    expect(confBody).toContain("/var/www/nebutra/carina/current");
+    expect(confBody).not.toMatch(/return 301 https:\/\/nebutra\.com/);
+
+    const main = readFileSync(mainNginx, "utf-8");
+    expect(main).toContain("carina.nebutra.com.conf");
 
     const deploy = readFileSync(deployWf, "utf-8");
     expect(deploy).toContain("Nebutra/carina");
-    expect(deploy).toContain("apps/docs");
-    expect(deploy).toContain("nebutra-carina");
-    expect(deploy).toContain("carina.nebutra.com");
-
-    const dns = readFileSync(dnsWf, "utf-8");
-    expect(dns).toContain("point-carina-dns-vercel.sh");
-  });
-
-  it("dns:render emits a carina CNAME when topology is loaded", () => {
-    // Dry-run render logic: brand + topology must resolve carina → www_cname
-    const topo = readFileSync("infra/ops/dns/topology.defaults.yaml", "utf-8");
-    expect(topo).toMatch(/www_cname:\s*"cname\.vercel-dns\.com"/);
-    expect(DEFAULT_BRAND.domains.carina.startsWith("carina.")).toBe(true);
-
-    // Script stays tracked (gitignored zone files are not)
-    const tracked = execSync("git ls-files infra/ops/scripts/point-carina-dns-vercel.sh", {
-      encoding: "utf-8",
-    }).trim();
-    // Untracked until commit — still require file on disk
-    expect(existsSync("infra/ops/scripts/point-carina-dns-vercel.sh")).toBe(true);
-    void tracked;
+    expect(deploy).toContain("deploy-carina-docs-ecs.sh");
+    expect(deploy).toContain("ECS_SSH_PRIVATE_KEY");
   });
 });


### PR DESCRIPTION
## Summary
- **Topology correction:** `carina.nebutra.com` stays **A → ECS** (like pebble), not Vercel CNAME.
- nginx `conf.d/carina.nebutra.com.conf` serves Astro static from `/var/www/nebutra/carina/current`.
- Deploy: `deploy-carina-ecs.yml` builds `Nebutra/carina` `apps/docs` and rsyncs to the box.
- Update `docs/DOMAINS.md` + architecture contract tests.

## Why
Without a dedicated vhost, Host `carina.nebutra.com` falls through default 443 → 301 to apex even when DNS A is correct.