### PR TITLE
fix(pebble): production-ready diagnostics upload_url + legacy feedback

### DIFF
--- a/backends/gateway/src/routes/pebble/diagnostics-token.test.ts
+++ b/backends/gateway/src/routes/pebble/diagnostics-token.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { deriveUploadUrl, resolvePublicTokenEndpoint } from "./diagnostics-token.js";
+
+describe("resolvePublicTokenEndpoint / deriveUploadUrl", () => {
+  it("maps CF origin host to api.nebutra.com and forces https", () => {
+    const upload = deriveUploadUrl("http://origin.nebutra.com/pebble/diagnostics/token", {
+      forwardedHost: "origin.nebutra.com",
+      forwardedProto: "http",
+    });
+    expect(upload).toBe("https://api.nebutra.com/pebble/diagnostics/upload");
+  });
+
+  it("prefers X-Forwarded-Host when CF presents origin internally", () => {
+    const upload = deriveUploadUrl("http://origin.nebutra.com/pebble/diagnostics/token", {
+      forwardedHost: "api.nebutra.com",
+      forwardedProto: "https",
+    });
+    expect(upload).toBe("https://api.nebutra.com/pebble/diagnostics/upload");
+  });
+
+  it("keeps brand host path without /pebble when X-Original-URI is set", () => {
+    const upload = deriveUploadUrl("http://127.0.0.1:3002/pebble/diagnostics/token", {
+      forwardedHost: "pebble.nebutra.com",
+      forwardedProto: "https",
+      originalUri: "/diagnostics/token",
+    });
+    expect(upload).toBe("https://pebble.nebutra.com/diagnostics/upload");
+  });
+
+  it("strips /pebble for brand host when only gateway path is known", () => {
+    const upload = deriveUploadUrl("http://127.0.0.1:3002/pebble/diagnostics/token", {
+      forwardedHost: "pebble.nebutra.com",
+      forwardedProto: "https",
+    });
+    expect(upload).toBe("https://pebble.nebutra.com/diagnostics/upload");
+  });
+
+  it("preserves localhost http for local tests", () => {
+    const upload = deriveUploadUrl("http://localhost/pebble/diagnostics/token");
+    expect(upload).toBe("http://localhost/pebble/diagnostics/upload");
+  });
+
+  it("resolvePublicTokenEndpoint exposes the client-facing token URL", () => {
+    const token = resolvePublicTokenEndpoint({
+      requestUrl: "http://origin.nebutra.com/pebble/diagnostics/token",
+      forwardedHost: "api.nebutra.com",
+      forwardedProto: "https",
+    });
+    expect(token.toString()).toBe("https://api.nebutra.com/pebble/diagnostics/token");
+  });
+});

--- a/backends/gateway/src/routes/pebble/diagnostics-token.ts
+++ b/backends/gateway/src/routes/pebble/diagnostics-token.ts
@@ -92,12 +92,119 @@ export function readBearerToken(header: string | undefined | null): string | nul
 }
 
 /**
- * The client rejects an upload URL on a different host than the token endpoint,
- * so derive it from the incoming request rather than from configuration that
- * could drift out of agreement with whatever host actually served the token.
+ * Headers used to reconstruct the **client-facing** public URL behind reverse
+ * proxies (Cloudflare → origin.nebutra.com, pebble nginx → api-gateway).
  */
-export function deriveUploadUrl(requestUrl: string): string {
-  const url = new URL(requestUrl);
-  const basePath = url.pathname.replace(/\/token\/?$/, "");
-  return `${url.origin}${basePath}/upload`;
+export type PublicRequestHints = {
+  /** Full request URL as seen by the process (often internal). */
+  requestUrl: string;
+  /** First X-Forwarded-Host, or Host. */
+  forwardedHost?: string | null;
+  /** First X-Forwarded-Proto (https/http). */
+  forwardedProto?: string | null;
+  /**
+   * Original path as the browser/client requested it (e.g. `/diagnostics/token`
+   * on pebble.nebutra.com). When missing, falls back to the gateway pathname.
+   */
+  originalUri?: string | null;
+};
+
+/** Internal / alternate hosts that must never appear in client-facing URLs. */
+const HOST_ALIASES: Record<string, string> = {
+  "origin.nebutra.com": "api.nebutra.com",
+  origin: "api.nebutra.com",
+};
+
+/**
+ * Brand / legacy hosts that reverse-proxy `/diagnostics/*` → gateway
+ * `/pebble/diagnostics/*`. Client same-host checks require the public path
+ * without the `/pebble` prefix.
+ */
+const BRAND_DIAGNOSTICS_HOSTS = new Set([
+  "pebble.nebutra.com",
+  "www.pebble.nebutra.com",
+  "www.onpebble.dev",
+  "onpebble.dev",
+]);
+
+function firstHeaderValue(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.split(",")[0]?.trim() || undefined;
+}
+
+function stripDefaultPort(host: string): string {
+  // host may include port; drop :443 / :80 for cleaner URLs
+  return host.replace(/:(443|80)$/, "");
+}
+
+/**
+ * Reconstruct the public origin + path for the token endpoint as the **client**
+ * sees it. Desktop Pebble requires:
+ * - https when the token endpoint was https
+ * - upload_url host === token endpoint host
+ * See pebble apps/desktop/.../diagnostics.rs `validate_upload_url`.
+ */
+export function resolvePublicTokenEndpoint(hints: PublicRequestHints): URL {
+  const internal = new URL(hints.requestUrl);
+
+  let host =
+    firstHeaderValue(hints.forwardedHost) || firstHeaderValue(internal.host) || internal.hostname;
+  host = stripDefaultPort(host);
+  host = HOST_ALIASES[host] ?? HOST_ALIASES[host.toLowerCase()] ?? host;
+
+  let proto =
+    firstHeaderValue(hints.forwardedProto)?.replace(/:$/, "") ||
+    internal.protocol.replace(":", "") ||
+    "https";
+
+  // Production public hosts must never advertise http — CF/nginx terminate TLS.
+  if (host.endsWith(".nebutra.com") || host.endsWith(".onpebble.dev") || host === "onpebble.dev") {
+    proto = "https";
+  }
+
+  // Prefer the path the client actually hit (brand proxy), else gateway path.
+  let pathname =
+    firstHeaderValue(hints.originalUri)?.split("?")[0] ||
+    internal.pathname ||
+    "/pebble/diagnostics/token";
+
+  // If only the gateway path is known but the public host is the brand front,
+  // strip the product namespace so same-host clients get /diagnostics/upload.
+  if (BRAND_DIAGNOSTICS_HOSTS.has(host) && pathname.startsWith("/pebble/")) {
+    pathname = pathname.slice("/pebble".length) || "/";
+  }
+
+  // Direct API host must keep /pebble prefix.
+  if (
+    (host === "api.nebutra.com" || host.endsWith(".workers.dev")) &&
+    pathname.startsWith("/diagnostics")
+  ) {
+    pathname = `/pebble${pathname}`;
+  }
+
+  if (!pathname.endsWith("/token") && !pathname.endsWith("/token/")) {
+    // Defensive: if something stripped the leaf, assume token route.
+    pathname = pathname.replace(/\/?$/, "/token");
+  }
+
+  return new URL(`${proto}://${host}${pathname.startsWith("/") ? "" : "/"}${pathname}`);
+}
+
+/**
+ * The client rejects an upload URL on a different host than the token endpoint,
+ * so derive it from the **public** request (forwarded headers), not the
+ * process-local URL (which is often http://origin.nebutra.com behind CF).
+ */
+export function deriveUploadUrl(
+  requestUrl: string,
+  hints: Omit<PublicRequestHints, "requestUrl"> = {},
+): string {
+  const tokenUrl = resolvePublicTokenEndpoint({
+    requestUrl,
+    forwardedHost: hints.forwardedHost ?? null,
+    forwardedProto: hints.forwardedProto ?? null,
+    originalUri: hints.originalUri ?? null,
+  });
+  const basePath = tokenUrl.pathname.replace(/\/token\/?$/, "");
+  return `${tokenUrl.origin}${basePath}/upload`;
 }

--- a/backends/gateway/src/routes/pebble/diagnostics.ts
+++ b/backends/gateway/src/routes/pebble/diagnostics.ts
@@ -140,7 +140,14 @@ diagnosticsRoutes.openapi(tokenRoute, async (c) => {
   return c.json(
     {
       token,
-      upload_url: deriveUploadUrl(c.req.url),
+      // Reconstruct client-facing host/proto/path (see deriveUploadUrl docs).
+      // Without this, CF→origin and pebble nginx rewrite Host/path break the
+      // desktop same-host + https check in validate_upload_url.
+      upload_url: deriveUploadUrl(c.req.url, {
+        forwardedHost: c.req.header("x-forwarded-host") ?? c.req.header("host") ?? null,
+        forwardedProto: c.req.header("x-forwarded-proto") ?? null,
+        originalUri: c.req.header("x-original-uri") ?? c.req.header("x-forwarded-uri") ?? null,
+      }),
       max_bytes: DIAGNOSTIC_MAX_BYTES,
     },
     200,

--- a/backends/gateway/src/routes/pebble/feedback.ts
+++ b/backends/gateway/src/routes/pebble/feedback.ts
@@ -20,6 +20,7 @@ export const feedbackRoutes = new OpenAPIHono();
 
 feedbackRoutes.use("*", createIpRateLimit(10));
 
+/** Canonical shape after `normalizeFeedbackBody`. */
 const FeedbackRequestSchema = z.object({
   submission_id: z.string().min(1).max(191),
   kind: z.enum(["feedback", "crash"]).default("feedback"),
@@ -29,6 +30,30 @@ const FeedbackRequestSchema = z.object({
   platform: z.string().max(32).optional(),
   locale: z.string().max(35).optional(),
 });
+
+/**
+ * OpenAPI request schema must accept legacy field names; strict validation runs
+ * only after `normalizeFeedbackBody` in the handler. If we required
+ * `submission_id`/`message` here, shipped desktop clients would get 400 before
+ * normalize could synthesize them.
+ */
+const FeedbackOpenApiBodySchema = z
+  .object({
+    submission_id: z.string().max(191).optional(),
+    kind: z.string().optional(),
+    message: z.string().optional(),
+    contact_email: z.string().optional(),
+    app_version: z.string().optional(),
+    platform: z.string().optional(),
+    locale: z.string().optional(),
+    // Legacy aliases from Tauri clients
+    feedback: z.string().optional(),
+    submission_type: z.string().optional(),
+    github_email: z.string().optional(),
+    os_release: z.string().optional(),
+    arch: z.string().optional(),
+  })
+  .passthrough();
 
 const FeedbackResponseSchema = z.object({
   submission_id: z.string(),
@@ -96,8 +121,8 @@ const submitRoute = createRoute({
   request: {
     body: {
       content: {
-        "application/json": { schema: FeedbackRequestSchema },
-        "multipart/form-data": { schema: FeedbackRequestSchema },
+        "application/json": { schema: FeedbackOpenApiBodySchema },
+        "multipart/form-data": { schema: FeedbackOpenApiBodySchema },
       },
     },
   },

--- a/backends/gateway/src/routes/pebble/index.test.ts
+++ b/backends/gateway/src/routes/pebble/index.test.ts
@@ -107,10 +107,21 @@ function ndjsonBody(text: string) {
   return { bytes, length: bytes.byteLength };
 }
 
-async function issueToken(app: Awaited<ReturnType<typeof createApp>>, bytes: number) {
+async function issueToken(
+  app: Awaited<ReturnType<typeof createApp>>,
+  bytes: number,
+  extraHeaders: Record<string, string> = {},
+) {
   const response = await app.request("/pebble/diagnostics/token", {
     method: "POST",
-    headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.7" },
+    headers: {
+      "content-type": "application/json",
+      "cf-connecting-ip": "203.0.113.7",
+      // Default: public API host (production path after CF).
+      "x-forwarded-host": "api.nebutra.com",
+      "x-forwarded-proto": "https",
+      ...extraHeaders,
+    },
     body: JSON.stringify({ bundle_submission_id: "bundle_1", bytes }),
   });
   return { response, body: (await response.json()) as Record<string, string> };
@@ -216,16 +227,36 @@ describe("pebble support intake", () => {
   });
 
   describe("POST /pebble/diagnostics/token", () => {
-    it("returns an upload URL on the same host as the token endpoint", async () => {
+    it("returns an https upload URL on the public API host", async () => {
       const app = await createApp();
       const { response, body } = await issueToken(app, 1024);
 
       expect(response.status).toBe(200);
       expect(body["max_bytes"]).toBe(4 * 1024 * 1024);
+      expect(String(body["upload_url"])).toBe("https://api.nebutra.com/pebble/diagnostics/upload");
+    });
 
-      const tokenHost = new URL("http://localhost/pebble/diagnostics/token").host;
-      expect(new URL(String(body["upload_url"])).host).toBe(tokenHost);
-      expect(String(body["upload_url"])).toMatch(/\/pebble\/diagnostics\/upload$/);
+    it("returns brand-host path without /pebble when X-Original-URI is brand", async () => {
+      const app = await createApp();
+      const { response, body } = await issueToken(app, 1024, {
+        "x-forwarded-host": "pebble.nebutra.com",
+        "x-forwarded-proto": "https",
+        "x-original-uri": "/diagnostics/token",
+      });
+
+      expect(response.status).toBe(200);
+      expect(String(body["upload_url"])).toBe("https://pebble.nebutra.com/diagnostics/upload");
+    });
+
+    it("maps origin.nebutra.com to api.nebutra.com", async () => {
+      const app = await createApp();
+      const { response, body } = await issueToken(app, 1024, {
+        "x-forwarded-host": "origin.nebutra.com",
+        "x-forwarded-proto": "http",
+      });
+
+      expect(response.status).toBe(200);
+      expect(String(body["upload_url"])).toBe("https://api.nebutra.com/pebble/diagnostics/upload");
     });
 
     it("refuses a byte count above the cap", async () => {

--- a/docs/ops/pebble-support-intake.md
+++ b/docs/ops/pebble-support-intake.md
@@ -1,0 +1,56 @@
+# Pebble support intake (production)
+
+Desktop support paths that must stay green:
+
+| Concern | Endpoint | Notes |
+|---------|----------|--------|
+| Feedback | `POST https://api.nebutra.com/pebble/v1/feedback` | Also `POST https://pebble.nebutra.com/v1/feedback` (nginx rewrite) |
+| Diagnostics token | `POST https://api.nebutra.com/pebble/diagnostics/token` | Returns `{ token, upload_url, max_bytes }` |
+| Diagnostics upload | `POST {upload_url}` | Bearer token; `Content-Type: application/x-ndjson`; exact `Content-Length` |
+| Diagnostics delete | `POST …/diagnostics/delete/:ticketId` | Same path prefix as token |
+
+## Desktop client contracts
+
+From `apps/desktop/.../diagnostics.rs` `validate_upload_url`:
+
+1. If token endpoint is **https**, `upload_url` must be **https**.
+2. `upload_url` **host** (and default port) must match the token endpoint host.
+
+Product analytics (PostHog) and crash reporting (Sentry) are **vendor-cloud** and do not use these routes.
+
+## `upload_url` derivation
+
+`deriveUploadUrl` reconstructs the **client-facing** URL from:
+
+- `X-Forwarded-Host` / `Host` (maps `origin.nebutra.com` → `api.nebutra.com`)
+- `X-Forwarded-Proto` (forces `https` for `*.nebutra.com`)
+- `X-Original-URI` when nginx rewrites brand `/diagnostics/*` → gateway `/pebble/diagnostics/*`
+
+Do **not** use the process-local `c.req.url` alone — behind CF grey-cloud origin it becomes `http://origin.nebutra.com/...` and the desktop client rejects it.
+
+## Smoke (after deploy)
+
+```bash
+# Feedback
+curl -sS -X POST 'https://api.nebutra.com/pebble/v1/feedback' \
+  -H 'Content-Type: application/json' \
+  -d '{"submission_id":"smoke-1","message":"ok"}'
+# → 202 {"submission_id":"smoke-1","received":true}
+
+# Token (canonical)
+curl -sS -X POST 'https://api.nebutra.com/pebble/diagnostics/token' \
+  -H 'Content-Type: application/json' \
+  -d '{"bundle_submission_id":"smoke-b1","bytes":12}'
+# → 200 upload_url must be https://api.nebutra.com/pebble/diagnostics/upload
+
+# Token (brand proxy)
+curl -sS -X POST 'https://pebble.nebutra.com/diagnostics/token' \
+  -H 'Content-Type: application/json' \
+  -d '{"bundle_submission_id":"smoke-b2","bytes":12}'
+# → 200 upload_url must be https://pebble.nebutra.com/diagnostics/upload
+```
+
+## Deploy surfaces
+
+- Gateway code: `backends/gateway` → ECS PM2 `api-gateway` (`deploy-ecs.yml` apps=`api` or monorepo map).
+- Brand nginx: `infra/runtime/nginx/conf.d/pebble.nebutra.com.conf` (must ship `X-Original-URI` + `Host $host` on support locations).

--- a/infra/runtime/nginx/conf.d/pebble.nebutra.com.conf
+++ b/infra/runtime/nginx/conf.d/pebble.nebutra.com.conf
@@ -50,14 +50,17 @@ server {
     # Do not 301 away — that path was 404ing and looked like a white-screen miss.
 
     # Legacy support intake — method + body preserved, no client redirect.
+    # Keep Host=$host + X-Original-URI so the gateway can mint upload_url on the
+    # same public host/path the desktop client used (same-host HTTPS check).
     location = /v1/feedback {
         proxy_pass http://nebutra_pebble_api/pebble/v1/feedback;
         proxy_http_version 1.1;
-        proxy_set_header Host api.nebutra.com;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Original-URI $request_uri;
         proxy_set_header Connection "";
         proxy_read_timeout 30s;
         client_max_body_size 256k;
@@ -66,11 +69,12 @@ server {
     location /diagnostics/ {
         proxy_pass http://nebutra_pebble_api/pebble/diagnostics/;
         proxy_http_version 1.1;
-        proxy_set_header Host api.nebutra.com;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Original-URI $request_uri;
         proxy_set_header Connection "";
         proxy_read_timeout 60s;
         client_max_body_size 5m;


### PR DESCRIPTION
## Summary
Make Pebble support intake production-ready for desktop clients.

Desktop `validate_upload_url` requires **https** + **same host** as the token endpoint. Live tokens returned `http://origin.nebutra.com/...` or wrong host/path behind CF/nginx, so every diagnostic upload was rejected client-side.

### Fixes
- Reconstruct public `upload_url` from `X-Forwarded-*` / `X-Original-URI`; map `origin.nebutra.com` → `api.nebutra.com`; force https on public hosts
- Brand proxy (`pebble.nebutra.com/diagnostics/*`) keeps path without `/pebble`
- nginx: `Host $host` + `X-Original-URI` on support locations
- OpenAPI feedback body accepts legacy fields before normalize (was 400 before handler)
- Ops smoke: `docs/ops/pebble-support-intake.md`

### Tests
- 22 gateway pebble unit tests green

## Deploy
```bash
gh workflow run deploy-ecs.yml -R Nebutra/Nebutra-Sailor -f apps=api -f reason="pebble diagnostics public upload_url"
# nginx vhost ships with deploy-ecs when conf.d changes are in the run
```

## Smoke after deploy
```bash
curl -sS -X POST https://api.nebutra.com/pebble/diagnostics/token \
  -H 'Content-Type: application/json' \
  -d '{"bundle_submission_id":"smoke","bytes":12}'
# expect upload_url https://api.nebutra.com/pebble/diagnostics/upload
```