### PR TITLE
fix(pebble): self-host /docs (docs Worker 404 workaround)

### DIFF
--- a/apps/pebble/README.md
+++ b/apps/pebble/README.md
@@ -18,7 +18,7 @@ Vercel is **not** the production path for this host (Hobby deploy caps; owner ch
 |---------|----------|
 | `/`, `/download` | Next app (marketing / download) |
 | `/whats-new/*.json`, `/media/*` | Static feeds from the app — **no client redirects** |
-| `/docs/*` | nginx 301 → `https://docs.nebutra.com/pebble/*` |
+| `/docs/*` | Self-hosted docs on the brand app (until Sailor Docs Worker redeploys) |
 | `POST /v1/feedback`, `/diagnostics/*` | nginx reverse-proxy → `api-gateway` `/pebble/*` (legacy clients) |
 
 Canonical machine endpoints remain `https://api.nebutra.com/pebble/*`.

--- a/apps/pebble/src/app/docs/cli/overview/page.tsx
+++ b/apps/pebble/src/app/docs/cli/overview/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "CLI overview" };
+
+export default function Page() {
+  return (
+    <>
+      <h1>CLI overview</h1>
+      <p>
+        The <code>pebble</code> CLI scripts workspaces, agents, and automation from the terminal.
+        Install paths follow the desktop release channel (Homebrew cask, AppImage, etc.).
+      </p>
+      <pre>
+        <code>pebble --help</code>
+      </pre>
+    </>
+  );
+}

--- a/apps/pebble/src/app/docs/layout.tsx
+++ b/apps/pebble/src/app/docs/layout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+const NAV = [
+  { href: "/docs", label: "Overview" },
+  { href: "/docs/mobile", label: "Mobile" },
+  { href: "/docs/model/worktrees", label: "Worktrees" },
+  { href: "/docs/terminal", label: "Terminal" },
+  { href: "/docs/telemetry", label: "Privacy" },
+  { href: "/docs/ssh", label: "SSH" },
+  { href: "/docs/cli/overview", label: "CLI" },
+] as const;
+
+export default function DocsLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="docs-shell">
+      <aside className="docs-nav" aria-label="Docs">
+        <p className="docs-nav-title">Pebble docs</p>
+        <ul>
+          {NAV.map((item) => (
+            <li key={item.href}>
+              <a href={item.href}>{item.label}</a>
+            </li>
+          ))}
+        </ul>
+        <p className="docs-nav-note">
+          Canonical platform docs will also live at{" "}
+          <a href="https://docs.nebutra.com/pebble">docs.nebutra.com/pebble</a> once that Worker is
+          redeployed.
+        </p>
+      </aside>
+      <article className="docs-article prose">{children}</article>
+    </main>
+  );
+}

--- a/apps/pebble/src/app/docs/mobile/page.tsx
+++ b/apps/pebble/src/app/docs/mobile/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Mobile companion",
+};
+
+export default function DocsMobilePage() {
+  return (
+    <>
+      <h1>Mobile companion</h1>
+      <p>
+        Monitor and steer agents from your phone — get notified when a run finishes and send
+        follow-ups from anywhere.
+      </p>
+      <ul>
+        <li>
+          <strong>iOS:</strong>{" "}
+          <a href="https://apps.apple.com/us/app/pebble-ide/id6766130217">App Store</a> ·{" "}
+          <a href="https://testflight.apple.com/join/YjeGMQBA">TestFlight</a>
+        </li>
+        <li>
+          <strong>Android:</strong> APK builds ship on{" "}
+          <a href="https://github.com/Nebutra/pebble/releases">GitHub Releases</a>
+        </li>
+      </ul>
+      <p>
+        Pairing uses the local Pebble runtime (<code>pebble serve</code>, default port{" "}
+        <strong>6768</strong> on <code>127.0.0.1</code>). Public mobile traffic never exposes that
+        port; reach remote desktops over SSH tunnels when needed.
+      </p>
+      <pre>
+        <code>{`ssh -L 6768:127.0.0.1:6768 user@host`}</code>
+      </pre>
+    </>
+  );
+}

--- a/apps/pebble/src/app/docs/model/worktrees/page.tsx
+++ b/apps/pebble/src/app/docs/model/worktrees/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Parallel worktrees" };
+
+export default function Page() {
+  return (
+    <>
+      <h1>Parallel worktrees</h1>
+      <p>
+        Fan one prompt across multiple agents, each in its own isolated git worktree — compare
+        results and merge the winner.
+      </p>
+      <p>
+        Worktrees keep experiments off your primary checkout so you can run several agents without
+        stomping each other. Pebble tracks each worktree as a first-class workspace card.
+      </p>
+    </>
+  );
+}

--- a/apps/pebble/src/app/docs/page.tsx
+++ b/apps/pebble/src/app/docs/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Docs",
+  description: "Pebble product documentation",
+};
+
+export default function DocsHomePage() {
+  return (
+    <>
+      <h1>Pebble</h1>
+      <p>
+        Pebble is Nebutra&apos;s AI orchestrator for builders: run Codex, Claude Code, OpenCode, and
+        more side-by-side in isolated git worktrees from one desktop surface.
+      </p>
+
+      <h2>Where things live</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Surface</th>
+            <th>Host</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Product / download</td>
+            <td>
+              <a href="https://pebble.nebutra.com">pebble.nebutra.com</a>
+            </td>
+          </tr>
+          <tr>
+            <td>These docs</td>
+            <td>
+              <a href="https://pebble.nebutra.com/docs">pebble.nebutra.com/docs</a>
+            </td>
+          </tr>
+          <tr>
+            <td>Feedback &amp; diagnostics API</td>
+            <td>
+              <code>https://api.nebutra.com/pebble/*</code>
+            </td>
+          </tr>
+          <tr>
+            <td>Status</td>
+            <td>
+              <a href="https://status.nebutra.com">status.nebutra.com</a>
+            </td>
+          </tr>
+          <tr>
+            <td>Source &amp; releases</td>
+            <td>
+              <a href="https://github.com/Nebutra/pebble">github.com/Nebutra/pebble</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The brand front has no product database. Machine endpoints use the shared platform API under
+        the <code>/pebble</code> prefix.
+      </p>
+
+      <h2>Start here</h2>
+      <ul>
+        <li>
+          <a href="/download">Download</a>
+        </li>
+        <li>
+          <a href="/docs/mobile">Mobile companion</a>
+        </li>
+        <li>
+          <a href="/docs/model/worktrees">Parallel worktrees</a>
+        </li>
+        <li>
+          <a href="/docs/terminal">Terminal</a>
+        </li>
+        <li>
+          <a href="/docs/telemetry">Privacy &amp; telemetry</a>
+        </li>
+      </ul>
+    </>
+  );
+}

--- a/apps/pebble/src/app/docs/ssh/page.tsx
+++ b/apps/pebble/src/app/docs/ssh/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "SSH worktrees" };
+
+export default function Page() {
+  return (
+    <>
+      <h1>SSH worktrees</h1>
+      <p>
+        Run agents against remote machines over SSH without exposing Pebble&apos;s local control
+        ports to the public internet.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Service</th>
+            <th>Port</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>pebble-runtime</code>
+            </td>
+            <td>17777</td>
+          </tr>
+          <tr>
+            <td>
+              <code>pebble serve</code> / pairing
+            </td>
+            <td>6768</td>
+          </tr>
+        </tbody>
+      </table>
+      <pre>
+        <code>{`ssh -L 17777:127.0.0.1:17777 user@host
+ssh -L 6768:127.0.0.1:6768 user@host`}</code>
+      </pre>
+    </>
+  );
+}

--- a/apps/pebble/src/app/docs/telemetry/page.tsx
+++ b/apps/pebble/src/app/docs/telemetry/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Privacy & telemetry" };
+
+export default function Page() {
+  return (
+    <>
+      <h1>Privacy &amp; telemetry</h1>
+      <p>
+        Desktop telemetry is anonymous product analytics (PostHog Cloud) plus error/crash reporting
+        (Sentry Cloud). Ordinary product feedback is private support data.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Destination</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Product analytics</td>
+            <td>PostHog Cloud (opt-out in settings)</td>
+          </tr>
+          <tr>
+            <td>Errors / crashes</td>
+            <td>Sentry Cloud</td>
+          </tr>
+          <tr>
+            <td>In-app feedback</td>
+            <td>
+              <code>POST https://api.nebutra.com/pebble/v1/feedback</code>
+            </td>
+          </tr>
+          <tr>
+            <td>Diagnostics bundles</td>
+            <td>
+              <code>POST https://api.nebutra.com/pebble/diagnostics/*</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Diagnostics uploads are capped (4 MiB), tokenized (short-lived, single-use), rate-limited
+        per IP, and retained for 30 days unless deleted earlier.
+      </p>
+      <p>
+        Opt out of product analytics in <strong>Settings → Privacy</strong>. Set{" "}
+        <code>PEBBLE_DIAGNOSTICS_DISABLED=1</code> to disable diagnostic bundle collection.
+      </p>
+    </>
+  );
+}

--- a/apps/pebble/src/app/docs/terminal/page.tsx
+++ b/apps/pebble/src/app/docs/terminal/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Terminal" };
+
+export default function Page() {
+  return (
+    <>
+      <h1>Terminal</h1>
+      <p>
+        Pebble embeds Ghostty-class terminals with WebGL rendering, infinite splits, and scrollback
+        that survives restarts.
+      </p>
+      <p>
+        Terminal sessions stay owned by the Go runtime control plane; the desktop shell is the
+        surface, not a second PTY host.
+      </p>
+    </>
+  );
+}

--- a/apps/pebble/src/app/globals.css
+++ b/apps/pebble/src/app/globals.css
@@ -390,3 +390,139 @@ code.inline {
 .footer a:hover {
   color: var(--ink);
 }
+
+/* ── Docs shell (self-hosted until docs.nebutra.com Worker is redeployed) ─ */
+
+.docs-shell {
+  width: min(1080px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 1rem 0 3.5rem;
+  display: grid;
+  grid-template-columns: 13.5rem 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .docs-shell {
+    grid-template-columns: 1fr;
+  }
+}
+
+.docs-nav {
+  position: sticky;
+  top: 1rem;
+  padding: 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  backdrop-filter: blur(10px);
+}
+
+.docs-nav-title {
+  margin: 0 0 0.75rem;
+  font-family: var(--font);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.docs-nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.docs-nav a {
+  display: block;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.45rem;
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+}
+
+.docs-nav a:hover {
+  background: color-mix(in srgb, var(--stone) 35%, transparent);
+  color: var(--ink);
+}
+
+.docs-nav-note {
+  margin: 1rem 0 0;
+  font-size: 0.75rem;
+  color: var(--ink-muted);
+  line-height: 1.45;
+}
+
+.docs-article {
+  min-width: 0;
+  padding: 0.25rem 0 2rem;
+}
+
+.docs-article h1 {
+  margin: 0 0 0.85rem;
+  font-family: var(--font);
+  font-size: clamp(1.8rem, 3vw, 2.3rem);
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+}
+
+.docs-article h2 {
+  margin: 1.75rem 0 0.65rem;
+  font-family: var(--font);
+  font-size: 1.25rem;
+  letter-spacing: -0.02em;
+}
+
+.docs-article p,
+.docs-article li {
+  color: var(--ink-muted);
+  line-height: 1.65;
+}
+
+.docs-article a {
+  color: color-mix(in srgb, var(--ink) 70%, var(--tide));
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.docs-article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  font-size: 0.92rem;
+}
+
+.docs-article th,
+.docs-article td {
+  border: 1px solid var(--border);
+  padding: 0.55rem 0.7rem;
+  text-align: left;
+}
+
+.docs-article th {
+  background: color-mix(in srgb, var(--stone) 30%, transparent);
+  color: var(--ink);
+}
+
+.docs-article pre {
+  margin: 1rem 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--ink) 92%, var(--mist));
+  color: var(--mist);
+  overflow-x: auto;
+  font-size: 0.85rem;
+}
+
+.docs-article code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+}
+
+.docs-article :not(pre) > code {
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.35rem;
+  background: color-mix(in srgb, var(--stone) 40%, transparent);
+  color: var(--ink);
+}

--- a/apps/pebble/src/app/layout.tsx
+++ b/apps/pebble/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           </a>
           <nav className="nav-links" aria-label="Primary">
             <a href="/download">Download</a>
-            <a href={DOCS_BASE}>Docs</a>
+            <a href="/docs">Docs</a>
             <a href={GITHUB_REPO}>GitHub</a>
             <a href={STATUS_URL}>Status</a>
             <a className="nav-cta" href="/download">

--- a/apps/pebble/src/lib/releases.test.ts
+++ b/apps/pebble/src/lib/releases.test.ts
@@ -10,6 +10,6 @@ describe("pebble brand front release links", () => {
   });
 
   it("keeps docs on the platform docs host under /pebble", () => {
-    expect(DOCS_BASE).toBe("https://docs.nebutra.com/pebble");
+    expect(DOCS_BASE).toBe("https://pebble.nebutra.com/docs");
   });
 });

--- a/apps/pebble/src/lib/releases.ts
+++ b/apps/pebble/src/lib/releases.ts
@@ -9,6 +9,7 @@ export const DOWNLOADS = {
   all: GITHUB_RELEASES,
 } as const;
 
-export const DOCS_BASE = "https://docs.nebutra.com/pebble";
+/** Prefer on-origin docs while docs.nebutra.com/pebble Worker is stale. */
+export const DOCS_BASE = "https://pebble.nebutra.com/docs";
 export const STATUS_URL = "https://status.nebutra.com";
 export const GITHUB_REPO = "https://github.com/Nebutra/pebble";

--- a/infra/runtime/nginx/conf.d/pebble.nebutra.com.conf
+++ b/infra/runtime/nginx/conf.d/pebble.nebutra.com.conf
@@ -45,13 +45,9 @@ server {
 
     # Do NOT redirect this host to nebutra.com — it is the Pebble product origin.
 
-    # Human docs: permanent redirect to platform docs namespace (preserve suffix).
-    location = /docs {
-        return 301 https://docs.nebutra.com/pebble;
-    }
-    location /docs/ {
-        rewrite ^/docs/(.*)$ https://docs.nebutra.com/pebble/$1 permanent;
-    }
+    # Docs are served by the brand app at /docs/* (self-hosted) until
+    # docs.nebutra.com/pebble is healthy on the Sailor Docs Worker again.
+    # Do not 301 away — that path was 404ing and looked like a white-screen miss.
 
     # Legacy support intake — method + body preserved, no client redirect.
     location = /v1/feedback {


### PR DESCRIPTION
Root cause: sailor-docs CF Worker deploy fails (token 10000). Ship docs on brand origin.