### PR TITLE
ci(docs): harden Sailor Docs CF deploy token path

### DIFF
--- a/.github/workflows/deploy-sailor-docs.yml
+++ b/.github/workflows/deploy-sailor-docs.yml
@@ -5,9 +5,15 @@ name: Deploy Sailor Docs
 # - vercel: CLI re-trigger (Hobby plan caps at ~100 deploys/day)
 # - cloudflare-workers: OpenNext → Worker + Assets (same pattern as typelens)
 #
-# Default: both jobs evaluate. Vercel soft-fails on daily quota. Cloudflare
-# runs when DEPLOY_TARGET_SAILOR_DOCS is cloudflare-pages / cloudflare-workers,
-# or when workflow_dispatch selects cloudflare / both.
+# Push path follows vars.DEPLOY_TARGET_SAILOR_DOCS:
+#   vercel | "" → Vercel job
+#   cloudflare-workers | cloudflare-pages → Cloudflare job
+# workflow_dispatch can force both / cloudflare / vercel.
+#
+# Cloudflare token: CLOUDFLARE_WORKERS_API_TOKEN || CLOUDFLARE_API_TOKEN
+# must include Workers Scripts Edit (preflight probes assets-upload-session).
+# See docs/ops/cloudflare-ci-token.md. Until token is fixed, set
+# DEPLOY_TARGET_SAILOR_DOCS=vercel so push deploys stay healthy.
 #
 # Historical note: old monorepo Workers builds could exceed script size; modern
 # OpenNext keeps handler thin and static under ASSETS. If CF deploy fails on
@@ -119,10 +125,51 @@ jobs:
         with:
           node-version: 22
 
+      # Prefer CLOUDFLARE_WORKERS_API_TOKEN (Workers Scripts Edit) when the
+      # general CLOUDFLARE_API_TOKEN is read-only / DNS-only. See:
+      # docs/ops/cloudflare-ci-token.md
       - name: Validate Cloudflare secrets
+        id: cf_secrets
+        env:
+          WORKERS_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ACCOUNT_ID_SECRET: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ACCOUNT_ID_VAR: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          [ -n "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || { echo "::error::CLOUDFLARE_API_TOKEN secret is not set"; exit 1; }
-          [ -n "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ] || { echo "::error::CLOUDFLARE_ACCOUNT_ID secret is not set"; exit 1; }
+          set -euo pipefail
+          TOKEN="${WORKERS_TOKEN:-${API_TOKEN:-}}"
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Set CLOUDFLARE_WORKERS_API_TOKEN or CLOUDFLARE_API_TOKEN (Workers Scripts Edit required). See docs/ops/cloudflare-ci-token.md"
+            exit 1
+          fi
+          ACCOUNT_ID="${ACCOUNT_ID_SECRET:-${ACCOUNT_ID_VAR:-}}"
+          if [ -z "$ACCOUNT_ID" ]; then
+            echo "::error::CLOUDFLARE_ACCOUNT_ID secret/var is not set"
+            exit 1
+          fi
+          if [ -n "${WORKERS_TOKEN:-}" ]; then
+            echo "token_source=CLOUDFLARE_WORKERS_API_TOKEN"
+          else
+            echo "token_source=CLOUDFLARE_API_TOKEN"
+          fi
+          echo "account_id=$ACCOUNT_ID" >> "$GITHUB_OUTPUT"
+          # Masked echo only of source name for logs
+          echo "Using token source above for Workers deploy + preflight."
+
+      - name: Preflight Workers token (assets-upload-session)
+        env:
+          CLOUDFLARE_WORKERS_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if ! bash infra/ops/scripts/verify-cloudflare-ci-token.sh; then
+            echo "::error::Cloudflare token cannot deploy Workers (often error 10000 — missing Workers Scripts Edit)."
+            echo "::error::Fix: docs/ops/cloudflare-ci-token.md — create token from Edit Cloudflare Workers template, then:"
+            echo "::error::  printf '%s' \"\$NEW_TOKEN\" | gh secret set CLOUDFLARE_API_TOKEN -R Nebutra/Nebutra-Sailor"
+            echo "::error::Temporary path: gh variable set DEPLOY_TARGET_SAILOR_DOCS --body vercel && re-run with target=vercel"
+            exit 1
+          fi
 
       # Workspace packages export dist/ (gitignored). Build transitive deps so
       # Next can resolve @nebutra/brand, @nebutra/ui, icons, tokens, etc.
@@ -140,7 +187,8 @@ jobs:
       - name: Deploy Worker
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Workers-scoped token first; general API token as fallback.
+          apiToken: ${{ secrets.CLOUDFLARE_WORKERS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           # Secret preferred; vars fallback if secret is empty/stale.
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/sailor-docs
@@ -149,16 +197,29 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Point docs DNS at Worker (proxied)
+        # DNS Edit usually lives on CLOUDFLARE_API_TOKEN (not Workers-only).
+        # Soft-fail: Worker is live on *.workers.dev even if DNS write is denied.
+        continue-on-error: true
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID }}
-        run: bash infra/ops/scripts/point-docs-dns-cloudflare-worker.sh
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::warning::No token for DNS point — skip. Worker still on nebutra-sailor-docs.nebutra.workers.dev"
+            exit 0
+          fi
+          if ! bash infra/ops/scripts/point-docs-dns-cloudflare-worker.sh; then
+            echo "::warning::DNS point failed (token may lack Zone DNS Edit). See docs/ops/cloudflare-ci-token.md"
+            exit 1
+          fi
 
       - name: Smoke docs
         run: |
           set -euo pipefail
           for url in \
             "https://docs.nebutra.com/en" \
+            "https://docs.nebutra.com/en/pebble" \
             "https://nebutra-sailor-docs.nebutra.workers.dev/en" \
             ; do
             code=$(curl -sS -o /tmp/docs-smoke.html -w '%{http_code}' --max-time 30 -L "$url" || echo 000)

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -113,7 +113,7 @@ Single source of truth for *where traffic lands today*. Do not invent a second s
 |----------|------------------|---------|
 | `HA_TOPOLOGY` | `cf-edge + vercel-marketing/docs + ecs-origin(app,auth,api,sso)` | Describe *actual* routing |
 | `DEPLOY_TARGET_LANDING` | `vercel` | Primary deploy path |
-| `DEPLOY_TARGET_SAILOR_DOCS` | `cloudflare-workers` | Primary deploy path (Vercel fallback when CF unavailable) |
+| `DEPLOY_TARGET_SAILOR_DOCS` | `vercel` (temp) / `cloudflare-workers` (target) | Push path for `deploy-sailor-docs.yml`. Prefer CF Workers when token has **Workers Scripts Edit**; until then set `vercel`. Token ops: [ops/cloudflare-ci-token.md](./ops/cloudflare-ci-token.md) |
 | `DEPLOY_TARGET_WEB` | `vercel` | *Target* platform; production traffic still ECS until DNS cutover |
 | `DEPLOY_TARGET_AUTH` | `vercel` | *Target* platform; production traffic still ECS until DNS cutover |
 | `DEPLOY_TARGET_ADMIN` | `standalone` | Control plane — ECS origin only; a Vercel project would create a second origin outside Cloudflare Access |

--- a/docs/ops/cloudflare-ci-token.md
+++ b/docs/ops/cloudflare-ci-token.md
@@ -1,0 +1,105 @@
+# Cloudflare CI API token (Nebutra-Sailor)
+
+GitHub Actions secrets used by `deploy-sailor-docs.yml`, `deploy-typelens.yml`,
+`deploy-gateway.yml`, and `point-*-dns.yml`:
+
+| Secret | Purpose |
+|--------|---------|
+| `CLOUDFLARE_API_TOKEN` | Workers deploy, DNS scripts, optional KV |
+| `CLOUDFLARE_ACCOUNT_ID` | Account `a4248a5738df319996a70092fe598d37` |
+
+Optional override (recommended when the general token is DNS/read-only):
+
+| Secret | Purpose |
+|--------|---------|
+| `CLOUDFLARE_WORKERS_API_TOKEN` | Prefer for Workers deploy (`||` fallback to `CLOUDFLARE_API_TOKEN`) |
+
+`deploy-sailor-docs` resolution order:
+
+1. Deploy Worker / preflight: `CLOUDFLARE_WORKERS_API_TOKEN` → else `CLOUDFLARE_API_TOKEN`
+2. Point DNS: `CLOUDFLARE_API_TOKEN` → else Workers token (soft-fail if no DNS Edit)
+
+## Why deploys fail with `10000 Authentication error`
+
+A token can **verify** and **list** zones/DNS while **failing** on:
+
+- `POST …/workers/scripts/…/assets-upload-session` (docs Worker deploy)
+- `POST …/zones/…/dns_records` (DNS create/update)
+
+That means the token is missing **Edit** scopes for Workers and/or DNS.
+
+## Required permissions (create a new token)
+
+Dashboard → **My Profile** → **API Tokens** → **Create Token** → **Create Custom Token**.
+
+### Account permissions
+
+| Permission | Level |
+|------------|--------|
+| **Workers Scripts** | **Edit** |
+| **Workers Routes** | **Edit** |
+| **Workers KV Storage** | Edit (if used) |
+| **Account Settings** | Read |
+
+### Zone permissions (zone = `nebutra.com`)
+
+| Permission | Level |
+|------------|--------|
+| **Workers Routes** | **Edit** |
+| **DNS** | **Edit** (for `point-*-dns` scripts) |
+| **Zone** | Read |
+
+### Account resources
+
+- Include: `Omichiliriku@gmail.com's Account` / id `a4248a5738df319996a70092fe598d37`
+
+### Zone resources
+
+- Include: `nebutra.com` only (or All zones if preferred)
+
+## One-click style start
+
+1. Open: <https://dash.cloudflare.com/profile/api-tokens>
+2. **Create Token** → start from template **Edit Cloudflare Workers**
+3. Add **Zone → DNS → Edit** for `nebutra.com`
+4. Create → copy token **once**
+5. Update GitHub:
+
+```bash
+# from a machine that has the new token in the clipboard / env
+printf '%s' "$NEW_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN -R Nebutra/Nebutra-Sailor
+
+# optional dedicated workers token
+printf '%s' "$NEW_TOKEN" | gh secret set CLOUDFLARE_WORKERS_API_TOKEN -R Nebutra/Nebutra-Sailor
+```
+
+6. Verify:
+
+```bash
+bash infra/ops/scripts/verify-cloudflare-ci-token.sh
+```
+
+7. Redeploy docs:
+
+```bash
+gh workflow run "Deploy Sailor Docs" -R Nebutra/Nebutra-Sailor -f target=cloudflare
+```
+
+## Temporary production path (no Workers Edit)
+
+Until the token is fixed:
+
+```bash
+gh variable set DEPLOY_TARGET_SAILOR_DOCS -R Nebutra/Nebutra-Sailor --body vercel
+gh workflow run "Deploy Sailor Docs" -R Nebutra/Nebutra-Sailor -f target=vercel
+```
+
+Ensure `docs.nebutra.com` DNS points at Vercel (`CNAME` → `cname.vercel-dns.com` or the project-specific `*.vercel-dns-*.com`) when using Vercel as primary. Worker route can remain for later cutback.
+
+## Related hosts
+
+| Host | Needs |
+|------|--------|
+| `docs.nebutra.com` Worker | Workers Scripts **Edit** + Assets |
+| `point-pebble-dns` / DNS scripts | Zone DNS **Edit** |
+| Pebble brand front | Already on **ECS** (`A` → origin); no Workers token required |

--- a/infra/ops/scripts/verify-cloudflare-ci-token.sh
+++ b/infra/ops/scripts/verify-cloudflare-ci-token.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Verify CLOUDFLARE_API_TOKEN (or CLOUDFLARE_WORKERS_API_TOKEN) can deploy Workers
+# and optionally edit DNS for nebutra.com.
+#
+# Usage:
+#   CLOUDFLARE_API_TOKEN=… bash infra/ops/scripts/verify-cloudflare-ci-token.sh
+#   CLOUDFLARE_API_TOKEN=… VERIFY_DNS=1 bash infra/ops/scripts/verify-cloudflare-ci-token.sh
+set -euo pipefail
+
+TOKEN="${CLOUDFLARE_WORKERS_API_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
+if [ -z "$TOKEN" ]; then
+  echo "Set CLOUDFLARE_API_TOKEN or CLOUDFLARE_WORKERS_API_TOKEN" >&2
+  exit 1
+fi
+
+ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-a4248a5738df319996a70092fe598d37}"
+ZONE_NAME="${CF_ZONE_NAME:-nebutra.com}"
+WORKER_NAME="${CF_WORKER_NAME:-nebutra-sailor-docs}"
+
+auth() { curl -sS -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "$@"; }
+
+echo "=== 1) token verify ==="
+VERIFY=$(auth "https://api.cloudflare.com/client/v4/user/tokens/verify")
+echo "$VERIFY" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("success"), d; print("token_ok", d.get("result",{}).get("status"))'
+
+echo "=== 2) account access (${ACCOUNT_ID}) ==="
+ACC=$(auth "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}")
+echo "$ACC" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("account", d.get("success"), (d.get("result") or {}).get("name"), d.get("errors"))'
+
+echo "=== 3) list workers scripts (needs Workers Scripts Read/Edit) ==="
+SCRIPTS=$(auth "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workers/scripts")
+echo "$SCRIPTS" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+print("scripts_list", d.get("success"), "count", len(d.get("result") or []), d.get("errors"))
+if not d.get("success"):
+  sys.exit(2)
+'
+
+echo "=== 4) assets-upload-session probe (needs Workers Scripts Edit) ==="
+# Empty manifest probe: Edit scope should not return 10000 auth error.
+# 400/404 on bad body is fine — we only care about auth.
+PROBE=$(curl -sS -o /tmp/cf-assets-probe.json -w "%{http_code}" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workers/scripts/${WORKER_NAME}/assets-upload-session" \
+  --data '{"manifest":{}}' || echo "000")
+echo "http_status=$PROBE body=$(head -c 240 /tmp/cf-assets-probe.json 2>/dev/null || true)"
+if [ "$PROBE" = "000" ]; then
+  echo "::error::assets-upload-session request failed network-level"
+  exit 3
+fi
+if python3 -c '
+import json, sys
+try:
+  d = json.load(open("/tmp/cf-assets-probe.json"))
+except Exception:
+  sys.exit(2)
+errs = d.get("errors") or []
+if any(e.get("code") == 10000 for e in errs):
+  sys.exit(1)
+# success, or non-auth API error (empty manifest, missing script, etc.) is fine
+sys.exit(0)
+'; then
+  echo "assets_upload_session: auth OK (or non-auth error — acceptable for probe)"
+else
+  echo "::error::assets-upload-session returned Authentication error 10000 — token lacks Workers Scripts Edit"
+  echo "Create token: https://dash.cloudflare.com/profile/api-tokens"
+  echo "Template: Edit Cloudflare Workers + Zone DNS Edit for nebutra.com"
+  echo "See docs/ops/cloudflare-ci-token.md"
+  exit 4
+fi
+
+if [ "${VERIFY_DNS:-0}" = "1" ]; then
+  echo "=== 5) DNS write probe (needs Zone DNS Edit) ==="
+  ZONE_ID="${CF_ZONE_ID:-}"
+  if [ -z "$ZONE_ID" ]; then
+    ZJ=$(auth "https://api.cloudflare.com/client/v4/zones?name=${ZONE_NAME}&account.id=${ACCOUNT_ID}")
+    ZONE_ID=$(echo "$ZJ" | python3 -c 'import json,sys; r=json.load(sys.stdin); print((r.get("result") or [{}])[0].get("id",""))')
+  fi
+  [ -n "$ZONE_ID" ] || { echo "zone id missing"; exit 5; }
+  # Dry-run style: GET records is Read; attempt PUT with invalid id is not useful.
+  # Create then delete a disposable TXT _nebutra_ci_probe
+  BODY='{"type":"TXT","name":"_nebutra_ci_probe","content":"ok","ttl":120}'
+  CREATE=$(curl -sS -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+    -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" --data "$BODY")
+  echo "$CREATE" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("dns_create", d.get("success"), d.get("errors")); raise SystemExit(0 if d.get("success") else 6)'
+  RID=$(echo "$CREATE" | python3 -c 'import json,sys; print((json.load(sys.stdin).get("result") or {}).get("id",""))')
+  if [ -n "$RID" ]; then
+    curl -sS -X DELETE -H "Authorization: Bearer ${TOKEN}" \
+      "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RID}" >/dev/null
+    echo "dns_probe cleaned"
+  fi
+fi
+
+echo "=== OK: token looks sufficient for Workers CI ==="
+echo "Docs: docs/ops/cloudflare-ci-token.md"


### PR DESCRIPTION
## Summary
- Prefer `CLOUDFLARE_WORKERS_API_TOKEN` over `CLOUDFLARE_API_TOKEN` for OpenNext Worker deploy
- Preflight `assets-upload-session` so CF **10000** auth fails early with `docs/ops/cloudflare-ci-token.md` fix steps
- Soft-fail DNS point when token lacks Zone DNS Edit
- Add local verify script `infra/ops/scripts/verify-cloudflare-ci-token.sh`
- Document temporary path: `DEPLOY_TARGET_SAILOR_DOCS=vercel` (already set on the repo)

## Why
Live `CLOUDFLARE_API_TOKEN` can list zones but cannot `POST …/assets-upload-session` (Workers Scripts Edit missing). That left `deploy-sailor-docs` failing while docs content shipped elsewhere (Vercel / pebble self-host).

## Ops already done
```bash
gh variable set DEPLOY_TARGET_SAILOR_DOCS -R Nebutra/Nebutra-Sailor --body vercel
```
Push path now deploys Sailor Docs via Vercel until a Workers-Edit token is wired.

## Human follow-up (cannot automate)
1. CF dashboard → Create Token → **Edit Cloudflare Workers** + Zone DNS Edit for `nebutra.com`
2. `printf '%s' "$NEW_TOKEN" | gh secret set CLOUDFLARE_API_TOKEN -R Nebutra/Nebutra-Sailor`
3. Optionally also set `CLOUDFLARE_WORKERS_API_TOKEN`
4. `bash infra/ops/scripts/verify-cloudflare-ci-token.sh`
5. `gh variable set DEPLOY_TARGET_SAILOR_DOCS --body cloudflare-workers`
6. `gh workflow run "Deploy Sailor Docs" -f target=cloudflare`

## Test plan
- [x] Variable set to `vercel`
- [ ] Merge; optional `gh workflow run "Deploy Sailor Docs" -f target=vercel`
- [ ] After new token: verify script exit 0 + cloudflare workflow green
- [x] Live: `https://docs.nebutra.com/en/pebble` 200; `https://pebble.nebutra.com/` 200