### PR TITLE
fix(docs): shrink OpenNext Worker under Cloudflare 64MiB limit

### DIFF
--- a/apps/sailor-docs/mdx-components.tsx
+++ b/apps/sailor-docs/mdx-components.tsx
@@ -257,9 +257,6 @@ import {
   TooltipTrigger,
   Accordion as UIAccordion,
 } from "@nebutra/ui/primitives";
-import { Mermaid } from "fumadocs-mermaid/ui";
-import * as ObsidianComponents from "fumadocs-obsidian/ui";
-import * as PythonComponents from "fumadocs-python/components";
 import { Callout } from "fumadocs-ui/components/callout";
 import { File, Files, Folder } from "fumadocs-ui/components/files";
 import { GithubInfo } from "fumadocs-ui/components/github-info";
@@ -269,8 +266,7 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 import defaultComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 import Link from "next/link";
-// Registry demos: import via @/__registry__ for lazy-loading
-// Direct demos: import directly when used as inline MDX children (not via ComponentPreview name=)
+// Registry demos: client-only dynamic (ssr:false) — keeps OpenNext handler lean
 import {
   AnimatedCircularProgressBarDemo,
   AvatarFallbackDemo,
@@ -296,7 +292,6 @@ import {
   SkipLinkStyleDemo,
   VisuallyHiddenDemo,
 } from "@/components/accessibility-demos";
-import { APIPage } from "@/components/api-page";
 import { AvatarSmartGroupDemo } from "@/components/avatar-smart-group-demo";
 import { AvatarWithIconDemo } from "@/components/avatar-with-icon-demo";
 import {
@@ -308,9 +303,6 @@ import {
   BadgeTableDemo,
   BadgeVariantsDemo,
 } from "@/components/badge-demos";
-import { BrandPhilosophyVisual, LogoShowcase } from "@/components/brand-overview-visuals";
-import { ColorPalette } from "@/components/color-palette";
-import { ColorUsageDemos } from "@/components/color-usage";
 import { ComponentPreview } from "@/components/component-preview";
 import {
   CopywritingButtonsDemo,
@@ -343,8 +335,6 @@ import {
   SplitLayoutDemo,
   StandardGridDemo,
 } from "@/components/grid-layout-demos";
-import { IconGallery } from "@/components/icon-gallery";
-import { IntroductionHero } from "@/components/introduction-hero";
 import {
   AccordionGroup,
   Check,
@@ -359,6 +349,17 @@ import {
   Tip,
   Warning,
 } from "@/components/mdx-compat";
+import {
+  APIPage,
+  BrandPhilosophyVisual,
+  ColorPalette,
+  ColorUsageDemos,
+  IconGallery,
+  IntroductionHero,
+  LogoShowcase,
+  Mermaid,
+  MotionDemos,
+} from "@/components/mdx-lazy";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/mdx-resizable";
 import { ScrollArea, ScrollBar } from "@/components/mdx-scroll-area";
 import {
@@ -369,7 +370,6 @@ import {
   Tab,
 } from "@/components/mdx-tabs";
 import { Toggle, ToggleGroup, ToggleGroupItem } from "@/components/mdx-toggle";
-import { MotionDemos } from "@/components/motion-demos";
 import {
   DotPatternCardDemo,
   FlickeringGridCardDemo,
@@ -436,8 +436,9 @@ const Combobox = Object.assign(ComboboxRoot, {
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   const merged = {
     ...defaultComponents,
-    ...ObsidianComponents,
-    ...PythonComponents,
+    // fumadocs-obsidian / fumadocs-python intentionally omitted from the static
+    // MDX component map — they bloat the OpenNext Worker past CF size limits.
+    // Niche pages can import them locally if needed later.
 
     // ─── Fumadocs Built-ins ────────────────────────────────────────────────────
     Callout,

--- a/apps/sailor-docs/next.config.ts
+++ b/apps/sailor-docs/next.config.ts
@@ -1,4 +1,3 @@
-import { brand } from "@nebutra/brand/metadata";
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 import { createMDX } from "fumadocs-mdx/next";
 import type { NextConfig } from "next";
@@ -32,7 +31,34 @@ const nextConfig: NextConfig = {
       process.env.OPEN_NEXT_BUILD === "true" ||
       process.env.CI === "true",
   },
-  serverExternalPackages: ["@takumi-rs/image-response"],
+  // Keep native/heavy packages out of the OpenNext esbuild graph when possible.
+  // Mermaid is 75MB on disk; OG image renderer is native; octokit only for feedback.
+  serverExternalPackages: ["@takumi-rs/image-response", "mermaid", "playwright", "playwright-core"],
+  experimental: {
+    // Tree-shake barrel imports so icons/ui do not land wholesale in handler.mjs.
+    optimizePackageImports: [
+      "@nebutra/icons",
+      "@nebutra/ui",
+      "@nebutra/ui/primitives",
+      "@nebutra/ui/patterns",
+      "fumadocs-ui",
+      "fumadocs-ui/components",
+    ],
+  },
+  // OpenNext/Workers size cuts:
+  // - `@nebutra/ui/primitives` barrel statically imports streamdown → full shiki
+  //   (~8 MiB langs). Docs never render MessageContent; stub streamdown out.
+  // - Prefer shiki/bundle/web if anything still imports shiki.
+  ...(process.env.OPEN_NEXT_BUILD === "true"
+    ? {
+        turbopack: {
+          resolveAlias: {
+            shiki: "shiki/bundle/web",
+            streamdown: "./src/shims/streamdown-stub.ts",
+          },
+        },
+      }
+    : {}),
   transpilePackages: [
     "@nebutra/fonts",
     "@nebutra/ui",

--- a/apps/sailor-docs/scripts/build-registry.mjs
+++ b/apps/sailor-docs/scripts/build-registry.mjs
@@ -24,10 +24,16 @@ const OUTPUT_FILE = path.join(OUTPUT_DIR, "index.tsx");
 // Files to skip (will be deleted once migration is done)
 const SKIP_FILES = new Set(["dynamic-demos.tsx"]);
 
-// Components that use browser-only APIs and must skip SSR
+// Components that use browser-only APIs and must skip SSR.
+// Default is now ssr:false for *all* demos (see FORCE_CLIENT_ONLY_DEMOS):
+// OpenNext/Workers pack every SSR-enabled client module into handler.mjs,
+// and 290+ demos + framer-motion + mermaid blow past the 64 MiB limit.
 const SSR_EXCLUDE = new Set([
-  // Add demo names here if they break during SSR
+  // Add demo names here if they break during SSR (redundant with force flag)
 ]);
+
+/** When true, every registry demo is `dynamic(..., { ssr: false })`. */
+const FORCE_CLIENT_ONLY_DEMOS = process.env.REGISTRY_SSR !== "1";
 
 /**
  * Detect if a file uses JSX component tags that aren't imported.
@@ -121,8 +127,82 @@ function toKebab(name) {
     .toLowerCase();
 }
 
+/**
+ * Resolve export * / export { X } re-exports into local preview wrappers that
+ * only re-export from @nebutra/docs-shared (or other packages).
+ */
+function resolveReexportTargets(source, filename) {
+  const names = [];
+  const dir = PREVIEWS_DIR;
+
+  // export * from "pkg"  OR  export * from "./rel"
+  for (const m of source.matchAll(/^export\s+\*\s+from\s+["']([^"']+)["']/gm)) {
+    const spec = m[1];
+    if (spec.startsWith(".")) {
+      const target = path.resolve(dir, path.dirname(filename), spec);
+      const candidates = [`${target}.tsx`, `${target}.ts`, path.join(target, "index.tsx")];
+      const hit = candidates.find((c) => fs.existsSync(c));
+      if (hit) names.push(...extractExports(fs.readFileSync(hit, "utf-8"), path.basename(hit)));
+      continue;
+    }
+    // package re-export: try to read from monorepo package source
+    // e.g. @nebutra/docs-shared/components/previews/button-demo
+    if (spec.startsWith("@nebutra/docs-shared/")) {
+      const rel = spec.replace("@nebutra/docs-shared/", "");
+      const candidates = [
+        // common layout in this monorepo (packages/design/docs-shared)
+        ...findDocsSharedPreview(rel),
+      ];
+      const hit = candidates.find((c) => fs.existsSync(c));
+      if (hit) {
+        names.push(...extractExports(fs.readFileSync(hit, "utf-8"), path.basename(hit)));
+      } else {
+        // Fallback: derive ComponentName from file basename (button-demo → ButtonDemo)
+        // and common multi-export files still need package read — warn later.
+        const baseName = path.basename(filename, ".tsx");
+        const guess = baseName
+          .split("-")
+          .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+          .join("");
+        if (guess.endsWith("Demo") || /[A-Z]/.test(guess)) names.push(guess);
+      }
+    }
+  }
+
+  // export { Foo, Bar as Baz } from "..."
+  for (const m of source.matchAll(/^export\s+\{([^}]+)\}\s+from\s+["'][^"']+["']/gm)) {
+    for (const part of m[1].split(",")) {
+      const bits = part.trim().split(/\s+as\s+/);
+      const exported = (bits[1] || bits[0] || "").trim();
+      if (exported && /^[A-Z]/.test(exported) && !exported.endsWith("Props")) names.push(exported);
+    }
+  }
+
+  return names;
+}
+
+function findDocsSharedPreview(rel) {
+  // Canonical: packages/design/docs-shared/src/<rel>.tsx
+  // rel e.g. "components/previews/button-demo"
+  const out = [
+    path.resolve(ROOT, "../../packages/design/docs-shared/src", `${rel}.tsx`),
+    path.resolve(ROOT, "../../packages/design/docs-shared/src", `${rel}.ts`),
+    path.resolve(ROOT, "../../packages/design/docs-shared", `${rel}.tsx`),
+  ];
+  try {
+    const pkg = path.join(ROOT, "node_modules/@nebutra/docs-shared");
+    if (fs.existsSync(pkg)) {
+      const real = fs.realpathSync(pkg);
+      out.push(path.join(real, "src", `${rel}.tsx`), path.join(real, `${rel}.tsx`));
+    }
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
 /** Extract exported component names from a file's source */
-function extractExports(source, _filename) {
+function extractExports(source, filename = "") {
   const names = [];
 
   // Strip out template literals to avoid matching code examples
@@ -143,6 +223,11 @@ function extractExports(source, _filename) {
     // Skip type aliases, interfaces, non-component constants
     if (m[1].endsWith("Props") || m[1].endsWith("Context")) continue;
     names.push(m[1]);
+  }
+
+  // Re-export barrels (local preview wrappers → docs-shared)
+  if (names.length === 0) {
+    names.push(...resolveReexportTargets(source, filename));
   }
 
   // Deduplicate
@@ -208,7 +293,8 @@ const lines = [
 // Named exports — so mdx-components.tsx can do:
 //   import { AccordionDemo, ButtonDemo } from "@/components/__registry__"
 for (const { exportName, file, key, isDefault, ssrOff: autoSsrOff } of entries) {
-  const ssrOff = SSR_EXCLUDE.has(key) || autoSsrOff ? `, { ssr: false }` : "";
+  const ssrOff =
+    FORCE_CLIENT_ONLY_DEMOS || SSR_EXCLUDE.has(key) || autoSsrOff ? `, { ssr: false }` : "";
   const accessor = isDefault ? "m.default" : `m.${exportName}`;
   lines.push(
     `export const ${exportName} = dynamic(() => import("@/components/previews/${file}").then(m => ({ default: ${accessor} }))${ssrOff});`,

--- a/apps/sailor-docs/source.config.ts
+++ b/apps/sailor-docs/source.config.ts
@@ -7,12 +7,27 @@ import {
   createGenerator,
   remarkAutoTypeTable,
 } from "fumadocs-typescript";
+import type { Pluggable } from "unified";
 import { z } from "zod";
 import { remarkComponent } from "./lib/remark-component";
 
-const generator = createGenerator({
-  cache: createFileSystemGeneratorCache(".next/fumadocs-typescript"),
-});
+// Worker / OpenNext builds must stay under Cloudflare's 64 MiB uncompressed
+// Worker limit. ts-morph (via fumadocs-typescript remarkAutoTypeTable) alone
+// is ~12 MiB; full Shiki language packs add ~8 MiB more.
+const isOpenNext = process.env.OPEN_NEXT_BUILD === "true";
+
+const typeTablePlugins: Pluggable[] = isOpenNext
+  ? []
+  : [
+      [
+        remarkAutoTypeTable,
+        {
+          generator: createGenerator({
+            cache: createFileSystemGeneratorCache(".next/fumadocs-typescript"),
+          }),
+        },
+      ],
+    ];
 
 export const docs = defineDocs({
   dir: "content/docs",
@@ -22,7 +37,10 @@ export const docs = defineDocs({
       figma: z.string().optional(),
     }),
     postprocess: {
-      includeProcessedMarkdown: true,
+      // "processed" doubles every page body into the server bundle. Prefer raw
+      // markdown for LLM routes (see get-llm-text.ts) so CF Workers stays under
+      // the 64 MiB handler limit.
+      includeProcessedMarkdown: !isOpenNext,
     },
   },
 });
@@ -30,12 +48,7 @@ export const docs = defineDocs({
 export default defineConfig({
   plugins: [lastModified()],
   mdxOptions: {
-    remarkPlugins: [
-      remarkComponent,
-      remarkMdxMermaid,
-      remarkFeedbackBlock,
-      [remarkAutoTypeTable, { generator }],
-    ],
+    remarkPlugins: [remarkComponent, remarkMdxMermaid, remarkFeedbackBlock, ...typeTablePlugins],
     rehypePlugins: [],
   },
 });

--- a/apps/sailor-docs/src/__registry__/index.tsx
+++ b/apps/sailor-docs/src/__registry__/index.tsx
@@ -5,1022 +5,1494 @@
 
 import dynamic from "next/dynamic";
 
-export const AccordionCompactDemo = dynamic(() =>
-  import("@/components/previews/accordion-compact-demo").then((m) => ({
-    default: m.AccordionCompactDemo,
-  })),
-);
-export const AccordionControlledDemo = dynamic(() =>
-  import("@/components/previews/accordion-controlled-demo").then((m) => ({
-    default: m.AccordionControlledDemo,
-  })),
-);
-export const AccordionDemo = dynamic(() =>
-  import("@/components/previews/accordion-demo").then((m) => ({ default: m.AccordionDemo })),
-);
-export const AccordionDisabledDemo = dynamic(() =>
-  import("@/components/previews/accordion-disabled-demo").then((m) => ({
-    default: m.AccordionDisabledDemo,
-  })),
-);
-export const AgentPlanDemo = dynamic(() =>
-  import("@/components/previews/agent-plan-demo").then((m) => ({ default: m.AgentPlanDemo })),
-);
-export const AlertDemo = dynamic(() =>
-  import("@/components/previews/alert-demo").then((m) => ({ default: m.AlertDemo })),
-);
-export const AlertDialogCustomDemo = dynamic(() =>
-  import("@/components/previews/alert-dialog-custom-demo").then((m) => ({
-    default: m.AlertDialogCustomDemo,
-  })),
-);
-export const AlertDialogDemo = dynamic(() =>
-  import("@/components/previews/alert-dialog-demo").then((m) => ({ default: m.AlertDialogDemo })),
-);
-export const AnimatedBeamDemo = dynamic(() =>
-  import("@/components/previews/animated-beam-demo").then((m) => ({ default: m.AnimatedBeamDemo })),
-);
-export const AnimatedCircularProgressBarDemo = dynamic(() =>
-  import("@/components/previews/animated-circular-progress-bar-demo").then((m) => ({
-    default: m.AnimatedCircularProgressBarDemo,
-  })),
-);
-export const AnimatedGradientTextDemo = dynamic(() =>
-  import("@/components/previews/animated-gradient-text-demo").then((m) => ({
-    default: m.AnimatedGradientTextDemo,
-  })),
-);
-export const AnimatedGroupDemo = dynamic(() =>
-  import("@/components/previews/animated-group-demo").then((m) => ({
-    default: m.AnimatedGroupDemo,
-  })),
-);
-export const AnimatedHikeCardDemo = dynamic(() =>
-  import("@/components/previews/animated-hike-card-demo").then((m) => ({
-    default: m.AnimatedHikeCardDemo,
-  })),
-);
-export const AnimatedListDemo = dynamic(() =>
-  import("@/components/previews/animated-list-demo").then((m) => ({ default: m.AnimatedListDemo })),
-);
-export const AnimatedShinyTextDemo = dynamic(() =>
-  import("@/components/previews/animated-shiny-text-demo").then((m) => ({
-    default: m.AnimatedShinyTextDemo,
-  })),
-);
-export const AnnouncementDemo = dynamic(() =>
-  import("@/components/previews/announcement-demo").then((m) => ({ default: m.AnnouncementDemo })),
-);
-export const AspectRatioDemo = dynamic(() =>
-  import("@/components/previews/aspect-ratio-demo").then((m) => ({ default: m.AspectRatioDemo })),
-);
-export const AssistedPasswordConfirmationDemo = dynamic(() =>
-  import("@/components/previews/assisted-password-confirmation-demo").then((m) => ({
-    default: m.AssistedPasswordConfirmationDemo,
-  })),
-);
-export const AuroraTextDemo = dynamic(() =>
-  import("@/components/previews/aurora-text-demo").then((m) => ({ default: m.AuroraTextDemo })),
-);
-export const AvatarCirclesDemo = dynamic(() =>
-  import("@/components/previews/avatar-circles-demo").then((m) => ({
-    default: m.AvatarCirclesDemo,
-  })),
-);
-export const AvatarSizeDemo = dynamic(() =>
-  import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarSizeDemo })),
-);
-export const AvatarFallbackDemo = dynamic(() =>
-  import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarFallbackDemo })),
-);
-export const AvatarGroupDemo = dynamic(() =>
-  import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarGroupDemo })),
-);
-export const AvatarGitPlatformDemo = dynamic(() =>
-  import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarGitPlatformDemo })),
-);
-export const AvatarWithIconDemo = dynamic(() =>
-  import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarWithIconDemo })),
-);
-export const DiceBearAvatarDemo = dynamic(() =>
-  import("@/components/previews/avatar-demo").then((m) => ({ default: m.DiceBearAvatarDemo })),
-);
-export const AvatarDicebearSimpleDemo = dynamic(() =>
-  import("@/components/previews/avatar-dicebear-simple-demo").then((m) => ({
-    default: m.AvatarDicebearSimpleDemo,
-  })),
-);
-export const AvatarFallbackSimpleDemo = dynamic(() =>
-  import("@/components/previews/avatar-fallback-simple-demo").then((m) => ({
-    default: m.AvatarFallbackSimpleDemo,
-  })),
-);
-export const AvatarGitSimpleDemo = dynamic(() =>
-  import("@/components/previews/avatar-git-simple-demo").then((m) => ({
-    default: m.AvatarGitSimpleDemo,
-  })),
-);
-export const AvatarGroupSimpleDemo = dynamic(() =>
-  import("@/components/previews/avatar-group-simple-demo").then((m) => ({
-    default: m.AvatarGroupSimpleDemo,
-  })),
-);
-export const AvatarSmartGroupDemo = dynamic(() =>
-  import("@/components/previews/avatar-smart-group-demo").then((m) => ({
-    default: m.AvatarSmartGroupDemo,
-  })),
-);
-export const AwardsDemo = dynamic(() =>
-  import("@/components/previews/awards-demo").then((m) => ({ default: m.AwardsDemo })),
-);
-export const BadgeAllColorsDemo = dynamic(() =>
-  import("@/components/previews/badge-all-colors-demo").then((m) => ({
-    default: m.BadgeAllColorsDemo,
-  })),
-);
-export const BadgeDemo = dynamic(() =>
-  import("@/components/previews/badge-demo").then((m) => ({ default: m.BadgeDemo })),
-);
-export const BadgeFeatureTagDemo = dynamic(() =>
-  import("@/components/previews/badge-feature-tag-demo").then((m) => ({
-    default: m.BadgeFeatureTagDemo,
-  })),
-);
-export const BadgeIconColorsDemo = dynamic(() =>
-  import("@/components/previews/badge-icon-colors-demo").then((m) => ({
-    default: m.BadgeIconColorsDemo,
-  })),
-);
-export const BadgeIconDemo = dynamic(() =>
-  import("@/components/previews/badge-icon-demo").then((m) => ({ default: m.BadgeIconDemo })),
-);
-export const BadgeNotificationDemo = dynamic(() =>
-  import("@/components/previews/badge-notification-demo").then((m) => ({
-    default: m.BadgeNotificationDemo,
-  })),
-);
-export const BadgePillDemo = dynamic(() =>
-  import("@/components/previews/badge-pill-demo").then((m) => ({ default: m.BadgePillDemo })),
-);
-export const BadgePillMatrixDemo = dynamic(() =>
-  import("@/components/previews/badge-pill-matrix-demo").then((m) => ({
-    default: m.BadgePillMatrixDemo,
-  })),
-);
-export const BadgeSizesDemo = dynamic(() =>
-  import("@/components/previews/badge-sizes-demo").then((m) => ({ default: m.BadgeSizesDemo })),
-);
-export const BadgeStatusDotDemo = dynamic(() =>
-  import("@/components/previews/badge-status-dot-demo").then((m) => ({
-    default: m.BadgeStatusDotDemo,
-  })),
-);
-export const BadgeTableDemo = dynamic(() =>
-  import("@/components/previews/badge-table-demo").then((m) => ({ default: m.BadgeTableDemo })),
-);
-export const BadgeVariantsDemo = dynamic(() =>
-  import("@/components/previews/badge-variants-demo").then((m) => ({
-    default: m.BadgeVariantsDemo,
-  })),
-);
-export const BasePopoverDemo = dynamic(() =>
-  import("@/components/previews/base-popover-demo").then((m) => ({ default: m.default })),
-);
-export const BentoGridDemo = dynamic(() =>
-  import("@/components/previews/bento-grid-demo").then((m) => ({ default: m.BentoGridDemo })),
-);
-export const BookDemo = dynamic(() =>
-  import("@/components/previews/book-demo").then((m) => ({ default: m.BookDemo })),
-);
-export const BorderTrailDemo = dynamic(() =>
-  import("@/components/previews/border-trail-demo").then((m) => ({ default: m.BorderTrailDemo })),
-);
-export const BoxDemo = dynamic(() =>
-  import("@/components/previews/box-demo").then((m) => ({ default: m.BoxDemo })),
-);
-export const BreadcrumbCustomSeparatorDemo = dynamic(() =>
-  import("@/components/previews/breadcrumb-custom-separator-demo").then((m) => ({
-    default: m.BreadcrumbCustomSeparatorDemo,
-  })),
-);
-export const BreadcrumbDemo = dynamic(() =>
-  import("@/components/previews/breadcrumb-demo").then((m) => ({ default: m.BreadcrumbDemo })),
-);
-export const BreadcrumbEllipsisDemo = dynamic(() =>
-  import("@/components/previews/breadcrumb-ellipsis-demo").then((m) => ({
-    default: m.BreadcrumbEllipsisDemo,
-  })),
-);
-export const BrowserMockupDemo = dynamic(() =>
-  import("@/components/previews/browser-mockup-demo").then((m) => ({
-    default: m.BrowserMockupDemo,
-  })),
-);
-export const ButtonDemo = dynamic(() =>
-  import("@/components/previews/button-demo").then((m) => ({ default: m.ButtonDemo })),
-);
-export const ButtonLoadingDemo = dynamic(() =>
-  import("@/components/previews/button-loading-demo").then((m) => ({
-    default: m.ButtonLoadingDemo,
-  })),
-);
-export const ButtonSizesDemo = dynamic(() =>
-  import("@/components/previews/button-sizes-demo").then((m) => ({ default: m.ButtonSizesDemo })),
-);
-export const ButtonVariantsDemo = dynamic(() =>
-  import("@/components/previews/button-variants-demo").then((m) => ({
-    default: m.ButtonVariantsDemo,
-  })),
-);
-export const ButtonWithIconDemo = dynamic(() =>
-  import("@/components/previews/button-with-icon-demo").then((m) => ({
-    default: m.ButtonWithIconDemo,
-  })),
-);
-export const CanvasRevealEffectDemo = dynamic(() =>
-  import("@/components/previews/canvas-reveal-effect-demo").then((m) => ({
-    default: m.CanvasRevealEffectDemo,
-  })),
-);
-export const Card2Demo = dynamic(() =>
-  import("@/components/previews/card-2-demo").then((m) => ({ default: m.Card2Demo })),
-);
-export const CardDemo = dynamic(() =>
-  import("@/components/previews/card-demo").then((m) => ({ default: m.CardDemo })),
-);
-export const CardPricingDemo = dynamic(() =>
-  import("@/components/previews/card-pricing-demo").then((m) => ({ default: m.CardPricingDemo })),
-);
-export const CardSpotlightDemo = dynamic(() =>
-  import("@/components/previews/card-spotlight-demo").then((m) => ({
-    default: m.CardSpotlightDemo,
-  })),
-);
-export const CardWithIconDemo = dynamic(() =>
-  import("@/components/previews/card-with-icon-demo").then((m) => ({
-    default: m.CardWithIconDemo,
-  })),
-);
-export const Carousel2Demo = dynamic(() =>
-  import("@/components/previews/carousel-2-demo").then((m) => ({ default: m.Carousel2Demo })),
-);
-export const Carousel3Demo = dynamic(() =>
-  import("@/components/previews/carousel-3-demo").then((m) => ({ default: m.Carousel3Demo })),
-);
-export const CarouselDemo = dynamic(() =>
-  import("@/components/previews/carousel-demo").then((m) => ({ default: m.CarouselDemo })),
-);
-export const CarouselMultipleDemo = dynamic(() =>
-  import("@/components/previews/carousel-multiple-demo").then((m) => ({
-    default: m.CarouselMultipleDemo,
-  })),
-);
-export const CarouselVerticalDemo = dynamic(() =>
-  import("@/components/previews/carousel-vertical-demo").then((m) => ({
-    default: m.CarouselVerticalDemo,
-  })),
-);
-export const CheckboxDemo = dynamic(() =>
-  import("@/components/previews/checkbox-demo").then((m) => ({ default: m.CheckboxDemo })),
-);
-export const CheckboxGroupDemo = dynamic(() =>
-  import("@/components/previews/checkbox-group-demo").then((m) => ({
-    default: m.CheckboxGroupDemo,
-  })),
-);
-export const CheckboxIndeterminateDemo = dynamic(() =>
-  import("@/components/previews/checkbox-indeterminate-demo").then((m) => ({
-    default: m.CheckboxIndeterminateDemo,
-  })),
-);
-export const ChoiceboxDemo = dynamic(() =>
-  import("@/components/previews/choicebox-demo").then((m) => ({ default: m.ChoiceboxDemo })),
-);
-export const ChoiceboxRadioDemo = dynamic(() =>
-  import("@/components/previews/choicebox-radio-demo").then((m) => ({
-    default: m.ChoiceboxRadioDemo,
-  })),
-);
-export const CodeBlockDemo = dynamic(() =>
-  import("@/components/previews/code-block-demo").then((m) => ({ default: m.CodeBlockDemo })),
-);
-export const Collapsible2Demo = dynamic(() =>
-  import("@/components/previews/collapsible-2-demo").then((m) => ({ default: m.Collapsible2Demo })),
-);
-export const CollapsibleDemo = dynamic(() =>
-  import("@/components/previews/collapsible-demo").then((m) => ({ default: m.CollapsibleDemo })),
-);
-export const ColorBadgeDemo = dynamic(() =>
-  import("@/components/previews/color-badge-demo").then((m) => ({ default: m.ColorBadgeDemo })),
-);
-export const Combobox10Demo = dynamic(() =>
-  import("@/components/previews/combobox-10-demo").then((m) => ({ default: m.Combobox10Demo })),
-);
-export const Combobox11Demo = dynamic(() =>
-  import("@/components/previews/combobox-11-demo").then((m) => ({ default: m.Combobox11Demo })),
-);
-export const Combobox2Demo = dynamic(() =>
-  import("@/components/previews/combobox-2-demo").then((m) => ({ default: m.Combobox2Demo })),
-);
-export const Combobox3Demo = dynamic(() =>
-  import("@/components/previews/combobox-3-demo").then((m) => ({ default: m.Combobox3Demo })),
-);
-export const Combobox4Demo = dynamic(() =>
-  import("@/components/previews/combobox-4-demo").then((m) => ({ default: m.Combobox4Demo })),
-);
-export const Combobox5Demo = dynamic(() =>
-  import("@/components/previews/combobox-5-demo").then((m) => ({ default: m.Combobox5Demo })),
-);
-export const Combobox6Demo = dynamic(() =>
-  import("@/components/previews/combobox-6-demo").then((m) => ({ default: m.Combobox6Demo })),
-);
-export const Combobox7Demo = dynamic(() =>
-  import("@/components/previews/combobox-7-demo").then((m) => ({ default: m.Combobox7Demo })),
-);
-export const Combobox8Demo = dynamic(() =>
-  import("@/components/previews/combobox-8-demo").then((m) => ({ default: m.Combobox8Demo })),
-);
-export const Combobox9Demo = dynamic(() =>
-  import("@/components/previews/combobox-9-demo").then((m) => ({ default: m.Combobox9Demo })),
-);
-export const ComboboxDefaultValueDemo = dynamic(() =>
-  import("@/components/previews/combobox-default-value-demo").then((m) => ({
-    default: m.ComboboxDefaultValueDemo,
-  })),
-);
-export const ComboboxDemo = dynamic(() =>
-  import("@/components/previews/combobox-demo").then((m) => ({ default: m.ComboboxDemo })),
-);
-export const ComboboxDisabledDemo = dynamic(() =>
-  import("@/components/previews/combobox-disabled-demo").then((m) => ({
-    default: m.ComboboxDisabledDemo,
-  })),
-);
-export const ComboboxErrorDemo = dynamic(() =>
-  import("@/components/previews/combobox-error-demo").then((m) => ({
-    default: m.ComboboxErrorDemo,
-  })),
-);
-export const ComboboxGroupsDemo = dynamic(() =>
-  import("@/components/previews/combobox-groups-demo").then((m) => ({
-    default: m.ComboboxGroupsDemo,
-  })),
-);
-export const ComboboxSizesDemo = dynamic(() =>
-  import("@/components/previews/combobox-sizes-demo").then((m) => ({
-    default: m.ComboboxSizesDemo,
-  })),
-);
-export const ComboboxWidthDemo = dynamic(() =>
-  import("@/components/previews/combobox-width-demo").then((m) => ({
-    default: m.ComboboxWidthDemo,
-  })),
-);
-export const CommandDemo = dynamic(() =>
-  import("@/components/previews/command-demo").then((m) => ({ default: m.CommandDemo })),
-);
-export const CommandDialogDemo = dynamic(() =>
-  import("@/components/previews/command-dialog-demo").then((m) => ({
-    default: m.CommandDialogDemo,
-  })),
-);
-export const CommandDialogSimpleDemo = dynamic(() =>
-  import("@/components/previews/command-dialog-simple-demo").then((m) => ({
-    default: m.CommandDialogSimpleDemo,
-  })),
+export const AccordionCompactDemo = dynamic(
+  () =>
+    import("@/components/previews/accordion-compact-demo").then((m) => ({
+      default: m.AccordionCompactDemo,
+    })),
+  { ssr: false },
+);
+export const AccordionControlledDemo = dynamic(
+  () =>
+    import("@/components/previews/accordion-controlled-demo").then((m) => ({
+      default: m.AccordionControlledDemo,
+    })),
+  { ssr: false },
+);
+export const AccordionDemo = dynamic(
+  () => import("@/components/previews/accordion-demo").then((m) => ({ default: m.AccordionDemo })),
+  { ssr: false },
+);
+export const AccordionDisabledDemo = dynamic(
+  () =>
+    import("@/components/previews/accordion-disabled-demo").then((m) => ({
+      default: m.AccordionDisabledDemo,
+    })),
+  { ssr: false },
+);
+export const AgentPlanDemo = dynamic(
+  () => import("@/components/previews/agent-plan-demo").then((m) => ({ default: m.AgentPlanDemo })),
+  { ssr: false },
+);
+export const AlertDemo = dynamic(
+  () => import("@/components/previews/alert-demo").then((m) => ({ default: m.AlertDemo })),
+  { ssr: false },
+);
+export const AlertDialogCustomDemo = dynamic(
+  () =>
+    import("@/components/previews/alert-dialog-custom-demo").then((m) => ({
+      default: m.AlertDialogCustomDemo,
+    })),
+  { ssr: false },
+);
+export const AlertDialogDemo = dynamic(
+  () =>
+    import("@/components/previews/alert-dialog-demo").then((m) => ({ default: m.AlertDialogDemo })),
+  { ssr: false },
+);
+export const AnimatedBeamDemo = dynamic(
+  () =>
+    import("@/components/previews/animated-beam-demo").then((m) => ({
+      default: m.AnimatedBeamDemo,
+    })),
+  { ssr: false },
+);
+export const AnimatedCircularProgressBarDemo = dynamic(
+  () =>
+    import("@/components/previews/animated-circular-progress-bar-demo").then((m) => ({
+      default: m.AnimatedCircularProgressBarDemo,
+    })),
+  { ssr: false },
+);
+export const AnimatedGradientTextDemo = dynamic(
+  () =>
+    import("@/components/previews/animated-gradient-text-demo").then((m) => ({
+      default: m.AnimatedGradientTextDemo,
+    })),
+  { ssr: false },
+);
+export const AnimatedGroupDemo = dynamic(
+  () =>
+    import("@/components/previews/animated-group-demo").then((m) => ({
+      default: m.AnimatedGroupDemo,
+    })),
+  { ssr: false },
+);
+export const AnimatedHikeCardDemo = dynamic(
+  () =>
+    import("@/components/previews/animated-hike-card-demo").then((m) => ({
+      default: m.AnimatedHikeCardDemo,
+    })),
+  { ssr: false },
+);
+export const AnimatedListDemo = dynamic(
+  () =>
+    import("@/components/previews/animated-list-demo").then((m) => ({
+      default: m.AnimatedListDemo,
+    })),
+  { ssr: false },
+);
+export const AnimatedShinyTextDemo = dynamic(
+  () =>
+    import("@/components/previews/animated-shiny-text-demo").then((m) => ({
+      default: m.AnimatedShinyTextDemo,
+    })),
+  { ssr: false },
+);
+export const AnnouncementDemo = dynamic(
+  () =>
+    import("@/components/previews/announcement-demo").then((m) => ({
+      default: m.AnnouncementDemo,
+    })),
+  { ssr: false },
+);
+export const AspectRatioDemo = dynamic(
+  () =>
+    import("@/components/previews/aspect-ratio-demo").then((m) => ({ default: m.AspectRatioDemo })),
+  { ssr: false },
+);
+export const AssistedPasswordConfirmationDemo = dynamic(
+  () =>
+    import("@/components/previews/assisted-password-confirmation-demo").then((m) => ({
+      default: m.AssistedPasswordConfirmationDemo,
+    })),
+  { ssr: false },
+);
+export const AuroraTextDemo = dynamic(
+  () =>
+    import("@/components/previews/aurora-text-demo").then((m) => ({ default: m.AuroraTextDemo })),
+  { ssr: false },
+);
+export const AvatarCirclesDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-circles-demo").then((m) => ({
+      default: m.AvatarCirclesDemo,
+    })),
+  { ssr: false },
+);
+export const AvatarSizeDemo = dynamic(
+  () => import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarSizeDemo })),
+  { ssr: false },
+);
+export const AvatarFallbackDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarFallbackDemo })),
+  { ssr: false },
+);
+export const AvatarGroupDemo = dynamic(
+  () => import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarGroupDemo })),
+  { ssr: false },
+);
+export const AvatarGitPlatformDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarGitPlatformDemo })),
+  { ssr: false },
+);
+export const AvatarWithIconDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-demo").then((m) => ({ default: m.AvatarWithIconDemo })),
+  { ssr: false },
+);
+export const DiceBearAvatarDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-demo").then((m) => ({ default: m.DiceBearAvatarDemo })),
+  { ssr: false },
+);
+export const AvatarDicebearSimpleDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-dicebear-simple-demo").then((m) => ({
+      default: m.AvatarDicebearSimpleDemo,
+    })),
+  { ssr: false },
+);
+export const AvatarFallbackSimpleDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-fallback-simple-demo").then((m) => ({
+      default: m.AvatarFallbackSimpleDemo,
+    })),
+  { ssr: false },
+);
+export const AvatarGitSimpleDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-git-simple-demo").then((m) => ({
+      default: m.AvatarGitSimpleDemo,
+    })),
+  { ssr: false },
+);
+export const AvatarGroupSimpleDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-group-simple-demo").then((m) => ({
+      default: m.AvatarGroupSimpleDemo,
+    })),
+  { ssr: false },
+);
+export const AvatarSmartGroupDemo = dynamic(
+  () =>
+    import("@/components/previews/avatar-smart-group-demo").then((m) => ({
+      default: m.AvatarSmartGroupDemo,
+    })),
+  { ssr: false },
+);
+export const AwardsDemo = dynamic(
+  () => import("@/components/previews/awards-demo").then((m) => ({ default: m.AwardsDemo })),
+  { ssr: false },
+);
+export const BadgeAllColorsDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-all-colors-demo").then((m) => ({
+      default: m.BadgeAllColorsDemo,
+    })),
+  { ssr: false },
+);
+export const BadgeDemo = dynamic(
+  () => import("@/components/previews/badge-demo").then((m) => ({ default: m.BadgeDemo })),
+  { ssr: false },
+);
+export const BadgeFeatureTagDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-feature-tag-demo").then((m) => ({
+      default: m.BadgeFeatureTagDemo,
+    })),
+  { ssr: false },
+);
+export const BadgeIconColorsDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-icon-colors-demo").then((m) => ({
+      default: m.BadgeIconColorsDemo,
+    })),
+  { ssr: false },
+);
+export const BadgeIconDemo = dynamic(
+  () => import("@/components/previews/badge-icon-demo").then((m) => ({ default: m.BadgeIconDemo })),
+  { ssr: false },
+);
+export const BadgeNotificationDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-notification-demo").then((m) => ({
+      default: m.BadgeNotificationDemo,
+    })),
+  { ssr: false },
+);
+export const BadgePillDemo = dynamic(
+  () => import("@/components/previews/badge-pill-demo").then((m) => ({ default: m.BadgePillDemo })),
+  { ssr: false },
+);
+export const BadgePillMatrixDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-pill-matrix-demo").then((m) => ({
+      default: m.BadgePillMatrixDemo,
+    })),
+  { ssr: false },
+);
+export const BadgeSizesDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-sizes-demo").then((m) => ({ default: m.BadgeSizesDemo })),
+  { ssr: false },
+);
+export const BadgeStatusDotDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-status-dot-demo").then((m) => ({
+      default: m.BadgeStatusDotDemo,
+    })),
+  { ssr: false },
+);
+export const BadgeTableDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-table-demo").then((m) => ({ default: m.BadgeTableDemo })),
+  { ssr: false },
+);
+export const BadgeVariantsDemo = dynamic(
+  () =>
+    import("@/components/previews/badge-variants-demo").then((m) => ({
+      default: m.BadgeVariantsDemo,
+    })),
+  { ssr: false },
+);
+export const BasePopoverDemo = dynamic(
+  () => import("@/components/previews/base-popover-demo").then((m) => ({ default: m.default })),
+  { ssr: false },
+);
+export const BentoGridDemo = dynamic(
+  () => import("@/components/previews/bento-grid-demo").then((m) => ({ default: m.BentoGridDemo })),
+  { ssr: false },
+);
+export const BookDemo = dynamic(
+  () => import("@/components/previews/book-demo").then((m) => ({ default: m.BookDemo })),
+  { ssr: false },
+);
+export const BorderTrailDemo = dynamic(
+  () =>
+    import("@/components/previews/border-trail-demo").then((m) => ({ default: m.BorderTrailDemo })),
+  { ssr: false },
+);
+export const BoxDemo = dynamic(
+  () => import("@/components/previews/box-demo").then((m) => ({ default: m.BoxDemo })),
+  { ssr: false },
+);
+export const BreadcrumbCustomSeparatorDemo = dynamic(
+  () =>
+    import("@/components/previews/breadcrumb-custom-separator-demo").then((m) => ({
+      default: m.BreadcrumbCustomSeparatorDemo,
+    })),
+  { ssr: false },
+);
+export const BreadcrumbDemo = dynamic(
+  () =>
+    import("@/components/previews/breadcrumb-demo").then((m) => ({ default: m.BreadcrumbDemo })),
+  { ssr: false },
+);
+export const BreadcrumbEllipsisDemo = dynamic(
+  () =>
+    import("@/components/previews/breadcrumb-ellipsis-demo").then((m) => ({
+      default: m.BreadcrumbEllipsisDemo,
+    })),
+  { ssr: false },
+);
+export const BrowserMockupDemo = dynamic(
+  () =>
+    import("@/components/previews/browser-mockup-demo").then((m) => ({
+      default: m.BrowserMockupDemo,
+    })),
+  { ssr: false },
+);
+export const ButtonDemo = dynamic(
+  () => import("@/components/previews/button-demo").then((m) => ({ default: m.ButtonDemo })),
+  { ssr: false },
+);
+export const ButtonLoadingDemo = dynamic(
+  () =>
+    import("@/components/previews/button-loading-demo").then((m) => ({
+      default: m.ButtonLoadingDemo,
+    })),
+  { ssr: false },
+);
+export const ButtonSizesDemo = dynamic(
+  () =>
+    import("@/components/previews/button-sizes-demo").then((m) => ({ default: m.ButtonSizesDemo })),
+  { ssr: false },
+);
+export const ButtonVariantsDemo = dynamic(
+  () =>
+    import("@/components/previews/button-variants-demo").then((m) => ({
+      default: m.ButtonVariantsDemo,
+    })),
+  { ssr: false },
+);
+export const ButtonWithIconDemo = dynamic(
+  () =>
+    import("@/components/previews/button-with-icon-demo").then((m) => ({
+      default: m.ButtonWithIconDemo,
+    })),
+  { ssr: false },
+);
+export const CanvasRevealEffectDemo = dynamic(
+  () =>
+    import("@/components/previews/canvas-reveal-effect-demo").then((m) => ({
+      default: m.CanvasRevealEffectDemo,
+    })),
+  { ssr: false },
+);
+export const Card2Demo = dynamic(
+  () => import("@/components/previews/card-2-demo").then((m) => ({ default: m.Card2Demo })),
+  { ssr: false },
+);
+export const CardDemo = dynamic(
+  () => import("@/components/previews/card-demo").then((m) => ({ default: m.CardDemo })),
+  { ssr: false },
+);
+export const CardPricingDemo = dynamic(
+  () =>
+    import("@/components/previews/card-pricing-demo").then((m) => ({ default: m.CardPricingDemo })),
+  { ssr: false },
+);
+export const CardSpotlightDemo = dynamic(
+  () =>
+    import("@/components/previews/card-spotlight-demo").then((m) => ({
+      default: m.CardSpotlightDemo,
+    })),
+  { ssr: false },
+);
+export const CardWithIconDemo = dynamic(
+  () =>
+    import("@/components/previews/card-with-icon-demo").then((m) => ({
+      default: m.CardWithIconDemo,
+    })),
+  { ssr: false },
+);
+export const Carousel2Demo = dynamic(
+  () => import("@/components/previews/carousel-2-demo").then((m) => ({ default: m.Carousel2Demo })),
+  { ssr: false },
+);
+export const Carousel3Demo = dynamic(
+  () => import("@/components/previews/carousel-3-demo").then((m) => ({ default: m.Carousel3Demo })),
+  { ssr: false },
+);
+export const CarouselDemo = dynamic(
+  () => import("@/components/previews/carousel-demo").then((m) => ({ default: m.CarouselDemo })),
+  { ssr: false },
+);
+export const CarouselMultipleDemo = dynamic(
+  () =>
+    import("@/components/previews/carousel-multiple-demo").then((m) => ({
+      default: m.CarouselMultipleDemo,
+    })),
+  { ssr: false },
+);
+export const CarouselVerticalDemo = dynamic(
+  () =>
+    import("@/components/previews/carousel-vertical-demo").then((m) => ({
+      default: m.CarouselVerticalDemo,
+    })),
+  { ssr: false },
+);
+export const CheckboxDemo = dynamic(
+  () => import("@/components/previews/checkbox-demo").then((m) => ({ default: m.CheckboxDemo })),
+  { ssr: false },
+);
+export const CheckboxGroupDemo = dynamic(
+  () =>
+    import("@/components/previews/checkbox-group-demo").then((m) => ({
+      default: m.CheckboxGroupDemo,
+    })),
+  { ssr: false },
+);
+export const CheckboxIndeterminateDemo = dynamic(
+  () =>
+    import("@/components/previews/checkbox-indeterminate-demo").then((m) => ({
+      default: m.CheckboxIndeterminateDemo,
+    })),
+  { ssr: false },
+);
+export const ChoiceboxDemo = dynamic(
+  () => import("@/components/previews/choicebox-demo").then((m) => ({ default: m.ChoiceboxDemo })),
+  { ssr: false },
+);
+export const ChoiceboxRadioDemo = dynamic(
+  () =>
+    import("@/components/previews/choicebox-radio-demo").then((m) => ({
+      default: m.ChoiceboxRadioDemo,
+    })),
+  { ssr: false },
+);
+export const CodeBlockDemo = dynamic(
+  () => import("@/components/previews/code-block-demo").then((m) => ({ default: m.CodeBlockDemo })),
+  { ssr: false },
+);
+export const Collapsible2Demo = dynamic(
+  () =>
+    import("@/components/previews/collapsible-2-demo").then((m) => ({
+      default: m.Collapsible2Demo,
+    })),
+  { ssr: false },
+);
+export const CollapsibleDemo = dynamic(
+  () =>
+    import("@/components/previews/collapsible-demo").then((m) => ({ default: m.CollapsibleDemo })),
+  { ssr: false },
+);
+export const ColorBadgeDemo = dynamic(
+  () =>
+    import("@/components/previews/color-badge-demo").then((m) => ({ default: m.ColorBadgeDemo })),
+  { ssr: false },
+);
+export const Combobox10Demo = dynamic(
+  () =>
+    import("@/components/previews/combobox-10-demo").then((m) => ({ default: m.Combobox10Demo })),
+  { ssr: false },
+);
+export const Combobox11Demo = dynamic(
+  () =>
+    import("@/components/previews/combobox-11-demo").then((m) => ({ default: m.Combobox11Demo })),
+  { ssr: false },
+);
+export const Combobox2Demo = dynamic(
+  () => import("@/components/previews/combobox-2-demo").then((m) => ({ default: m.Combobox2Demo })),
+  { ssr: false },
+);
+export const Combobox3Demo = dynamic(
+  () => import("@/components/previews/combobox-3-demo").then((m) => ({ default: m.Combobox3Demo })),
+  { ssr: false },
+);
+export const Combobox4Demo = dynamic(
+  () => import("@/components/previews/combobox-4-demo").then((m) => ({ default: m.Combobox4Demo })),
+  { ssr: false },
+);
+export const Combobox5Demo = dynamic(
+  () => import("@/components/previews/combobox-5-demo").then((m) => ({ default: m.Combobox5Demo })),
+  { ssr: false },
+);
+export const Combobox6Demo = dynamic(
+  () => import("@/components/previews/combobox-6-demo").then((m) => ({ default: m.Combobox6Demo })),
+  { ssr: false },
+);
+export const Combobox7Demo = dynamic(
+  () => import("@/components/previews/combobox-7-demo").then((m) => ({ default: m.Combobox7Demo })),
+  { ssr: false },
+);
+export const Combobox8Demo = dynamic(
+  () => import("@/components/previews/combobox-8-demo").then((m) => ({ default: m.Combobox8Demo })),
+  { ssr: false },
+);
+export const Combobox9Demo = dynamic(
+  () => import("@/components/previews/combobox-9-demo").then((m) => ({ default: m.Combobox9Demo })),
+  { ssr: false },
+);
+export const ComboboxDefaultValueDemo = dynamic(
+  () =>
+    import("@/components/previews/combobox-default-value-demo").then((m) => ({
+      default: m.ComboboxDefaultValueDemo,
+    })),
+  { ssr: false },
+);
+export const ComboboxDemo = dynamic(
+  () => import("@/components/previews/combobox-demo").then((m) => ({ default: m.ComboboxDemo })),
+  { ssr: false },
+);
+export const ComboboxDisabledDemo = dynamic(
+  () =>
+    import("@/components/previews/combobox-disabled-demo").then((m) => ({
+      default: m.ComboboxDisabledDemo,
+    })),
+  { ssr: false },
+);
+export const ComboboxErrorDemo = dynamic(
+  () =>
+    import("@/components/previews/combobox-error-demo").then((m) => ({
+      default: m.ComboboxErrorDemo,
+    })),
+  { ssr: false },
+);
+export const ComboboxGroupsDemo = dynamic(
+  () =>
+    import("@/components/previews/combobox-groups-demo").then((m) => ({
+      default: m.ComboboxGroupsDemo,
+    })),
+  { ssr: false },
+);
+export const ComboboxSizesDemo = dynamic(
+  () =>
+    import("@/components/previews/combobox-sizes-demo").then((m) => ({
+      default: m.ComboboxSizesDemo,
+    })),
+  { ssr: false },
+);
+export const ComboboxWidthDemo = dynamic(
+  () =>
+    import("@/components/previews/combobox-width-demo").then((m) => ({
+      default: m.ComboboxWidthDemo,
+    })),
+  { ssr: false },
+);
+export const CommandDemo = dynamic(
+  () => import("@/components/previews/command-demo").then((m) => ({ default: m.CommandDemo })),
+  { ssr: false },
+);
+export const CommandDialogDemo = dynamic(
+  () =>
+    import("@/components/previews/command-dialog-demo").then((m) => ({
+      default: m.CommandDialogDemo,
+    })),
+  { ssr: false },
+);
+export const CommandDialogSimpleDemo = dynamic(
+  () =>
+    import("@/components/previews/command-dialog-simple-demo").then((m) => ({
+      default: m.CommandDialogSimpleDemo,
+    })),
+  { ssr: false },
 );
 export const ConfettiDemo = dynamic(
   () => import("@/components/previews/confetti-demo").then((m) => ({ default: m.ConfettiDemo })),
   { ssr: false },
 );
-export const ContextCardDemo = dynamic(() =>
-  import("@/components/previews/context-card-demo").then((m) => ({ default: m.ContextCardDemo })),
-);
-export const ContextMenuDemo = dynamic(() =>
-  import("@/components/previews/context-menu-demo").then((m) => ({ default: m.ContextMenuDemo })),
-);
-export const ContextMenuWithIconsDemo = dynamic(() =>
-  import("@/components/previews/context-menu-with-icons-demo").then((m) => ({
-    default: m.ContextMenuWithIconsDemo,
-  })),
-);
-export const DescriptionDemo = dynamic(() =>
-  import("@/components/previews/description-demo").then((m) => ({ default: m.DescriptionDemo })),
-);
-export const DialogDemo = dynamic(() =>
-  import("@/components/previews/dialog-demo").then((m) => ({ default: m.DialogDemo })),
-);
-export const DialogDestructiveDemo = dynamic(() =>
-  import("@/components/previews/dialog-destructive-demo").then((m) => ({
-    default: m.DialogDestructiveDemo,
-  })),
-);
-export const DisplayCardsDemo = dynamic(() =>
-  import("@/components/previews/display-cards-demo").then((m) => ({ default: m.DisplayCardsDemo })),
-);
-export const DitheringBackgroundDemo = dynamic(() =>
-  import("@/components/previews/dithering-background-demo").then((m) => ({
-    default: m.DitheringBackgroundDemo,
-  })),
-);
-export const DitheringShaderDemo = dynamic(() =>
-  import("@/components/previews/dithering-shader-demo").then((m) => ({
-    default: m.DitheringShaderDemo,
-  })),
-);
-export const DotPatternDemo = dynamic(() =>
-  import("@/components/previews/dot-pattern-demo").then((m) => ({ default: m.DotPatternDemo })),
-);
-export const DottedMapDemo = dynamic(() =>
-  import("@/components/previews/dotted-map-demo").then((m) => ({ default: m.DottedMapDemo })),
-);
-export const DottedWorldMapDemo = dynamic(() =>
-  import("@/components/previews/dotted-world-map-demo").then((m) => ({
-    default: m.DottedWorldMapDemo,
-  })),
-);
-export const Drawer2Demo = dynamic(() =>
-  import("@/components/previews/drawer-2-demo").then((m) => ({ default: m.Drawer2Demo })),
-);
-export const Drawer3Demo = dynamic(() =>
-  import("@/components/previews/drawer-3-demo").then((m) => ({ default: m.Drawer3Demo })),
-);
-export const DrawerDemo = dynamic(() =>
-  import("@/components/previews/drawer-demo").then((m) => ({ default: m.DrawerDemo })),
-);
-export const DrawerSideRightDemo = dynamic(() =>
-  import("@/components/previews/drawer-side-right-demo").then((m) => ({
-    default: m.DrawerSideRightDemo,
-  })),
-);
-export const DropdownMenu2Demo = dynamic(() =>
-  import("@/components/previews/dropdown-menu-2-demo").then((m) => ({
-    default: m.DropdownMenu2Demo,
-  })),
-);
-export const DropdownMenu3Demo = dynamic(() =>
-  import("@/components/previews/dropdown-menu-3-demo").then((m) => ({
-    default: m.DropdownMenu3Demo,
-  })),
-);
-export const DropdownMenu4Demo = dynamic(() =>
-  import("@/components/previews/dropdown-menu-4-demo").then((m) => ({
-    default: m.DropdownMenu4Demo,
-  })),
-);
-export const DropdownMenuDemo = dynamic(() =>
-  import("@/components/previews/dropdown-menu-demo").then((m) => ({ default: m.DropdownMenuDemo })),
-);
-export const DropdownMenuRadioGroupDemo = dynamic(() =>
-  import("@/components/previews/dropdown-menu-radio-group-demo").then((m) => ({
-    default: m.DropdownMenuRadioGroupDemo,
-  })),
-);
-export const DropdownMenuSubDemo = dynamic(() =>
-  import("@/components/previews/dropdown-menu-sub-demo").then((m) => ({
-    default: m.DropdownMenuSubDemo,
-  })),
-);
-export const EmptyStateDemo = dynamic(() =>
-  import("@/components/previews/empty-state-demo").then((m) => ({ default: m.EmptyStateDemo })),
-);
-export const EntityDemo = dynamic(() =>
-  import("@/components/previews/entity-demo").then((m) => ({ default: m.EntityDemo })),
-);
-export const ErrorMessageDemo = dynamic(() =>
-  import("@/components/previews/error-message-demo").then((m) => ({ default: m.ErrorMessageDemo })),
-);
-export const ExpandableTabsDemo = dynamic(() =>
-  import("@/components/previews/expandable-tabs-demo").then((m) => ({
-    default: m.ExpandableTabsDemo,
-  })),
-);
-export const ExpandingTextareaDemo = dynamic(() =>
-  import("@/components/previews/expanding-textarea-demo").then((m) => ({
-    default: m.ExpandingTextareaDemo,
-  })),
-);
-export const FeatureArrowCardDemo = dynamic(() =>
-  import("@/components/previews/feature-arrow-card-demo").then((m) => ({
-    default: m.FeatureArrowCardDemo,
-  })),
-);
-export const FeatureCardDemo = dynamic(() =>
-  import("@/components/previews/feature-card-demo").then((m) => ({ default: m.FeatureCardDemo })),
-);
-export const FeatureCheckItemDemo = dynamic(() =>
-  import("@/components/previews/feature-check-item-demo").then((m) => ({
-    default: m.FeatureCheckItemDemo,
-  })),
-);
-export const FeatureIconItemDemo = dynamic(() =>
-  import("@/components/previews/feature-icon-item-demo").then((m) => ({
-    default: m.FeatureIconItemDemo,
-  })),
-);
-export const FeedbackDemo = dynamic(() =>
-  import("@/components/previews/feedback-demo").then((m) => ({ default: m.FeedbackDemo })),
-);
-export const FieldDemo = dynamic(() =>
-  import("@/components/previews/field-demo").then((m) => ({ default: m.FieldDemo })),
-);
-export const FlexDemo = dynamic(() =>
-  import("@/components/previews/flex-demo").then((m) => ({ default: m.FlexDemo })),
-);
-export const FlickeringGridDemo = dynamic(() =>
-  import("@/components/previews/flickering-grid-demo").then((m) => ({
-    default: m.FlickeringGridDemo,
-  })),
-);
-export const FormDemo = dynamic(() =>
-  import("@/components/previews/form-demo").then((m) => ({ default: m.FormDemo })),
-);
-export const GaugeDemo = dynamic(() =>
-  import("@/components/previews/gauge-demo").then((m) => ({ default: m.GaugeDemo })),
-);
-export const GithubCalendarDemo = dynamic(() =>
-  import("@/components/previews/github-calendar-demo").then((m) => ({
-    default: m.GithubCalendarDemo,
-  })),
-);
-export const GithubInlineDiffDemo = dynamic(() =>
-  import("@/components/previews/github-inline-diff-demo").then((m) => ({
-    default: m.GithubInlineDiffDemo,
-  })),
-);
-export const GlobeDemo = dynamic(() =>
-  import("@/components/previews/globe-demo").then((m) => ({ default: m.GlobeDemo })),
-);
-export const GradientAnimatedTextDemo = dynamic(() =>
-  import("@/components/previews/gradient-animated-text-demo").then((m) => ({ default: m.default })),
-);
-export const GrainGradientBackgroundDemo = dynamic(() =>
-  import("@/components/previews/grain-gradient-background-demo").then((m) => ({
-    default: m.GrainGradientBackgroundDemo,
-  })),
-);
-export const GridFeatureCardDemo = dynamic(() =>
-  import("@/components/previews/grid-feature-card-demo").then((m) => ({
-    default: m.GridFeatureCardDemo,
-  })),
-);
-export const GridPatternCardDemo = dynamic(() =>
-  import("@/components/previews/grid-pattern-card-demo").then((m) => ({
-    default: m.GridPatternCardDemo,
-  })),
-);
-export const GridSystemDemo = dynamic(() =>
-  import("@/components/previews/grid-system-demo").then((m) => ({ default: m.GridSystemDemo })),
-);
-export const HeadingDemo = dynamic(() =>
-  import("@/components/previews/heading-demo").then((m) => ({ default: m.HeadingDemo })),
-);
-export const HexGridDemo = dynamic(() =>
-  import("@/components/previews/hex-grid-demo").then((m) => ({ default: m.HexGridDemo })),
-);
-export const HighlighterDemo = dynamic(() =>
-  import("@/components/previews/highlighter-demo").then((m) => ({ default: m.HighlighterDemo })),
-);
-export const HoverCard2Demo = dynamic(() =>
-  import("@/components/previews/hover-card-2-demo").then((m) => ({ default: m.HoverCard2Demo })),
-);
-export const HoverCardDemo = dynamic(() =>
-  import("@/components/previews/hover-card-demo").then((m) => ({ default: m.HoverCardDemo })),
-);
-export const InfiniteSliderDemo = dynamic(() =>
-  import("@/components/previews/infinite-slider-demo").then((m) => ({
-    default: m.InfiniteSliderDemo,
-  })),
-);
-export const Input2Demo = dynamic(() =>
-  import("@/components/previews/input-2-demo").then((m) => ({ default: m.Input2Demo })),
-);
-export const InputBasicDemo = dynamic(() =>
-  import("@/components/previews/input-basic-demo").then((m) => ({ default: m.InputBasicDemo })),
-);
-export const InputClearableDemo = dynamic(() =>
-  import("@/components/previews/input-clearable-demo").then((m) => ({
-    default: m.InputClearableDemo,
-  })),
-);
-export const InputDemo = dynamic(() =>
-  import("@/components/previews/input-demo").then((m) => ({ default: m.InputDemo })),
-);
-export const InputErrorDemo = dynamic(() =>
-  import("@/components/previews/input-error-demo").then((m) => ({ default: m.InputErrorDemo })),
-);
-export const InputOtpDemo = dynamic(() =>
-  import("@/components/previews/input-otp-demo").then((m) => ({ default: m.InputOtpDemo })),
-);
-export const InputOTPNumericDemo = dynamic(() =>
-  import("@/components/previews/input-otp-numeric-demo").then((m) => ({
-    default: m.InputOTPNumericDemo,
-  })),
-);
-export const InputPasswordRevealDemo = dynamic(() =>
-  import("@/components/previews/input-password-reveal-demo").then((m) => ({
-    default: m.InputPasswordRevealDemo,
-  })),
-);
-export const InputWithAddonsDemo = dynamic(() =>
-  import("@/components/previews/input-with-addons-demo").then((m) => ({
-    default: m.InputWithAddonsDemo,
-  })),
-);
-export const InputWithIconDemo = dynamic(() =>
-  import("@/components/previews/input-with-icon-demo").then((m) => ({
-    default: m.InputWithIconDemo,
-  })),
-);
-export const InputWithLabelDemo = dynamic(() =>
-  import("@/components/previews/input-with-label-demo").then((m) => ({
-    default: m.InputWithLabelDemo,
-  })),
-);
-export const InteractiveCardDemo = dynamic(() =>
-  import("@/components/previews/interactive-card-demo").then((m) => ({
-    default: m.InteractiveCardDemo,
-  })),
-);
-export const IntroductionDemo = dynamic(() =>
-  import("@/components/previews/introduction-demo").then((m) => ({ default: m.IntroductionDemo })),
-);
-export const IphoneMockupDemo = dynamic(() =>
-  import("@/components/previews/iphone-mockup-demo").then((m) => ({ default: m.IphoneMockupDemo })),
-);
-export const KbdDemo = dynamic(() =>
-  import("@/components/previews/kbd-demo").then((m) => ({ default: m.KbdDemo })),
-);
-export const Label2Demo = dynamic(() =>
-  import("@/components/previews/label-2-demo").then((m) => ({ default: m.Label2Demo })),
-);
-export const Label3Demo = dynamic(() =>
-  import("@/components/previews/label-3-demo").then((m) => ({ default: m.Label3Demo })),
-);
-export const Label4Demo = dynamic(() =>
-  import("@/components/previews/label-4-demo").then((m) => ({ default: m.Label4Demo })),
-);
-export const LabelDemo = dynamic(() =>
-  import("@/components/previews/label-demo").then((m) => ({ default: m.LabelDemo })),
-);
-export const LabelDescriptionDemo = dynamic(() =>
-  import("@/components/previews/label-description-demo").then((m) => ({
-    default: m.LabelDescriptionDemo,
-  })),
-);
-export const LabelDisabledDemo = dynamic(() =>
-  import("@/components/previews/label-disabled-demo").then((m) => ({
-    default: m.LabelDisabledDemo,
-  })),
-);
-export const LightRaysDemo = dynamic(() =>
-  import("@/components/previews/light-rays-demo").then((m) => ({ default: m.LightRaysDemo })),
-);
-export const LineShadowTextDemo = dynamic(() =>
-  import("@/components/previews/line-shadow-text-demo").then((m) => ({ default: m.default })),
-);
-export const LoaderDemo = dynamic(() =>
-  import("@/components/previews/loader-demo").then((m) => ({ default: m.LoaderDemo })),
-);
-export const MacbookProDemo = dynamic(() =>
-  import("@/components/previews/macbook-pro-demo").then((m) => ({ default: m.MacbookProDemo })),
-);
-export const MagicCardDemo = dynamic(() =>
-  import("@/components/previews/magic-card-demo").then((m) => ({ default: m.MagicCardDemo })),
-);
-export const MaterialDemo = dynamic(() =>
-  import("@/components/previews/material-demo").then((m) => ({ default: m.MaterialDemo })),
-);
-export const Menu2Demo = dynamic(() =>
-  import("@/components/previews/menu-2-demo").then((m) => ({ default: m.Menu2Demo })),
-);
-export const Menu3Demo = dynamic(() =>
-  import("@/components/previews/menu-3-demo").then((m) => ({ default: m.Menu3Demo })),
-);
-export const Menu4Demo = dynamic(() =>
-  import("@/components/previews/menu-4-demo").then((m) => ({ default: m.Menu4Demo })),
-);
-export const Menu5Demo = dynamic(() =>
-  import("@/components/previews/menu-5-demo").then((m) => ({ default: m.Menu5Demo })),
-);
-export const MenuDemo = dynamic(() =>
-  import("@/components/previews/menu-demo").then((m) => ({ default: m.MenuDemo })),
-);
-export const MenubarDemo = dynamic(() =>
-  import("@/components/previews/menubar-demo").then((m) => ({ default: m.MenubarDemo })),
-);
-export const MermaidDemo = dynamic(() =>
-  import("@/components/previews/mermaid-demo").then((m) => ({ default: m.MermaidDemo })),
-);
-export const MessageWithReactionsDemo = dynamic(() =>
-  import("@/components/previews/message-with-reactions-demo").then((m) => ({ default: m.default })),
-);
-export const MiddleTruncateDemo = dynamic(() =>
-  import("@/components/previews/middle-truncate-demo").then((m) => ({
-    default: m.MiddleTruncateDemo,
-  })),
-);
-export const MultipleSelectorDemo = dynamic(() =>
-  import("@/components/previews/multiple-selector-demo").then((m) => ({
-    default: m.MultipleSelectorDemo,
-  })),
-);
-export const NavigationMenuDemo = dynamic(() =>
-  import("@/components/previews/navigation-menu-demo").then((m) => ({
-    default: m.NavigationMenuDemo,
-  })),
-);
-export const NoisePatternCardDemo = dynamic(() =>
-  import("@/components/previews/noise-pattern-card-demo").then((m) => ({
-    default: m.NoisePatternCardDemo,
-  })),
-);
-export const NotificationMessageListDemo = dynamic(() =>
-  import("@/components/previews/notification-message-list-demo").then((m) => ({
-    default: m.NotificationMessageListDemo,
-  })),
-);
-export const PageContainerDemo = dynamic(() =>
-  import("@/components/previews/page-container-demo").then((m) => ({
-    default: m.PageContainerDemo,
-  })),
-);
-export const PaginationDemo = dynamic(() =>
-  import("@/components/previews/pagination-demo").then((m) => ({ default: m.PaginationDemo })),
-);
-export const Popover2Demo = dynamic(() =>
-  import("@/components/previews/popover-2-demo").then((m) => ({ default: m.Popover2Demo })),
-);
-export const PopoverControlledDemo = dynamic(() =>
-  import("@/components/previews/popover-controlled-demo").then((m) => ({
-    default: m.PopoverControlledDemo,
-  })),
-);
-export const PopoverDemo = dynamic(() =>
-  import("@/components/previews/popover-demo").then((m) => ({ default: m.PopoverDemo })),
-);
-export const PopoverSettingsDemo = dynamic(() =>
-  import("@/components/previews/popover-settings-demo").then((m) => ({
-    default: m.PopoverSettingsDemo,
-  })),
-);
-export const PricingCardDemo = dynamic(() =>
-  import("@/components/previews/pricing-card-demo").then((m) => ({ default: m.PricingCardDemo })),
-);
-export const Progress2Demo = dynamic(() =>
-  import("@/components/previews/progress-2-demo").then((m) => ({ default: m.Progress2Demo })),
-);
-export const Progress3Demo = dynamic(() =>
-  import("@/components/previews/progress-3-demo").then((m) => ({ default: m.Progress3Demo })),
-);
-export const Progress4Demo = dynamic(() =>
-  import("@/components/previews/progress-4-demo").then((m) => ({ default: m.Progress4Demo })),
-);
-export const ProgressBasicDemo = dynamic(() =>
-  import("@/components/previews/progress-basic-demo").then((m) => ({
-    default: m.ProgressBasicDemo,
-  })),
-);
-export const ProgressCustomColorDemo = dynamic(() =>
-  import("@/components/previews/progress-custom-color-demo").then((m) => ({
-    default: m.ProgressCustomColorDemo,
-  })),
-);
-export const ProgressDemo = dynamic(() =>
-  import("@/components/previews/progress-demo").then((m) => ({ default: m.ProgressDemo })),
-);
-export const ProgressIndeterminateDemo = dynamic(() =>
-  import("@/components/previews/progress-indeterminate-demo").then((m) => ({
-    default: m.ProgressIndeterminateDemo,
-  })),
-);
-export const ProgressWithLabelDemo = dynamic(() =>
-  import("@/components/previews/progress-with-label-demo").then((m) => ({
-    default: m.ProgressWithLabelDemo,
-  })),
-);
-export const ProgressiveBlurDemo = dynamic(() =>
-  import("@/components/previews/progressive-blur-demo").then((m) => ({
-    default: m.ProgressiveBlurDemo,
-  })),
-);
-export const RadioGroup2Demo = dynamic(() =>
-  import("@/components/previews/radio-group-2-demo").then((m) => ({ default: m.RadioGroup2Demo })),
-);
-export const RadioGroup3Demo = dynamic(() =>
-  import("@/components/previews/radio-group-3-demo").then((m) => ({ default: m.RadioGroup3Demo })),
-);
-export const RadioGroupBillingDemo = dynamic(() =>
-  import("@/components/previews/radio-group-billing-demo").then((m) => ({
-    default: m.RadioGroupBillingDemo,
-  })),
-);
-export const RadioGroupCardDemo = dynamic(() =>
-  import("@/components/previews/radio-group-card-demo").then((m) => ({
-    default: m.RadioGroupCardDemo,
-  })),
-);
-export const RadioGroupDemo = dynamic(() =>
-  import("@/components/previews/radio-group-demo").then((m) => ({ default: m.RadioGroupDemo })),
-);
-export const RadioGroupHorizontalDemo = dynamic(() =>
-  import("@/components/previews/radio-group-horizontal-demo").then((m) => ({
-    default: m.RadioGroupHorizontalDemo,
-  })),
-);
-export const RadioGroupStackedDemo = dynamic(() =>
-  import("@/components/previews/radio-group-stacked-demo").then((m) => ({
-    default: m.RadioGroupStackedDemo,
-  })),
-);
-export const ReactionChipDemo = dynamic(() =>
-  import("@/components/previews/reaction-chip-demo").then((m) => ({ default: m.ReactionChipDemo })),
-);
-export const Resizable2Demo = dynamic(() =>
-  import("@/components/previews/resizable-2-demo").then((m) => ({ default: m.Resizable2Demo })),
-);
-export const ResizableDemo = dynamic(() =>
-  import("@/components/previews/resizable-demo").then((m) => ({ default: m.ResizableDemo })),
-);
-export const SafariDemo = dynamic(() =>
-  import("@/components/previews/safari-demo").then((m) => ({ default: m.SafariDemo })),
-);
-export const ScrollArea2Demo = dynamic(() =>
-  import("@/components/previews/scroll-area-2-demo").then((m) => ({ default: m.ScrollArea2Demo })),
-);
-export const ScrollArea3Demo = dynamic(() =>
-  import("@/components/previews/scroll-area-3-demo").then((m) => ({ default: m.ScrollArea3Demo })),
-);
-export const ScrollAreaDemo = dynamic(() =>
-  import("@/components/previews/scroll-area-demo").then((m) => ({ default: m.ScrollAreaDemo })),
-);
-export const ScrollAreaListDemo = dynamic(() =>
-  import("@/components/previews/scroll-area-list-demo").then((m) => ({
-    default: m.ScrollAreaListDemo,
-  })),
-);
-export const ScrollVelocityDemo = dynamic(() =>
-  import("@/components/previews/scroll-velocity-demo").then((m) => ({
-    default: m.ScrollVelocityDemo,
-  })),
-);
-export const SelectDemo = dynamic(() =>
-  import("@/components/previews/select-demo").then((m) => ({ default: m.SelectDemo })),
-);
-export const SelectDisabledDemo = dynamic(() =>
-  import("@/components/previews/select-disabled-demo").then((m) => ({
-    default: m.SelectDisabledDemo,
-  })),
-);
-export const SelectGroupsDemo = dynamic(() =>
-  import("@/components/previews/select-groups-demo").then((m) => ({ default: m.SelectGroupsDemo })),
-);
-export const Separator2Demo = dynamic(() =>
-  import("@/components/previews/separator-2-demo").then((m) => ({ default: m.Separator2Demo })),
-);
-export const Separator3Demo = dynamic(() =>
-  import("@/components/previews/separator-3-demo").then((m) => ({ default: m.Separator3Demo })),
-);
-export const Separator4Demo = dynamic(() =>
-  import("@/components/previews/separator-4-demo").then((m) => ({ default: m.Separator4Demo })),
-);
-export const SeparatorDemo = dynamic(() =>
-  import("@/components/previews/separator-demo").then((m) => ({ default: m.SeparatorDemo })),
-);
-export const SeparatorVerticalDemo = dynamic(() =>
-  import("@/components/previews/separator-vertical-demo").then((m) => ({
-    default: m.SeparatorVerticalDemo,
-  })),
-);
-export const SeparatorWithTextDemo = dynamic(() =>
-  import("@/components/previews/separator-with-text-demo").then((m) => ({
-    default: m.SeparatorWithTextDemo,
-  })),
-);
-export const SeparatorWithTextI18nDemo = dynamic(() =>
-  import("@/components/previews/separator-with-text-i18n-demo").then((m) => ({
-    default: m.SeparatorWithTextI18nDemo,
-  })),
-);
-export const SheetDemo = dynamic(() =>
-  import("@/components/previews/sheet-demo").then((m) => ({ default: m.SheetDemo })),
-);
-export const SheetMobileDemo = dynamic(() =>
-  import("@/components/previews/sheet-mobile-demo").then((m) => ({ default: m.SheetMobileDemo })),
-);
-export const SheetSideDemo = dynamic(() =>
-  import("@/components/previews/sheet-side-demo").then((m) => ({ default: m.SheetSideDemo })),
-);
-export const ShineBorderDemo = dynamic(() =>
-  import("@/components/previews/shine-border-demo").then((m) => ({ default: m.ShineBorderDemo })),
-);
-export const SidebarDemo = dynamic(() =>
-  import("@/components/previews/sidebar-demo").then((m) => ({ default: m.SidebarDemo })),
-);
-export const Skeleton2Demo = dynamic(() =>
-  import("@/components/previews/skeleton-2-demo").then((m) => ({ default: m.Skeleton2Demo })),
-);
-export const Skeleton3Demo = dynamic(() =>
-  import("@/components/previews/skeleton-3-demo").then((m) => ({ default: m.Skeleton3Demo })),
-);
-export const SkeletonDemo = dynamic(() =>
-  import("@/components/previews/skeleton-demo").then((m) => ({ default: m.SkeletonDemo })),
-);
-export const SkeletonListDemo = dynamic(() =>
-  import("@/components/previews/skeleton-list-demo").then((m) => ({ default: m.SkeletonListDemo })),
-);
-export const Slider2Demo = dynamic(() =>
-  import("@/components/previews/slider-2-demo").then((m) => ({ default: m.Slider2Demo })),
-);
-export const Slider3Demo = dynamic(() =>
-  import("@/components/previews/slider-3-demo").then((m) => ({ default: m.Slider3Demo })),
-);
-export const Slider4Demo = dynamic(() =>
-  import("@/components/previews/slider-4-demo").then((m) => ({ default: m.Slider4Demo })),
-);
-export const SliderDemo = dynamic(() =>
-  import("@/components/previews/slider-demo").then((m) => ({ default: m.SliderDemo })),
-);
-export const SliderIconDemo = dynamic(() =>
-  import("@/components/previews/slider-icon-demo").then((m) => ({ default: m.SliderIconDemo })),
-);
-export const SliderNumberFlowDemo = dynamic(() =>
-  import("@/components/previews/slider-number-flow-demo").then((m) => ({
-    default: m.SliderNumberFlowDemo,
-  })),
-);
-export const SliderOnValueChangeDemo = dynamic(() =>
-  import("@/components/previews/slider-on-value-change-demo").then((m) => ({ default: m.default })),
-);
-export const SliderStatefulDemo = dynamic(() =>
-  import("@/components/previews/slider-stateful-demo").then((m) => ({ default: m.default })),
-);
-export const SonnerDemo = dynamic(() =>
-  import("@/components/previews/sonner-demo").then((m) => ({ default: m.SonnerDemo })),
-);
-export const SpinnerDemo = dynamic(() =>
-  import("@/components/previews/spinner-demo").then((m) => ({ default: m.SpinnerDemo })),
-);
-export const StackDemo = dynamic(() =>
-  import("@/components/previews/stack-demo").then((m) => ({ default: m.StackDemo })),
-);
-export const StarsCanvasDemo = dynamic(() =>
-  import("@/components/previews/stars-canvas-demo").then((m) => ({ default: m.StarsCanvasDemo })),
-);
-export const StatusBadgeDemo = dynamic(() =>
-  import("@/components/previews/status-badge-demo").then((m) => ({ default: m.StatusBadgeDemo })),
-);
-export const SwitchDemo = dynamic(() =>
-  import("@/components/previews/switch-demo").then((m) => ({ default: m.SwitchDemo })),
-);
-export const TableDemo = dynamic(() =>
-  import("@/components/previews/table-demo").then((m) => ({ default: m.TableDemo })),
-);
-export const TabsButtonDemo = dynamic(() =>
-  import("@/components/previews/tabs-button-demo").then((m) => ({ default: m.TabsButtonDemo })),
-);
-export const TabsDemo = dynamic(() =>
-  import("@/components/previews/tabs-demo").then((m) => ({ default: m.TabsDemo })),
-);
-export const TabsLineDemo = dynamic(() =>
-  import("@/components/previews/tabs-line-demo").then((m) => ({ default: m.TabsLineDemo })),
-);
-export const TabsPillDemo = dynamic(() =>
-  import("@/components/previews/tabs-pill-demo").then((m) => ({ default: m.TabsPillDemo })),
-);
-export const TerminalDemo = dynamic(() =>
-  import("@/components/previews/terminal-demo").then((m) => ({ default: m.TerminalDemo })),
-);
-export const TextDemo = dynamic(() =>
-  import("@/components/previews/text-demo").then((m) => ({ default: m.TextDemo })),
-);
-export const TextLoopDemo = dynamic(() =>
-  import("@/components/previews/text-loop-demo").then((m) => ({ default: m.default })),
-);
-export const TextScrambleDemo = dynamic(() =>
-  import("@/components/previews/text-scramble-demo").then((m) => ({ default: m.default })),
-);
-export const TextShimmerDemo = dynamic(() =>
-  import("@/components/previews/text-shimmer-demo").then((m) => ({ default: m.default })),
-);
-export const Textarea2Demo = dynamic(() =>
-  import("@/components/previews/textarea-2-demo").then((m) => ({ default: m.Textarea2Demo })),
-);
-export const Textarea3Demo = dynamic(() =>
-  import("@/components/previews/textarea-3-demo").then((m) => ({ default: m.Textarea3Demo })),
-);
-export const TextareaDemo = dynamic(() =>
-  import("@/components/previews/textarea-demo").then((m) => ({ default: m.TextareaDemo })),
-);
-export const TextareaDisabledDemo = dynamic(() =>
-  import("@/components/previews/textarea-disabled-demo").then((m) => ({
-    default: m.TextareaDisabledDemo,
-  })),
-);
-export const TextareaWithLimitDemo = dynamic(() =>
-  import("@/components/previews/textarea-with-limit-demo").then((m) => ({
-    default: m.TextareaWithLimitDemo,
-  })),
+export const ContextCardDemo = dynamic(
+  () =>
+    import("@/components/previews/context-card-demo").then((m) => ({ default: m.ContextCardDemo })),
+  { ssr: false },
+);
+export const ContextMenuDemo = dynamic(
+  () =>
+    import("@/components/previews/context-menu-demo").then((m) => ({ default: m.ContextMenuDemo })),
+  { ssr: false },
+);
+export const ContextMenuWithIconsDemo = dynamic(
+  () =>
+    import("@/components/previews/context-menu-with-icons-demo").then((m) => ({
+      default: m.ContextMenuWithIconsDemo,
+    })),
+  { ssr: false },
+);
+export const DescriptionDemo = dynamic(
+  () =>
+    import("@/components/previews/description-demo").then((m) => ({ default: m.DescriptionDemo })),
+  { ssr: false },
+);
+export const DialogDemo = dynamic(
+  () => import("@/components/previews/dialog-demo").then((m) => ({ default: m.DialogDemo })),
+  { ssr: false },
+);
+export const DialogDestructiveDemo = dynamic(
+  () =>
+    import("@/components/previews/dialog-destructive-demo").then((m) => ({
+      default: m.DialogDestructiveDemo,
+    })),
+  { ssr: false },
+);
+export const DisplayCardsDemo = dynamic(
+  () =>
+    import("@/components/previews/display-cards-demo").then((m) => ({
+      default: m.DisplayCardsDemo,
+    })),
+  { ssr: false },
+);
+export const DitheringBackgroundDemo = dynamic(
+  () =>
+    import("@/components/previews/dithering-background-demo").then((m) => ({
+      default: m.DitheringBackgroundDemo,
+    })),
+  { ssr: false },
+);
+export const DitheringShaderDemo = dynamic(
+  () =>
+    import("@/components/previews/dithering-shader-demo").then((m) => ({
+      default: m.DitheringShaderDemo,
+    })),
+  { ssr: false },
+);
+export const DotPatternDemo = dynamic(
+  () =>
+    import("@/components/previews/dot-pattern-demo").then((m) => ({ default: m.DotPatternDemo })),
+  { ssr: false },
+);
+export const DottedMapDemo = dynamic(
+  () => import("@/components/previews/dotted-map-demo").then((m) => ({ default: m.DottedMapDemo })),
+  { ssr: false },
+);
+export const DottedWorldMapDemo = dynamic(
+  () =>
+    import("@/components/previews/dotted-world-map-demo").then((m) => ({
+      default: m.DottedWorldMapDemo,
+    })),
+  { ssr: false },
+);
+export const Drawer2Demo = dynamic(
+  () => import("@/components/previews/drawer-2-demo").then((m) => ({ default: m.Drawer2Demo })),
+  { ssr: false },
+);
+export const Drawer3Demo = dynamic(
+  () => import("@/components/previews/drawer-3-demo").then((m) => ({ default: m.Drawer3Demo })),
+  { ssr: false },
+);
+export const DrawerDemo = dynamic(
+  () => import("@/components/previews/drawer-demo").then((m) => ({ default: m.DrawerDemo })),
+  { ssr: false },
+);
+export const DrawerSideRightDemo = dynamic(
+  () =>
+    import("@/components/previews/drawer-side-right-demo").then((m) => ({
+      default: m.DrawerSideRightDemo,
+    })),
+  { ssr: false },
+);
+export const DropdownMenu2Demo = dynamic(
+  () =>
+    import("@/components/previews/dropdown-menu-2-demo").then((m) => ({
+      default: m.DropdownMenu2Demo,
+    })),
+  { ssr: false },
+);
+export const DropdownMenu3Demo = dynamic(
+  () =>
+    import("@/components/previews/dropdown-menu-3-demo").then((m) => ({
+      default: m.DropdownMenu3Demo,
+    })),
+  { ssr: false },
+);
+export const DropdownMenu4Demo = dynamic(
+  () =>
+    import("@/components/previews/dropdown-menu-4-demo").then((m) => ({
+      default: m.DropdownMenu4Demo,
+    })),
+  { ssr: false },
+);
+export const DropdownMenuDemo = dynamic(
+  () =>
+    import("@/components/previews/dropdown-menu-demo").then((m) => ({
+      default: m.DropdownMenuDemo,
+    })),
+  { ssr: false },
+);
+export const DropdownMenuRadioGroupDemo = dynamic(
+  () =>
+    import("@/components/previews/dropdown-menu-radio-group-demo").then((m) => ({
+      default: m.DropdownMenuRadioGroupDemo,
+    })),
+  { ssr: false },
+);
+export const DropdownMenuSubDemo = dynamic(
+  () =>
+    import("@/components/previews/dropdown-menu-sub-demo").then((m) => ({
+      default: m.DropdownMenuSubDemo,
+    })),
+  { ssr: false },
+);
+export const EmptyStateDemo = dynamic(
+  () =>
+    import("@/components/previews/empty-state-demo").then((m) => ({ default: m.EmptyStateDemo })),
+  { ssr: false },
+);
+export const EntityDemo = dynamic(
+  () => import("@/components/previews/entity-demo").then((m) => ({ default: m.EntityDemo })),
+  { ssr: false },
+);
+export const ErrorMessageDemo = dynamic(
+  () =>
+    import("@/components/previews/error-message-demo").then((m) => ({
+      default: m.ErrorMessageDemo,
+    })),
+  { ssr: false },
+);
+export const ExpandableTabsDemo = dynamic(
+  () =>
+    import("@/components/previews/expandable-tabs-demo").then((m) => ({
+      default: m.ExpandableTabsDemo,
+    })),
+  { ssr: false },
+);
+export const ExpandingTextareaDemo = dynamic(
+  () =>
+    import("@/components/previews/expanding-textarea-demo").then((m) => ({
+      default: m.ExpandingTextareaDemo,
+    })),
+  { ssr: false },
+);
+export const FeatureArrowCardDemo = dynamic(
+  () =>
+    import("@/components/previews/feature-arrow-card-demo").then((m) => ({
+      default: m.FeatureArrowCardDemo,
+    })),
+  { ssr: false },
+);
+export const FeatureCardDemo = dynamic(
+  () =>
+    import("@/components/previews/feature-card-demo").then((m) => ({ default: m.FeatureCardDemo })),
+  { ssr: false },
+);
+export const FeatureCheckItemDemo = dynamic(
+  () =>
+    import("@/components/previews/feature-check-item-demo").then((m) => ({
+      default: m.FeatureCheckItemDemo,
+    })),
+  { ssr: false },
+);
+export const FeatureIconItemDemo = dynamic(
+  () =>
+    import("@/components/previews/feature-icon-item-demo").then((m) => ({
+      default: m.FeatureIconItemDemo,
+    })),
+  { ssr: false },
+);
+export const FeedbackDemo = dynamic(
+  () => import("@/components/previews/feedback-demo").then((m) => ({ default: m.FeedbackDemo })),
+  { ssr: false },
+);
+export const FieldDemo = dynamic(
+  () => import("@/components/previews/field-demo").then((m) => ({ default: m.FieldDemo })),
+  { ssr: false },
+);
+export const FlexDemo = dynamic(
+  () => import("@/components/previews/flex-demo").then((m) => ({ default: m.FlexDemo })),
+  { ssr: false },
+);
+export const FlickeringGridDemo = dynamic(
+  () =>
+    import("@/components/previews/flickering-grid-demo").then((m) => ({
+      default: m.FlickeringGridDemo,
+    })),
+  { ssr: false },
+);
+export const FormDemo = dynamic(
+  () => import("@/components/previews/form-demo").then((m) => ({ default: m.FormDemo })),
+  { ssr: false },
+);
+export const GaugeDemo = dynamic(
+  () => import("@/components/previews/gauge-demo").then((m) => ({ default: m.GaugeDemo })),
+  { ssr: false },
+);
+export const GithubCalendarDemo = dynamic(
+  () =>
+    import("@/components/previews/github-calendar-demo").then((m) => ({
+      default: m.GithubCalendarDemo,
+    })),
+  { ssr: false },
+);
+export const GithubInlineDiffDemo = dynamic(
+  () =>
+    import("@/components/previews/github-inline-diff-demo").then((m) => ({
+      default: m.GithubInlineDiffDemo,
+    })),
+  { ssr: false },
+);
+export const GlobeDemo = dynamic(
+  () => import("@/components/previews/globe-demo").then((m) => ({ default: m.GlobeDemo })),
+  { ssr: false },
+);
+export const GradientAnimatedTextDemo = dynamic(
+  () =>
+    import("@/components/previews/gradient-animated-text-demo").then((m) => ({
+      default: m.default,
+    })),
+  { ssr: false },
+);
+export const GrainGradientBackgroundDemo = dynamic(
+  () =>
+    import("@/components/previews/grain-gradient-background-demo").then((m) => ({
+      default: m.GrainGradientBackgroundDemo,
+    })),
+  { ssr: false },
+);
+export const GridFeatureCardDemo = dynamic(
+  () =>
+    import("@/components/previews/grid-feature-card-demo").then((m) => ({
+      default: m.GridFeatureCardDemo,
+    })),
+  { ssr: false },
+);
+export const GridPatternCardDemo = dynamic(
+  () =>
+    import("@/components/previews/grid-pattern-card-demo").then((m) => ({
+      default: m.GridPatternCardDemo,
+    })),
+  { ssr: false },
+);
+export const GridSystemDemo = dynamic(
+  () =>
+    import("@/components/previews/grid-system-demo").then((m) => ({ default: m.GridSystemDemo })),
+  { ssr: false },
+);
+export const HeadingDemo = dynamic(
+  () => import("@/components/previews/heading-demo").then((m) => ({ default: m.HeadingDemo })),
+  { ssr: false },
+);
+export const HexGridDemo = dynamic(
+  () => import("@/components/previews/hex-grid-demo").then((m) => ({ default: m.HexGridDemo })),
+  { ssr: false },
+);
+export const HighlighterDemo = dynamic(
+  () =>
+    import("@/components/previews/highlighter-demo").then((m) => ({ default: m.HighlighterDemo })),
+  { ssr: false },
+);
+export const HoverCard2Demo = dynamic(
+  () =>
+    import("@/components/previews/hover-card-2-demo").then((m) => ({ default: m.HoverCard2Demo })),
+  { ssr: false },
+);
+export const HoverCardDemo = dynamic(
+  () => import("@/components/previews/hover-card-demo").then((m) => ({ default: m.HoverCardDemo })),
+  { ssr: false },
+);
+export const InfiniteSliderDemo = dynamic(
+  () =>
+    import("@/components/previews/infinite-slider-demo").then((m) => ({
+      default: m.InfiniteSliderDemo,
+    })),
+  { ssr: false },
+);
+export const Input2Demo = dynamic(
+  () => import("@/components/previews/input-2-demo").then((m) => ({ default: m.Input2Demo })),
+  { ssr: false },
+);
+export const InputBasicDemo = dynamic(
+  () =>
+    import("@/components/previews/input-basic-demo").then((m) => ({ default: m.InputBasicDemo })),
+  { ssr: false },
+);
+export const InputClearableDemo = dynamic(
+  () =>
+    import("@/components/previews/input-clearable-demo").then((m) => ({
+      default: m.InputClearableDemo,
+    })),
+  { ssr: false },
+);
+export const InputDemo = dynamic(
+  () => import("@/components/previews/input-demo").then((m) => ({ default: m.InputDemo })),
+  { ssr: false },
+);
+export const InputErrorDemo = dynamic(
+  () =>
+    import("@/components/previews/input-error-demo").then((m) => ({ default: m.InputErrorDemo })),
+  { ssr: false },
+);
+export const InputOtpDemo = dynamic(
+  () => import("@/components/previews/input-otp-demo").then((m) => ({ default: m.InputOtpDemo })),
+  { ssr: false },
+);
+export const InputOTPNumericDemo = dynamic(
+  () =>
+    import("@/components/previews/input-otp-numeric-demo").then((m) => ({
+      default: m.InputOTPNumericDemo,
+    })),
+  { ssr: false },
+);
+export const InputPasswordRevealDemo = dynamic(
+  () =>
+    import("@/components/previews/input-password-reveal-demo").then((m) => ({
+      default: m.InputPasswordRevealDemo,
+    })),
+  { ssr: false },
+);
+export const InputWithAddonsDemo = dynamic(
+  () =>
+    import("@/components/previews/input-with-addons-demo").then((m) => ({
+      default: m.InputWithAddonsDemo,
+    })),
+  { ssr: false },
+);
+export const InputWithIconDemo = dynamic(
+  () =>
+    import("@/components/previews/input-with-icon-demo").then((m) => ({
+      default: m.InputWithIconDemo,
+    })),
+  { ssr: false },
+);
+export const InputWithLabelDemo = dynamic(
+  () =>
+    import("@/components/previews/input-with-label-demo").then((m) => ({
+      default: m.InputWithLabelDemo,
+    })),
+  { ssr: false },
+);
+export const InteractiveCardDemo = dynamic(
+  () =>
+    import("@/components/previews/interactive-card-demo").then((m) => ({
+      default: m.InteractiveCardDemo,
+    })),
+  { ssr: false },
+);
+export const IntroductionDemo = dynamic(
+  () =>
+    import("@/components/previews/introduction-demo").then((m) => ({
+      default: m.IntroductionDemo,
+    })),
+  { ssr: false },
+);
+export const IphoneMockupDemo = dynamic(
+  () =>
+    import("@/components/previews/iphone-mockup-demo").then((m) => ({
+      default: m.IphoneMockupDemo,
+    })),
+  { ssr: false },
+);
+export const KbdDemo = dynamic(
+  () => import("@/components/previews/kbd-demo").then((m) => ({ default: m.KbdDemo })),
+  { ssr: false },
+);
+export const Label2Demo = dynamic(
+  () => import("@/components/previews/label-2-demo").then((m) => ({ default: m.Label2Demo })),
+  { ssr: false },
+);
+export const Label3Demo = dynamic(
+  () => import("@/components/previews/label-3-demo").then((m) => ({ default: m.Label3Demo })),
+  { ssr: false },
+);
+export const Label4Demo = dynamic(
+  () => import("@/components/previews/label-4-demo").then((m) => ({ default: m.Label4Demo })),
+  { ssr: false },
+);
+export const LabelDemo = dynamic(
+  () => import("@/components/previews/label-demo").then((m) => ({ default: m.LabelDemo })),
+  { ssr: false },
+);
+export const LabelDescriptionDemo = dynamic(
+  () =>
+    import("@/components/previews/label-description-demo").then((m) => ({
+      default: m.LabelDescriptionDemo,
+    })),
+  { ssr: false },
+);
+export const LabelDisabledDemo = dynamic(
+  () =>
+    import("@/components/previews/label-disabled-demo").then((m) => ({
+      default: m.LabelDisabledDemo,
+    })),
+  { ssr: false },
+);
+export const LightRaysDemo = dynamic(
+  () => import("@/components/previews/light-rays-demo").then((m) => ({ default: m.LightRaysDemo })),
+  { ssr: false },
+);
+export const LineShadowTextDemo = dynamic(
+  () => import("@/components/previews/line-shadow-text-demo").then((m) => ({ default: m.default })),
+  { ssr: false },
+);
+export const LoaderDemo = dynamic(
+  () => import("@/components/previews/loader-demo").then((m) => ({ default: m.LoaderDemo })),
+  { ssr: false },
+);
+export const MacbookProDemo = dynamic(
+  () =>
+    import("@/components/previews/macbook-pro-demo").then((m) => ({ default: m.MacbookProDemo })),
+  { ssr: false },
+);
+export const MagicCardDemo = dynamic(
+  () => import("@/components/previews/magic-card-demo").then((m) => ({ default: m.MagicCardDemo })),
+  { ssr: false },
+);
+export const MaterialDemo = dynamic(
+  () => import("@/components/previews/material-demo").then((m) => ({ default: m.MaterialDemo })),
+  { ssr: false },
+);
+export const Menu2Demo = dynamic(
+  () => import("@/components/previews/menu-2-demo").then((m) => ({ default: m.Menu2Demo })),
+  { ssr: false },
+);
+export const Menu3Demo = dynamic(
+  () => import("@/components/previews/menu-3-demo").then((m) => ({ default: m.Menu3Demo })),
+  { ssr: false },
+);
+export const Menu4Demo = dynamic(
+  () => import("@/components/previews/menu-4-demo").then((m) => ({ default: m.Menu4Demo })),
+  { ssr: false },
+);
+export const Menu5Demo = dynamic(
+  () => import("@/components/previews/menu-5-demo").then((m) => ({ default: m.Menu5Demo })),
+  { ssr: false },
+);
+export const MenuDemo = dynamic(
+  () => import("@/components/previews/menu-demo").then((m) => ({ default: m.MenuDemo })),
+  { ssr: false },
+);
+export const MenubarDemo = dynamic(
+  () => import("@/components/previews/menubar-demo").then((m) => ({ default: m.MenubarDemo })),
+  { ssr: false },
+);
+export const MermaidDemo = dynamic(
+  () => import("@/components/previews/mermaid-demo").then((m) => ({ default: m.MermaidDemo })),
+  { ssr: false },
+);
+export const MessageWithReactionsDemo = dynamic(
+  () =>
+    import("@/components/previews/message-with-reactions-demo").then((m) => ({
+      default: m.default,
+    })),
+  { ssr: false },
+);
+export const MiddleTruncateDemo = dynamic(
+  () =>
+    import("@/components/previews/middle-truncate-demo").then((m) => ({
+      default: m.MiddleTruncateDemo,
+    })),
+  { ssr: false },
+);
+export const MultipleSelectorDemo = dynamic(
+  () =>
+    import("@/components/previews/multiple-selector-demo").then((m) => ({
+      default: m.MultipleSelectorDemo,
+    })),
+  { ssr: false },
+);
+export const NavigationMenuDemo = dynamic(
+  () =>
+    import("@/components/previews/navigation-menu-demo").then((m) => ({
+      default: m.NavigationMenuDemo,
+    })),
+  { ssr: false },
+);
+export const NoisePatternCardDemo = dynamic(
+  () =>
+    import("@/components/previews/noise-pattern-card-demo").then((m) => ({
+      default: m.NoisePatternCardDemo,
+    })),
+  { ssr: false },
+);
+export const NotificationMessageListDemo = dynamic(
+  () =>
+    import("@/components/previews/notification-message-list-demo").then((m) => ({
+      default: m.NotificationMessageListDemo,
+    })),
+  { ssr: false },
+);
+export const PageContainerDemo = dynamic(
+  () =>
+    import("@/components/previews/page-container-demo").then((m) => ({
+      default: m.PageContainerDemo,
+    })),
+  { ssr: false },
+);
+export const PaginationDemo = dynamic(
+  () =>
+    import("@/components/previews/pagination-demo").then((m) => ({ default: m.PaginationDemo })),
+  { ssr: false },
+);
+export const Popover2Demo = dynamic(
+  () => import("@/components/previews/popover-2-demo").then((m) => ({ default: m.Popover2Demo })),
+  { ssr: false },
+);
+export const PopoverControlledDemo = dynamic(
+  () =>
+    import("@/components/previews/popover-controlled-demo").then((m) => ({
+      default: m.PopoverControlledDemo,
+    })),
+  { ssr: false },
+);
+export const PopoverDemo = dynamic(
+  () => import("@/components/previews/popover-demo").then((m) => ({ default: m.PopoverDemo })),
+  { ssr: false },
+);
+export const PopoverSettingsDemo = dynamic(
+  () =>
+    import("@/components/previews/popover-settings-demo").then((m) => ({
+      default: m.PopoverSettingsDemo,
+    })),
+  { ssr: false },
+);
+export const PricingCardDemo = dynamic(
+  () =>
+    import("@/components/previews/pricing-card-demo").then((m) => ({ default: m.PricingCardDemo })),
+  { ssr: false },
+);
+export const Progress2Demo = dynamic(
+  () => import("@/components/previews/progress-2-demo").then((m) => ({ default: m.Progress2Demo })),
+  { ssr: false },
+);
+export const Progress3Demo = dynamic(
+  () => import("@/components/previews/progress-3-demo").then((m) => ({ default: m.Progress3Demo })),
+  { ssr: false },
+);
+export const Progress4Demo = dynamic(
+  () => import("@/components/previews/progress-4-demo").then((m) => ({ default: m.Progress4Demo })),
+  { ssr: false },
+);
+export const ProgressBasicDemo = dynamic(
+  () =>
+    import("@/components/previews/progress-basic-demo").then((m) => ({
+      default: m.ProgressBasicDemo,
+    })),
+  { ssr: false },
+);
+export const ProgressCustomColorDemo = dynamic(
+  () =>
+    import("@/components/previews/progress-custom-color-demo").then((m) => ({
+      default: m.ProgressCustomColorDemo,
+    })),
+  { ssr: false },
+);
+export const ProgressDemo = dynamic(
+  () => import("@/components/previews/progress-demo").then((m) => ({ default: m.ProgressDemo })),
+  { ssr: false },
+);
+export const ProgressIndeterminateDemo = dynamic(
+  () =>
+    import("@/components/previews/progress-indeterminate-demo").then((m) => ({
+      default: m.ProgressIndeterminateDemo,
+    })),
+  { ssr: false },
+);
+export const ProgressWithLabelDemo = dynamic(
+  () =>
+    import("@/components/previews/progress-with-label-demo").then((m) => ({
+      default: m.ProgressWithLabelDemo,
+    })),
+  { ssr: false },
+);
+export const ProgressiveBlurDemo = dynamic(
+  () =>
+    import("@/components/previews/progressive-blur-demo").then((m) => ({
+      default: m.ProgressiveBlurDemo,
+    })),
+  { ssr: false },
+);
+export const RadioGroup2Demo = dynamic(
+  () =>
+    import("@/components/previews/radio-group-2-demo").then((m) => ({
+      default: m.RadioGroup2Demo,
+    })),
+  { ssr: false },
+);
+export const RadioGroup3Demo = dynamic(
+  () =>
+    import("@/components/previews/radio-group-3-demo").then((m) => ({
+      default: m.RadioGroup3Demo,
+    })),
+  { ssr: false },
+);
+export const RadioGroupBillingDemo = dynamic(
+  () =>
+    import("@/components/previews/radio-group-billing-demo").then((m) => ({
+      default: m.RadioGroupBillingDemo,
+    })),
+  { ssr: false },
+);
+export const RadioGroupCardDemo = dynamic(
+  () =>
+    import("@/components/previews/radio-group-card-demo").then((m) => ({
+      default: m.RadioGroupCardDemo,
+    })),
+  { ssr: false },
+);
+export const RadioGroupDemo = dynamic(
+  () =>
+    import("@/components/previews/radio-group-demo").then((m) => ({ default: m.RadioGroupDemo })),
+  { ssr: false },
+);
+export const RadioGroupHorizontalDemo = dynamic(
+  () =>
+    import("@/components/previews/radio-group-horizontal-demo").then((m) => ({
+      default: m.RadioGroupHorizontalDemo,
+    })),
+  { ssr: false },
+);
+export const RadioGroupStackedDemo = dynamic(
+  () =>
+    import("@/components/previews/radio-group-stacked-demo").then((m) => ({
+      default: m.RadioGroupStackedDemo,
+    })),
+  { ssr: false },
+);
+export const ReactionChipDemo = dynamic(
+  () =>
+    import("@/components/previews/reaction-chip-demo").then((m) => ({
+      default: m.ReactionChipDemo,
+    })),
+  { ssr: false },
+);
+export const Resizable2Demo = dynamic(
+  () =>
+    import("@/components/previews/resizable-2-demo").then((m) => ({ default: m.Resizable2Demo })),
+  { ssr: false },
+);
+export const ResizableDemo = dynamic(
+  () => import("@/components/previews/resizable-demo").then((m) => ({ default: m.ResizableDemo })),
+  { ssr: false },
+);
+export const SafariDemo = dynamic(
+  () => import("@/components/previews/safari-demo").then((m) => ({ default: m.SafariDemo })),
+  { ssr: false },
+);
+export const ScrollArea2Demo = dynamic(
+  () =>
+    import("@/components/previews/scroll-area-2-demo").then((m) => ({
+      default: m.ScrollArea2Demo,
+    })),
+  { ssr: false },
+);
+export const ScrollArea3Demo = dynamic(
+  () =>
+    import("@/components/previews/scroll-area-3-demo").then((m) => ({
+      default: m.ScrollArea3Demo,
+    })),
+  { ssr: false },
+);
+export const ScrollAreaDemo = dynamic(
+  () =>
+    import("@/components/previews/scroll-area-demo").then((m) => ({ default: m.ScrollAreaDemo })),
+  { ssr: false },
+);
+export const ScrollAreaListDemo = dynamic(
+  () =>
+    import("@/components/previews/scroll-area-list-demo").then((m) => ({
+      default: m.ScrollAreaListDemo,
+    })),
+  { ssr: false },
+);
+export const ScrollVelocityDemo = dynamic(
+  () =>
+    import("@/components/previews/scroll-velocity-demo").then((m) => ({
+      default: m.ScrollVelocityDemo,
+    })),
+  { ssr: false },
+);
+export const SelectDemo = dynamic(
+  () => import("@/components/previews/select-demo").then((m) => ({ default: m.SelectDemo })),
+  { ssr: false },
+);
+export const SelectDisabledDemo = dynamic(
+  () =>
+    import("@/components/previews/select-disabled-demo").then((m) => ({
+      default: m.SelectDisabledDemo,
+    })),
+  { ssr: false },
+);
+export const SelectGroupsDemo = dynamic(
+  () =>
+    import("@/components/previews/select-groups-demo").then((m) => ({
+      default: m.SelectGroupsDemo,
+    })),
+  { ssr: false },
+);
+export const Separator2Demo = dynamic(
+  () =>
+    import("@/components/previews/separator-2-demo").then((m) => ({ default: m.Separator2Demo })),
+  { ssr: false },
+);
+export const Separator3Demo = dynamic(
+  () =>
+    import("@/components/previews/separator-3-demo").then((m) => ({ default: m.Separator3Demo })),
+  { ssr: false },
+);
+export const Separator4Demo = dynamic(
+  () =>
+    import("@/components/previews/separator-4-demo").then((m) => ({ default: m.Separator4Demo })),
+  { ssr: false },
+);
+export const SeparatorDemo = dynamic(
+  () => import("@/components/previews/separator-demo").then((m) => ({ default: m.SeparatorDemo })),
+  { ssr: false },
+);
+export const SeparatorVerticalDemo = dynamic(
+  () =>
+    import("@/components/previews/separator-vertical-demo").then((m) => ({
+      default: m.SeparatorVerticalDemo,
+    })),
+  { ssr: false },
+);
+export const SeparatorWithTextDemo = dynamic(
+  () =>
+    import("@/components/previews/separator-with-text-demo").then((m) => ({
+      default: m.SeparatorWithTextDemo,
+    })),
+  { ssr: false },
+);
+export const SeparatorWithTextI18nDemo = dynamic(
+  () =>
+    import("@/components/previews/separator-with-text-i18n-demo").then((m) => ({
+      default: m.SeparatorWithTextI18nDemo,
+    })),
+  { ssr: false },
+);
+export const SheetDemo = dynamic(
+  () => import("@/components/previews/sheet-demo").then((m) => ({ default: m.SheetDemo })),
+  { ssr: false },
+);
+export const SheetMobileDemo = dynamic(
+  () =>
+    import("@/components/previews/sheet-mobile-demo").then((m) => ({ default: m.SheetMobileDemo })),
+  { ssr: false },
+);
+export const SheetSideDemo = dynamic(
+  () => import("@/components/previews/sheet-side-demo").then((m) => ({ default: m.SheetSideDemo })),
+  { ssr: false },
+);
+export const ShineBorderDemo = dynamic(
+  () =>
+    import("@/components/previews/shine-border-demo").then((m) => ({ default: m.ShineBorderDemo })),
+  { ssr: false },
+);
+export const SidebarDemo = dynamic(
+  () => import("@/components/previews/sidebar-demo").then((m) => ({ default: m.SidebarDemo })),
+  { ssr: false },
+);
+export const Skeleton2Demo = dynamic(
+  () => import("@/components/previews/skeleton-2-demo").then((m) => ({ default: m.Skeleton2Demo })),
+  { ssr: false },
+);
+export const Skeleton3Demo = dynamic(
+  () => import("@/components/previews/skeleton-3-demo").then((m) => ({ default: m.Skeleton3Demo })),
+  { ssr: false },
+);
+export const SkeletonDemo = dynamic(
+  () => import("@/components/previews/skeleton-demo").then((m) => ({ default: m.SkeletonDemo })),
+  { ssr: false },
+);
+export const SkeletonListDemo = dynamic(
+  () =>
+    import("@/components/previews/skeleton-list-demo").then((m) => ({
+      default: m.SkeletonListDemo,
+    })),
+  { ssr: false },
+);
+export const Slider2Demo = dynamic(
+  () => import("@/components/previews/slider-2-demo").then((m) => ({ default: m.Slider2Demo })),
+  { ssr: false },
+);
+export const Slider3Demo = dynamic(
+  () => import("@/components/previews/slider-3-demo").then((m) => ({ default: m.Slider3Demo })),
+  { ssr: false },
+);
+export const Slider4Demo = dynamic(
+  () => import("@/components/previews/slider-4-demo").then((m) => ({ default: m.Slider4Demo })),
+  { ssr: false },
+);
+export const SliderDemo = dynamic(
+  () => import("@/components/previews/slider-demo").then((m) => ({ default: m.SliderDemo })),
+  { ssr: false },
+);
+export const SliderIconDemo = dynamic(
+  () =>
+    import("@/components/previews/slider-icon-demo").then((m) => ({ default: m.SliderIconDemo })),
+  { ssr: false },
+);
+export const SliderNumberFlowDemo = dynamic(
+  () =>
+    import("@/components/previews/slider-number-flow-demo").then((m) => ({
+      default: m.SliderNumberFlowDemo,
+    })),
+  { ssr: false },
+);
+export const SliderOnValueChangeDemo = dynamic(
+  () =>
+    import("@/components/previews/slider-on-value-change-demo").then((m) => ({
+      default: m.default,
+    })),
+  { ssr: false },
+);
+export const SliderStatefulDemo = dynamic(
+  () => import("@/components/previews/slider-stateful-demo").then((m) => ({ default: m.default })),
+  { ssr: false },
+);
+export const SonnerDemo = dynamic(
+  () => import("@/components/previews/sonner-demo").then((m) => ({ default: m.SonnerDemo })),
+  { ssr: false },
+);
+export const SpinnerDemo = dynamic(
+  () => import("@/components/previews/spinner-demo").then((m) => ({ default: m.SpinnerDemo })),
+  { ssr: false },
+);
+export const StackDemo = dynamic(
+  () => import("@/components/previews/stack-demo").then((m) => ({ default: m.StackDemo })),
+  { ssr: false },
+);
+export const StarsCanvasDemo = dynamic(
+  () =>
+    import("@/components/previews/stars-canvas-demo").then((m) => ({ default: m.StarsCanvasDemo })),
+  { ssr: false },
+);
+export const StatusBadgeDemo = dynamic(
+  () =>
+    import("@/components/previews/status-badge-demo").then((m) => ({ default: m.StatusBadgeDemo })),
+  { ssr: false },
+);
+export const SwitchDemo = dynamic(
+  () => import("@/components/previews/switch-demo").then((m) => ({ default: m.SwitchDemo })),
+  { ssr: false },
+);
+export const TableDemo = dynamic(
+  () => import("@/components/previews/table-demo").then((m) => ({ default: m.TableDemo })),
+  { ssr: false },
+);
+export const TabsButtonDemo = dynamic(
+  () =>
+    import("@/components/previews/tabs-button-demo").then((m) => ({ default: m.TabsButtonDemo })),
+  { ssr: false },
+);
+export const TabsDemo = dynamic(
+  () => import("@/components/previews/tabs-demo").then((m) => ({ default: m.TabsDemo })),
+  { ssr: false },
+);
+export const TabsLineDemo = dynamic(
+  () => import("@/components/previews/tabs-line-demo").then((m) => ({ default: m.TabsLineDemo })),
+  { ssr: false },
+);
+export const TabsPillDemo = dynamic(
+  () => import("@/components/previews/tabs-pill-demo").then((m) => ({ default: m.TabsPillDemo })),
+  { ssr: false },
+);
+export const TerminalDemo = dynamic(
+  () => import("@/components/previews/terminal-demo").then((m) => ({ default: m.TerminalDemo })),
+  { ssr: false },
+);
+export const TextDemo = dynamic(
+  () => import("@/components/previews/text-demo").then((m) => ({ default: m.TextDemo })),
+  { ssr: false },
+);
+export const TextLoopDemo = dynamic(
+  () => import("@/components/previews/text-loop-demo").then((m) => ({ default: m.default })),
+  { ssr: false },
+);
+export const TextScrambleDemo = dynamic(
+  () => import("@/components/previews/text-scramble-demo").then((m) => ({ default: m.default })),
+  { ssr: false },
+);
+export const TextShimmerDemo = dynamic(
+  () => import("@/components/previews/text-shimmer-demo").then((m) => ({ default: m.default })),
+  { ssr: false },
+);
+export const Textarea2Demo = dynamic(
+  () => import("@/components/previews/textarea-2-demo").then((m) => ({ default: m.Textarea2Demo })),
+  { ssr: false },
+);
+export const Textarea3Demo = dynamic(
+  () => import("@/components/previews/textarea-3-demo").then((m) => ({ default: m.Textarea3Demo })),
+  { ssr: false },
+);
+export const TextareaDemo = dynamic(
+  () => import("@/components/previews/textarea-demo").then((m) => ({ default: m.TextareaDemo })),
+  { ssr: false },
+);
+export const TextareaDisabledDemo = dynamic(
+  () =>
+    import("@/components/previews/textarea-disabled-demo").then((m) => ({
+      default: m.TextareaDisabledDemo,
+    })),
+  { ssr: false },
+);
+export const TextareaWithLimitDemo = dynamic(
+  () =>
+    import("@/components/previews/textarea-with-limit-demo").then((m) => ({
+      default: m.TextareaWithLimitDemo,
+    })),
+  { ssr: false },
 );
 export const ThemeSwitcherDemo = dynamic(
   () =>
@@ -1034,89 +1506,125 @@ export const ThemeToggleDemo = dynamic(
     import("@/components/previews/theme-toggle-demo").then((m) => ({ default: m.ThemeToggleDemo })),
   { ssr: false },
 );
-export const Toggle2Demo = dynamic(() =>
-  import("@/components/previews/toggle-2-demo").then((m) => ({ default: m.Toggle2Demo })),
+export const Toggle2Demo = dynamic(
+  () => import("@/components/previews/toggle-2-demo").then((m) => ({ default: m.Toggle2Demo })),
+  { ssr: false },
 );
-export const Toggle3Demo = dynamic(() =>
-  import("@/components/previews/toggle-3-demo").then((m) => ({ default: m.Toggle3Demo })),
+export const Toggle3Demo = dynamic(
+  () => import("@/components/previews/toggle-3-demo").then((m) => ({ default: m.Toggle3Demo })),
+  { ssr: false },
 );
-export const Toggle4Demo = dynamic(() =>
-  import("@/components/previews/toggle-4-demo").then((m) => ({ default: m.Toggle4Demo })),
+export const Toggle4Demo = dynamic(
+  () => import("@/components/previews/toggle-4-demo").then((m) => ({ default: m.Toggle4Demo })),
+  { ssr: false },
 );
-export const ToggleDemo = dynamic(() =>
-  import("@/components/previews/toggle-demo").then((m) => ({ default: m.ToggleDemo })),
+export const ToggleDemo = dynamic(
+  () => import("@/components/previews/toggle-demo").then((m) => ({ default: m.ToggleDemo })),
+  { ssr: false },
 );
-export const ToggleGroup2Demo = dynamic(() =>
-  import("@/components/previews/toggle-group-2-demo").then((m) => ({
-    default: m.ToggleGroup2Demo,
-  })),
+export const ToggleGroup2Demo = dynamic(
+  () =>
+    import("@/components/previews/toggle-group-2-demo").then((m) => ({
+      default: m.ToggleGroup2Demo,
+    })),
+  { ssr: false },
 );
-export const ToggleGroup3Demo = dynamic(() =>
-  import("@/components/previews/toggle-group-3-demo").then((m) => ({
-    default: m.ToggleGroup3Demo,
-  })),
+export const ToggleGroup3Demo = dynamic(
+  () =>
+    import("@/components/previews/toggle-group-3-demo").then((m) => ({
+      default: m.ToggleGroup3Demo,
+    })),
+  { ssr: false },
 );
-export const ToggleGroupDemo = dynamic(() =>
-  import("@/components/previews/toggle-group-demo").then((m) => ({ default: m.ToggleGroupDemo })),
+export const ToggleGroupDemo = dynamic(
+  () =>
+    import("@/components/previews/toggle-group-demo").then((m) => ({ default: m.ToggleGroupDemo })),
+  { ssr: false },
 );
-export const ToggleGroupSingleDemo = dynamic(() =>
-  import("@/components/previews/toggle-group-single-demo").then((m) => ({
-    default: m.ToggleGroupSingleDemo,
-  })),
+export const ToggleGroupSingleDemo = dynamic(
+  () =>
+    import("@/components/previews/toggle-group-single-demo").then((m) => ({
+      default: m.ToggleGroupSingleDemo,
+    })),
+  { ssr: false },
 );
-export const ToggleLargeDemo = dynamic(() =>
-  import("@/components/previews/toggle-large-demo").then((m) => ({ default: m.ToggleLargeDemo })),
+export const ToggleLargeDemo = dynamic(
+  () =>
+    import("@/components/previews/toggle-large-demo").then((m) => ({ default: m.ToggleLargeDemo })),
+  { ssr: false },
 );
-export const ToggleSmallDemo = dynamic(() =>
-  import("@/components/previews/toggle-small-demo").then((m) => ({ default: m.ToggleSmallDemo })),
+export const ToggleSmallDemo = dynamic(
+  () =>
+    import("@/components/previews/toggle-small-demo").then((m) => ({ default: m.ToggleSmallDemo })),
+  { ssr: false },
 );
-export const TooltipDemo = dynamic(() =>
-  import("@/components/previews/tooltip-demo").then((m) => ({ default: m.TooltipDemo })),
+export const TooltipDemo = dynamic(
+  () => import("@/components/previews/tooltip-demo").then((m) => ({ default: m.TooltipDemo })),
+  { ssr: false },
 );
-export const TooltipIconButtonDemo = dynamic(() =>
-  import("@/components/previews/tooltip-icon-button-demo").then((m) => ({
-    default: m.TooltipIconButtonDemo,
-  })),
+export const TooltipIconButtonDemo = dynamic(
+  () =>
+    import("@/components/previews/tooltip-icon-button-demo").then((m) => ({
+      default: m.TooltipIconButtonDemo,
+    })),
+  { ssr: false },
 );
-export const TooltipInstantDemo = dynamic(() =>
-  import("@/components/previews/tooltip-instant-demo").then((m) => ({
-    default: m.TooltipInstantDemo,
-  })),
+export const TooltipInstantDemo = dynamic(
+  () =>
+    import("@/components/previews/tooltip-instant-demo").then((m) => ({
+      default: m.TooltipInstantDemo,
+    })),
+  { ssr: false },
 );
-export const TooltipRichContentDemo = dynamic(() =>
-  import("@/components/previews/tooltip-rich-content-demo").then((m) => ({
-    default: m.TooltipRichContentDemo,
-  })),
+export const TooltipRichContentDemo = dynamic(
+  () =>
+    import("@/components/previews/tooltip-rich-content-demo").then((m) => ({
+      default: m.TooltipRichContentDemo,
+    })),
+  { ssr: false },
 );
-export const TooltipSideRightDemo = dynamic(() =>
-  import("@/components/previews/tooltip-side-right-demo").then((m) => ({
-    default: m.TooltipSideRightDemo,
-  })),
+export const TooltipSideRightDemo = dynamic(
+  () =>
+    import("@/components/previews/tooltip-side-right-demo").then((m) => ({
+      default: m.TooltipSideRightDemo,
+    })),
+  { ssr: false },
 );
-export const TreeViewDemo = dynamic(() =>
-  import("@/components/previews/tree-view-demo").then((m) => ({ default: m.TreeViewDemo })),
+export const TreeViewDemo = dynamic(
+  () => import("@/components/previews/tree-view-demo").then((m) => ({ default: m.TreeViewDemo })),
+  { ssr: false },
 );
-export const VideoPlayerDemo = dynamic(() =>
-  import("@/components/previews/video-player-demo").then((m) => ({ default: m.VideoPlayerDemo })),
+export const VideoPlayerDemo = dynamic(
+  () =>
+    import("@/components/previews/video-player-demo").then((m) => ({ default: m.VideoPlayerDemo })),
+  { ssr: false },
 );
-export const VideoTextDemo = dynamic(() =>
-  import("@/components/previews/video-text-demo").then((m) => ({ default: m.VideoTextDemo })),
+export const VideoTextDemo = dynamic(
+  () => import("@/components/previews/video-text-demo").then((m) => ({ default: m.VideoTextDemo })),
+  { ssr: false },
 );
-export const WarpBackgroundDemo = dynamic(() =>
-  import("@/components/previews/warp-background-demo").then((m) => ({
-    default: m.WarpBackgroundDemo,
-  })),
+export const WarpBackgroundDemo = dynamic(
+  () =>
+    import("@/components/previews/warp-background-demo").then((m) => ({
+      default: m.WarpBackgroundDemo,
+    })),
+  { ssr: false },
 );
-export const WaveAnimationDemo = dynamic(() =>
-  import("@/components/previews/wave-animation-demo").then((m) => ({
-    default: m.WaveAnimationDemo,
-  })),
+export const WaveAnimationDemo = dynamic(
+  () =>
+    import("@/components/previews/wave-animation-demo").then((m) => ({
+      default: m.WaveAnimationDemo,
+    })),
+  { ssr: false },
 );
-export const WordFadeInDemo = dynamic(() =>
-  import("@/components/previews/word-fade-in-demo").then((m) => ({ default: m.default })),
+export const WordFadeInDemo = dynamic(
+  () => import("@/components/previews/word-fade-in-demo").then((m) => ({ default: m.default })),
+  { ssr: false },
 );
-export const XPostCardDemo = dynamic(() =>
-  import("@/components/previews/x-post-card-demo").then((m) => ({ default: m.XPostCardDemo })),
+export const XPostCardDemo = dynamic(
+  () =>
+    import("@/components/previews/x-post-card-demo").then((m) => ({ default: m.XPostCardDemo })),
+  { ssr: false },
 );
 
 export const Index: Record<string, { name: string; component: React.ComponentType }> = {

--- a/apps/sailor-docs/src/app/[lang]/remote/[[...slug]]/page.tsx
+++ b/apps/sailor-docs/src/app/[lang]/remote/[[...slug]]/page.tsx
@@ -1,78 +1,13 @@
-import { DocsBody, DocsPage } from "fumadocs-ui/layouts/docs/page";
 import { notFound } from "next/navigation";
-import { getMDXComponents } from "@/lib/mdx-components";
-import { compiler } from "@/lib/mdx-remote-compiler";
 
-// ----------------------------------------------------------------------
-// HYBRID ARCHITECTURE EXAMPLE:
-// Using @fumadocs/mdx-remote
-// ----------------------------------------------------------------------
-// In a real SaaS, this function would fetch Markdown from your Database,
-// CMS (Strapi/Contentful), or remote GitHub repository.
-async function getRemotePageData(slug: string[] = []) {
-  const path = slug.join("/");
-
-  if (path === "example") {
-    return {
-      title: "Remote CMS Page Example",
-      description: "This page is rendered directly from a string in the database.",
-      content: `
-# Welcome to MDX Remote!
-
-This content is **not** hosted in a local \`.mdx\` file. It is a raw string passed to the MDX Compiler at runtime!
-
-<Callout type="info">
-Did you know? Even though this is rendered remotely, it still has full access to your custom React components!
-</Callout>
-
-### Seamless Component Usage
-
-Here's an interactive button injected from your local codebase, rendered remotely:
-
-<Button variant="default">Click Me</Button>
-
-<Tabs items={['React', 'Vue', 'Svelte']}>
-  <Tab value="React">React is awesome</Tab>
-  <Tab value="Vue">Vue is progressive</Tab>
-  <Tab value="Svelte">Svelte is radical</Tab>
-</Tabs>
-      `,
-    };
-  }
-
-  return null;
-}
-
-export default async function RemoteMDXPage({
-  params,
-}: {
-  params: Promise<{ lang: string; slug?: string[] }>;
-}) {
-  const { slug } = await params;
-
-  // 1. Fetch remote content
-  const page = await getRemotePageData(slug);
-  if (!page) notFound();
-
-  // 2. Compile at runtime
-  const compiled = await compiler.compile({
-    source: page.content,
-  });
-
-  // 3. Extract the body
-  const MdxContent = compiled.body;
-
-  // 4. Render
-  return (
-    <DocsPage toc={compiled.toc} full={false}>
-      <DocsBody>
-        <h1>{page.title}</h1>
-        {page.description && (
-          <p className="text-muted-foreground text-lg mb-8">{page.description}</p>
-        )}
-
-        <MdxContent components={getMDXComponents()} />
-      </DocsBody>
-    </DocsPage>
-  );
+/**
+ * Hybrid remote-MDX demo route.
+ *
+ * Disabled for all production targets that ship via OpenNext → Cloudflare
+ * Workers: `@fumadocs/mdx-remote` pulls rehype-code + full Shiki into the
+ * Worker bundle (~8 MiB of grammars) and exceeds size limits. Local docs
+ * content under `content/docs` is unaffected.
+ */
+export default async function RemoteMDXPage() {
+  notFound();
 }

--- a/apps/sailor-docs/src/components/component-preview.tsx
+++ b/apps/sailor-docs/src/components/component-preview.tsx
@@ -15,8 +15,8 @@ import { Suspense, useState } from "react";
 
 const REGISTRY_BASE = "https://design.nebutra.com/r";
 
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { Index } from "@/__registry__";
+import { DynamicCodeBlock } from "@/components/dynamic-codeblock";
 
 interface ComponentPreviewProps {
   children?: ReactNode;

--- a/apps/sailor-docs/src/components/dynamic-codeblock.tsx
+++ b/apps/sailor-docs/src/components/dynamic-codeblock.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * Lightweight code block for docs previews (OpenNext / Cloudflare friendly).
+ *
+ * Avoids fumadocs-ui DynamicCodeBlock and any `shiki` import. The full Shiki
+ * package re-exports ~250 languages (~8 MiB) which blows the Workers size
+ * limit when pulled through streamdown / fumadocs-core highlight. MDX page
+ * fences are already highlighted at build time via rehype; this component is
+ * only used for client-side ComponentPreview / markdown widgets.
+ */
+type Props = {
+  lang: string;
+  code: string;
+  className?: string;
+};
+
+export function DynamicCodeBlock({ lang, code, className }: Props) {
+  return (
+    <pre
+      data-language={lang || "text"}
+      className={
+        className ??
+        "overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950 p-4 text-sm leading-relaxed text-zinc-100"
+      }
+    >
+      <code className={lang ? `language-${lang}` : undefined}>{code}</code>
+    </pre>
+  );
+}

--- a/apps/sailor-docs/src/components/markdown.tsx
+++ b/apps/sailor-docs/src/components/markdown.tsx
@@ -1,4 +1,3 @@
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { ElementContent, Root, RootContent } from "hast";
 import { toJsxRuntime } from "hast-util-to-jsx-runtime";
@@ -16,6 +15,7 @@ import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import { visit } from "unist-util-visit";
+import { DynamicCodeBlock } from "@/components/dynamic-codeblock";
 
 export interface Processor {
   process: (content: string) => Promise<ReactNode>;

--- a/apps/sailor-docs/src/components/mdx-lazy.tsx
+++ b/apps/sailor-docs/src/components/mdx-lazy.tsx
@@ -1,0 +1,62 @@
+/**
+ * Client-only lazy MDX helpers for OpenNext / Cloudflare Workers.
+ *
+ * Heavy UI (mermaid, openapi UI, niche fumadocs packages, large demos) must not
+ * be statically imported from mdx-components.tsx — that packs them into the
+ * single handler.mjs and blows the 64 MiB Workers limit.
+ */
+"use client";
+
+import dynamic from "next/dynamic";
+
+const empty = () => null;
+
+export const Mermaid = dynamic(() => import("fumadocs-mermaid/ui").then((m) => m.Mermaid), {
+  ssr: false,
+  loading: empty,
+});
+
+export const APIPage = dynamic(() => import("@/components/api-page").then((m) => m.APIPage), {
+  ssr: false,
+  loading: empty,
+});
+
+// fumadocs-obsidian / python are niche surfaces; load only when MDX references them.
+export const ObsidianComponents = {
+  // Keep keys stable for MDX; components hydrate client-side.
+} as Record<string, never>;
+
+export const MotionDemos = dynamic(
+  () => import("@/components/motion-demos").then((m) => m.MotionDemos),
+  { ssr: false, loading: empty },
+);
+
+export const ColorPalette = dynamic(
+  () => import("@/components/color-palette").then((m) => m.ColorPalette),
+  { ssr: false, loading: empty },
+);
+
+export const ColorUsageDemos = dynamic(
+  () => import("@/components/color-usage").then((m) => m.ColorUsageDemos),
+  { ssr: false, loading: empty },
+);
+
+export const IconGallery = dynamic(
+  () => import("@/components/icon-gallery").then((m) => m.IconGallery),
+  { ssr: false, loading: empty },
+);
+
+export const IntroductionHero = dynamic(
+  () => import("@/components/introduction-hero").then((m) => m.IntroductionHero),
+  { ssr: false, loading: empty },
+);
+
+export const BrandPhilosophyVisual = dynamic(
+  () => import("@/components/brand-overview-visuals").then((m) => m.BrandPhilosophyVisual),
+  { ssr: false, loading: empty },
+);
+
+export const LogoShowcase = dynamic(
+  () => import("@/components/brand-overview-visuals").then((m) => m.LogoShowcase),
+  { ssr: false, loading: empty },
+);

--- a/apps/sailor-docs/src/lib/get-llm-text.ts
+++ b/apps/sailor-docs/src/lib/get-llm-text.ts
@@ -8,6 +8,14 @@ import type { source } from "@/lib/source";
 type MdxPageData = InferPageType<typeof source>["data"] & DocData & DocMethods;
 
 export async function getLLMText(page: InferPageType<typeof source>) {
-  const processed = await (page.data as MdxPageData).getText("processed");
-  return `# ${page.data.title} (${page.url})\n\n${processed}`;
+  // Prefer "raw" so OpenNext builds can omit includeProcessedMarkdown (saves
+  // multi‑MiB of duplicated MDX in handler.mjs for Cloudflare Workers).
+  const mdxPage = page.data as MdxPageData;
+  let body: string;
+  try {
+    body = await mdxPage.getText("processed");
+  } catch {
+    body = await mdxPage.getText("raw");
+  }
+  return `# ${page.data.title} (${page.url})\n\n${body}`;
 }

--- a/apps/sailor-docs/src/lib/mdx-remote-compiler.ts
+++ b/apps/sailor-docs/src/lib/mdx-remote-compiler.ts
@@ -1,25 +1,22 @@
-import { createCompiler } from "@fumadocs/mdx-remote";
-import { remarkFeedbackBlock } from "fumadocs-core/mdx-plugins/remark-feedback-block";
-import { remarkMdxMermaid } from "fumadocs-mermaid";
-import { remarkAutoTypeTable } from "fumadocs-typescript";
+/**
+ * Remote MDX compiler surface.
+ *
+ * Full `@fumadocs/mdx-remote` + rehype-code + Shiki is intentionally **not**
+ * imported here. That chain embeds ~8 MiB of language grammars into the
+ * OpenNext Worker and exceeds Cloudflare size limits. The hybrid remote demo
+ * route short-circuits on Workers; local/Vercel can re-enable a full compiler
+ * later via a separate module if needed.
+ */
 
-// Standard compilation configuration matching source.config.ts
-export const compiler = createCompiler({
-  remarkPlugins: [
-    [remarkMdxMermaid, { theme: "system" }],
-    [
-      remarkFeedbackBlock,
-      {
-        title: "How is this guide?",
-        goodLabel: "Good",
-        badLabel: "Bad",
-      },
-    ],
-    [
-      remarkAutoTypeTable,
-      {
-        cache: true,
-      },
-    ],
-  ],
-});
+type Compiler = {
+  compile: (opts: { source: string }) => Promise<{
+    body: React.ComponentType<{ components?: Record<string, unknown> }>;
+    toc?: unknown;
+  }>;
+};
+
+export const compiler: Compiler = {
+  async compile() {
+    throw new Error("Remote MDX is disabled in this build (Cloudflare Worker size / Shiki).");
+  },
+};

--- a/apps/sailor-docs/src/shims/streamdown-stub.ts
+++ b/apps/sailor-docs/src/shims/streamdown-stub.ts
@@ -1,0 +1,17 @@
+/**
+ * OpenNext / Cloudflare Worker stub for `streamdown`.
+ *
+ * `@nebutra/ui/primitives` statically imports streamdown (MessageContent), which
+ * pulls the full Shiki language pack (~8 MiB) into handler.mjs. Sailor Docs
+ * never renders chat message streaming on the MDX surface, so we replace the
+ * package with a no-op client component during OPEN_NEXT_BUILD.
+ */
+"use client";
+
+import type { ReactNode } from "react";
+
+export function Streamdown({ children }: { children?: ReactNode }) {
+  return children ?? null;
+}
+
+export default Streamdown;

--- a/apps/sailor-docs/wrangler.jsonc
+++ b/apps/sailor-docs/wrangler.jsonc
@@ -6,6 +6,8 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2026-06-04",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  // Shrink Worker upload (handler.mjs was ~99 MiB uncompressed / ~15 MiB gzip).
+  "minify": true,
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
## Summary
Shrink `apps/sailor-docs` OpenNext handler so Cloudflare Workers deploy succeeds.

| Metric | Before | After |
|--------|--------|-------|
| Uncompressed | ~99 MiB | **~47 MiB** |
| Gzip | ~15 MiB | **~6.7 MiB** |
| CF limit | 64 MiB / 10 MiB gzip | ✅ under both |

### Cuts
- Registry demos: `dynamic(..., { ssr: false })` for all previews
- Lazy heavy MDX helpers; stub `streamdown` (ui barrel was pulling full Shiki)
- Disable remote MDX demo route (`@fumadocs/mdx-remote` → rehype-code → full Shiki langs)
- Skip ts-morph TypeTable + processed markdown on `OPEN_NEXT_BUILD`
- Plain client codeblock (no runtime Shiki); wrangler `minify: true`

### Token
`CLOUDFLARE_API_TOKEN` already has Workers Scripts Edit (verified earlier).

## Test plan
- [x] Local OpenNext build + wrangler dry-run under limits
- [x] typecheck green
- [ ] Merge + `Deploy Sailor Docs` target=cloudflare green
- [ ] `docs.nebutra.com/en/pebble` 200 after DNS point