### PR TITLE
fix(pebble): durable diagnostic store (local/R2) for production uploads

### DIFF
--- a/backends/gateway/src/routes/pebble/diagnostics-store.ts
+++ b/backends/gateway/src/routes/pebble/diagnostics-store.ts
@@ -1,0 +1,95 @@
+/**
+ * Persist Pebble diagnostic bundles without relying on a working public HTTP
+ * loopback for presigned uploads (local provider) or accidental random keys.
+ *
+ * Order:
+ * 1. If cloud credentials exist → presigned PUT via @nebutra/uploads (S3/R2)
+ * 2. Else → local disk under PEBBLE_DIAGNOSTICS_DIR (ECS single-node OK)
+ */
+
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { logger } from "@nebutra/logger";
+import { getActiveProviderType, getUploadProvider } from "@nebutra/uploads";
+
+const NDJSON = "application/x-ndjson";
+
+function localRoot(): string {
+  return (
+    process.env["PEBBLE_DIAGNOSTICS_DIR"]?.trim() ||
+    process.env["LOCAL_UPLOAD_DIR"]?.trim() ||
+    join(process.cwd(), "data", "pebble-diagnostics")
+  );
+}
+
+function hasCloudUploadCredentials(): boolean {
+  return Boolean(
+    process.env["R2_ACCESS_KEY_ID"] ||
+      process.env["R2_SECRET_ACCESS_KEY"] ||
+      process.env["AWS_ACCESS_KEY_ID"] ||
+      process.env["AWS_SECRET_ACCESS_KEY"] ||
+      process.env["S3_ENDPOINT"] ||
+      process.env["BLOB_READ_WRITE_TOKEN"] ||
+      process.env["UPLOAD_PROVIDER"] === "s3" ||
+      process.env["UPLOAD_PROVIDER"] === "blob",
+  );
+}
+
+export async function putDiagnosticBundle(input: {
+  bucket: string;
+  key: string;
+  body: Uint8Array;
+}): Promise<{ backend: "cloud" | "local" }> {
+  if (hasCloudUploadCredentials()) {
+    const provider = await getUploadProvider();
+    const presigned = await provider.createPresignedUpload({
+      bucket: input.bucket,
+      key: input.key,
+      contentType: NDJSON,
+      maxSize: input.body.byteLength,
+      acl: "private",
+      metadata: { purpose: "pebble-diagnostics" },
+    });
+
+    const stored = await fetch(presigned.url, {
+      method: presigned.method,
+      headers: { ...presigned.headers, "content-type": NDJSON },
+      body: input.body as unknown as BodyInit,
+    });
+
+    if (!stored.ok) {
+      const detail = await stored.text().catch(() => "");
+      logger.error("Pebble diagnostic cloud store failed", {
+        status: stored.status,
+        backend: getActiveProviderType(),
+        detail: detail.slice(0, 200),
+      });
+      throw new Error(`cloud_store_failed:${stored.status}`);
+    }
+
+    return { backend: "cloud" };
+  }
+
+  const fullPath = join(localRoot(), input.bucket, input.key);
+  await mkdir(dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, input.body);
+  logger.info("Pebble diagnostic stored on local disk", {
+    path: fullPath,
+    bytes: input.body.byteLength,
+  });
+  return { backend: "local" };
+}
+
+export async function deleteDiagnosticBundle(input: {
+  bucket: string;
+  key: string;
+}): Promise<void> {
+  if (hasCloudUploadCredentials()) {
+    const provider = await getUploadProvider();
+    await provider.deleteFile(input.bucket, input.key);
+    return;
+  }
+
+  const fullPath = join(localRoot(), input.bucket, input.key);
+  await unlink(fullPath).catch(() => undefined);
+}

--- a/backends/gateway/src/routes/pebble/diagnostics.ts
+++ b/backends/gateway/src/routes/pebble/diagnostics.ts
@@ -17,7 +17,7 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { logger } from "@nebutra/logger";
 import { DIAGNOSTIC_MAX_BYTES, getPebbleDiagnosticTicketRepository } from "@nebutra/repositories";
-import { getUploadProvider } from "@nebutra/uploads";
+import { deleteDiagnosticBundle, putDiagnosticBundle } from "./diagnostics-store.js";
 import {
   DIAGNOSTIC_TOKEN_TTL_SECONDS,
   deriveUploadUrl,
@@ -247,28 +247,15 @@ diagnosticsRoutes.openapi(uploadRoute, async (c) => {
   const key = diagnosticObjectKey(ticket.id);
   const checksum = await sha256Hex(body);
 
-  // Private by construction: the provider is asked for a private ACL and the
-  // key is unguessable, so nothing here is reachable without the database row.
-  const provider = await getUploadProvider();
-  const presigned = await provider.createPresignedUpload({
-    bucket,
-    key,
-    contentType: NDJSON_CONTENT_TYPE,
-    maxSize: DIAGNOSTIC_MAX_BYTES,
-    acl: "private",
-    metadata: { ticket_id: ticket.id },
-  });
-
-  const stored = await fetch(presigned.url, {
-    method: presigned.method,
-    headers: { ...presigned.headers, "content-type": NDJSON_CONTENT_TYPE },
-    body: body as unknown as BodyInit,
-  });
-
-  if (!stored.ok) {
+  // Private by construction: unguessable key + private ACL / local disk under
+  // PEBBLE_DIAGNOSTICS_DIR. Prefer cloud when R2/S3 env is present; otherwise
+  // durable local write (works on single-node ECS without cloud credentials).
+  try {
+    await putDiagnosticBundle({ bucket, key, body });
+  } catch (error) {
     logger.error("Pebble diagnostic bundle storage failed", {
       ticketId: ticket.id,
-      status: stored.status,
+      error: error instanceof Error ? error.message : String(error),
     });
     return c.json({ error: "Bad Gateway", message: "Could not store the bundle." }, 400);
   }
@@ -284,7 +271,7 @@ diagnosticsRoutes.openapi(uploadRoute, async (c) => {
   });
 
   if (!marked) {
-    await provider.deleteFile(bucket, key).catch(() => undefined);
+    await deleteDiagnosticBundle({ bucket, key }).catch(() => undefined);
     return c.json({ error: "Unauthorized", message: "This token has already been used." }, 401);
   }
 
@@ -353,8 +340,12 @@ diagnosticsRoutes.openapi(deleteRoute, async (c) => {
   // order could leave a live row pointing at a deleted object, which reads to
   // a support agent as "still stored".
   if (object) {
-    const provider = await getUploadProvider();
-    await provider.deleteFile(object.bucket, object.key);
+    await deleteDiagnosticBundle({ bucket: object.bucket, key: object.key }).catch((error) => {
+      logger.warn("Pebble diagnostic object delete failed after row mark", {
+        ticketId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 
   logger.info("Pebble diagnostic ticket deleted", { ticketId });

--- a/backends/gateway/src/routes/pebble/index.test.ts
+++ b/backends/gateway/src/routes/pebble/index.test.ts
@@ -77,18 +77,11 @@ vi.mock("@nebutra/repositories", () => ({
   getPebbleFeedbackRepository: () => feedbackRepository,
 }));
 
-vi.mock("@nebutra/uploads", () => ({
-  getUploadProvider: async () => ({
-    createPresignedUpload: async () => ({
-      url: "https://storage.test/put",
-      method: "PUT" as const,
-      headers: {},
-      expiresAt: new Date(Date.now() + 60_000),
-    }),
-    deleteFile: async (bucket: string, key: string) => {
-      deletedObjects.push({ bucket, key });
-    },
-  }),
+vi.mock("./diagnostics-store.js", () => ({
+  putDiagnosticBundle: async () => ({ backend: "local" as const }),
+  deleteDiagnosticBundle: async (input: { bucket: string; key: string }) => {
+    deletedObjects.push({ bucket: input.bucket, key: input.key });
+  },
 }));
 
 vi.mock("@nebutra/logger", () => ({
@@ -268,9 +261,6 @@ describe("pebble support intake", () => {
 
   describe("POST /pebble/diagnostics/upload", () => {
     it("stores a bundle and returns its ticket id", async () => {
-      const fetchMock = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(null, { status: 200 }));
       const app = await createApp();
       const { bytes, length } = ndjsonBody('{"event":"startup"}\n');
       const { body: token } = await issueToken(app, length);
@@ -287,8 +277,11 @@ describe("pebble support intake", () => {
       });
 
       expect(response.status).toBe(200);
-      expect((await response.json()) as Record<string, string>).toHaveProperty("ticket_id");
-      expect(fetchMock).toHaveBeenCalledWith("https://storage.test/put", expect.anything());
+      const body = (await response.json()) as Record<string, string>;
+      expect(body).toHaveProperty("ticket_id");
+      const ticket = tickets.get(body["ticket_id"] ?? "");
+      expect(ticket?.status).toBe("STORED");
+      expect(ticket?.objectKey).toMatch(/^pebble\/diagnostics\//);
     });
 
     it("rejects an upload with no token", async () => {

--- a/docs/ops/pebble-support-intake.md
+++ b/docs/ops/pebble-support-intake.md
@@ -50,7 +50,20 @@ curl -sS -X POST 'https://pebble.nebutra.com/diagnostics/token' \
 # → 200 upload_url must be https://pebble.nebutra.com/diagnostics/upload
 ```
 
+## Diagnostic object storage
+
+Upload path stores NDJSON privately:
+
+1. **Cloud** when any of `R2_*` / `AWS_*` / `S3_ENDPOINT` / `BLOB_READ_WRITE_TOKEN` / `UPLOAD_PROVIDER=s3|blob` is set (presigned PUT with the exact object key).
+2. **Local disk** otherwise: `PEBBLE_DIAGNOSTICS_DIR` (default `./data/pebble-diagnostics` or `LOCAL_UPLOAD_DIR`). Fine for single-node ECS; switch to R2 when multi-node or durable off-box storage is required.
+
+Bucket name: `PEBBLE_DIAGNOSTICS_BUCKET` (default `nebutra-pebble-diagnostics`).
+
 ## Deploy surfaces
 
-- Gateway code: `backends/gateway` → ECS PM2 `api-gateway` (`deploy-ecs.yml` apps=`api` or monorepo map).
+- Gateway code: `backends/gateway` → ECS PM2 `api-gateway`.
+  - **Important:** `deploy-ecs.yml` **push-to-main auto-CI is forge-only**. Ship gateway with:
+    ```bash
+    gh workflow run deploy-ecs.yml -R Nebutra/Nebutra-Sailor -f apps=api -f reason="…"
+    ```
 - Brand nginx: `infra/runtime/nginx/conf.d/pebble.nebutra.com.conf` (must ship `X-Original-URI` + `Host $host` on support locations).

--- a/packages/integrations/uploads/src/providers/local.ts
+++ b/packages/integrations/uploads/src/providers/local.ts
@@ -47,11 +47,17 @@ export class LocalUploadProvider implements UploadProvider {
     return `${id}/${target.key.split("/").pop()}`;
   }
 
+  /** Prefer an explicit full object key (contains `/`) over generating a new one. */
+  private resolveKey(target: UploadTarget): string {
+    if (target.key.includes("/")) return target.key;
+    return this.buildKey(target);
+  }
+
   /**
    * Generate presigned URL for simple uploads
    */
   async createPresignedUpload(target: UploadTarget): Promise<PresignedUpload> {
-    const key = this.buildKey(target);
+    const key = this.resolveKey(target);
 
     // Ensure directory exists
     await this.ensureDir(target.bucket);

--- a/packages/integrations/uploads/src/providers/s3.ts
+++ b/packages/integrations/uploads/src/providers/s3.ts
@@ -75,11 +75,17 @@ export class S3UploadProvider implements UploadProvider {
     return `${id}/${target.key.split("/").pop()}`;
   }
 
+  /** Prefer an explicit full object key (contains `/`) over generating a new one. */
+  private resolveKey(target: UploadTarget): string {
+    if (target.key.includes("/")) return target.key;
+    return this.buildKey(target);
+  }
+
   /**
    * Generate presigned PUT URL for simple uploads
    */
   async createPresignedUpload(target: UploadTarget): Promise<PresignedUpload> {
-    const key = this.buildKey(target);
+    const key = this.resolveKey(target);
     const expiresIn = 3600; // 1 hour
 
     const command = new PutObjectCommand({


### PR DESCRIPTION
## Summary
Follow-up to #367: live token URLs were fixed, but `POST /upload` still failed with "Could not store the bundle" (presign→fetch loop + random S3 keys).

- `putDiagnosticBundle` / `deleteDiagnosticBundle`: cloud when R2/S3 env present, else local disk (`PEBBLE_DIAGNOSTICS_DIR`)
- S3/local providers keep explicit full object keys
- Unit tests green

## Deploy
```bash
gh workflow run deploy-ecs.yml -R Nebutra/Nebutra-Sailor -f apps=api -f reason="pebble diagnostics store"
```