### PR TITLE
ci(ecs): auto-deploy gateway on main + Pebble R2 setup

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -6,8 +6,8 @@ name: Deploy to Cloud VM (PM2 Manual Fallback)
 # any equivalent VM with SSH + Node.js + PM2.
 #
 # The production default is still Vercel frontends + Cloudflare Workers gateway
-# + VM/FastAPI origin for most surfaces. Forge is the exception: it lives on
-# this VM and auto-deploys from main when forge paths change (see `on.push`).
+# + VM/FastAPI origin for most surfaces. Auto-CI on this VM (see `on.push`) is
+# limited to product edges + the api-gateway (forge, router, pebble, api).
 # All other apps stay manual via workflow_dispatch to protect the small disk
 # and avoid cross-region SSH blast radius.
 #
@@ -51,13 +51,14 @@ on:
         description: "Reason (shown in run summary)"
         required: false
         default: ""
-  # Product edges auto CI/CD: main push of forge/router product paths deploys
-  # those apps (+ nginx vhosts). Other ECS apps remain workflow_dispatch.
+  # Auto CI/CD on this VM (allowlisted). Other apps remain workflow_dispatch.
   push:
     branches: [main]
     paths:
       - "apps/forge/**"
       - "apps/router/**"
+      - "apps/pebble/**"
+      - "backends/gateway/**"
       - "packages/ai/forge-runtime/**"
       - "packages/platform/router-supply/**"
       - "infra/runtime/nginx/conf.d/*.nebutra.com.conf"
@@ -141,6 +142,9 @@ jobs:
               - 'infra/ops/scripts/ecs-deploy-remote.sh'
               - 'infra/runtime/nginx/**'
               - '.github/workflows/deploy-ecs.yml'
+            # Tighter filter for main-push auto-CI (avoids packages/** fan-out).
+            api-core:
+              - 'backends/gateway/**'
             idp:
               - 'apps/idp/**'
               - 'packages/iam/oauth-server/**'
@@ -222,6 +226,7 @@ jobs:
           F_LANDING:      ${{ steps.filter.outputs.landing }}
           F_WEB:          ${{ steps.filter.outputs.web }}
           F_API:          ${{ steps.filter.outputs.api }}
+          F_API_CORE:     ${{ steps.filter.outputs['api-core'] }}
           F_IDP:          ${{ steps.filter.outputs.idp }}
           F_AUTH:         ${{ steps.filter.outputs.auth }}
           F_DESIGN_DOCS:  ${{ steps.filter.outputs['design-docs'] }}
@@ -242,24 +247,39 @@ jobs:
             esac
           }
 
-          # main push auto-CI is forge-only (see on.push.paths). Do not trust
-          # broad path filters (e.g. packages/** on other apps) for that path.
+          # main push auto-CI allowlist: product edges + api-gateway on this VM.
+          # Use api-core (backends/gateway only) so packages/** does not fan out.
+          # Nginx-only edits still match forge/router/api/pebble filters via
+          # their shared infra/runtime/nginx/** paths — prefer forge as carrier
+          # when no app source changed.
           if [ "${EVENT_NAME:-}" = "push" ]; then
+            api="${F_API_CORE:-false}"
+            forge="${F_FORGE:-false}"
+            router="${F_ROUTER:-false}"
+            pebble="${F_PEBBLE:-false}"
+            if [ "$api" != "true" ] && [ "$forge" != "true" ] && [ "$router" != "true" ] && [ "$pebble" != "true" ]; then
+              # Shared deploy/nginx/workflow-only change: ship via forge so vhosts update.
+              forge=true
+            fi
+            any=false
+            if [ "$api" = "true" ] || [ "$forge" = "true" ] || [ "$router" = "true" ] || [ "$pebble" = "true" ]; then
+              any=true
+            fi
             {
               echo "landing=false"
               echo "web=false"
-              echo "api=false"
+              echo "api=$api"
               echo "idp=false"
               echo "auth=false"
               echo "design-docs=false"
-              echo "pebble=false"
+              echo "pebble=$pebble"
               echo "sailor-docs=false"
-              echo "router=false"
-              echo "forge=true"
+              echo "router=$router"
+              echo "forge=$forge"
               echo "admin=false"
-              echo "any=true"
+              echo "any=$any"
             } >> "$GITHUB_OUTPUT"
-            echo "Auto-CI push: deploying forge only"
+            echo "Auto-CI push: api=$api forge=$forge router=$router pebble=$pebble any=$any"
             exit 0
           fi
 

--- a/.github/workflows/ops-configure-pebble-r2.yml
+++ b/.github/workflows/ops-configure-pebble-r2.yml
@@ -1,0 +1,135 @@
+name: Configure Pebble R2 on ECS
+
+# Writes R2 credentials into /var/www/nebutra/api/.env and restarts api-gateway.
+# Secrets (create once after CF R2 S3 API token):
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY
+# Optional secrets/vars:
+#   R2_ACCOUNT_ID / CLOUDFLARE_ACCOUNT_ID
+#   PEBBLE_DIAGNOSTICS_BUCKET (default nebutra-pebble-diagnostics)
+#
+# SSH secrets: VM_SSH_PRIVATE_KEY (or ECS_SSH_*), VM_HOST / ECS_HOST, VM_USER / ECS_USER
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why (run summary)"
+        required: false
+        default: "configure pebble diagnostics R2"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ops-configure-pebble-r2
+  cancel-in-progress: false
+
+jobs:
+  provision-bucket:
+    name: Ensure R2 bucket exists
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Create nebutra-pebble-diagnostics if missing
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CLOUDFLARE_WORKERS_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID || 'a4248a5738df319996a70092fe598d37' }}
+          PEBBLE_DIAGNOSTICS_BUCKET: ${{ vars.PEBBLE_DIAGNOSTICS_BUCKET || 'nebutra-pebble-diagnostics' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::warning::No CLOUDFLARE_API_TOKEN — skip bucket create (create manually in dashboard)."
+            exit 0
+          fi
+          bash infra/ops/scripts/provision-pebble-diagnostics-r2.sh || {
+            echo "::warning::Bucket provision failed (token may lack R2 Admin). Create bucket in dashboard if needed."
+            exit 0
+          }
+
+  configure:
+    name: SSH + merge R2 env
+    needs: [provision-bucket]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Require R2 secrets
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          if [ -z "${R2_ACCESS_KEY_ID:-}" ] || [ -z "${R2_SECRET_ACCESS_KEY:-}" ]; then
+            echo "::error::Set repository secrets R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY (CF R2 S3 API token)."
+            echo "Dashboard: https://dash.cloudflare.com → R2 → Manage R2 API Tokens"
+            echo "Then: printf '%s' \"\$KEY\" | gh secret set R2_ACCESS_KEY_ID -R Nebutra/Nebutra-Sailor"
+            echo "Docs: docs/ops/pebble-support-intake.md"
+            exit 1
+          fi
+
+      - name: Configure SSH
+        env:
+          KEY: ${{ secrets.VM_SSH_PRIVATE_KEY || secrets.ECS_SSH_PRIVATE_KEY || secrets.CLOUD_VM_SSH_PRIVATE_KEY }}
+          KNOWN: ${{ secrets.VM_SSH_KNOWN_HOSTS || secrets.ECS_SSH_KNOWN_HOSTS || secrets.CLOUD_VM_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KEY:-}" ]; then
+            echo "::error::Missing VM_SSH_PRIVATE_KEY (or ECS_SSH_PRIVATE_KEY)"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "$KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          if [ -n "${KNOWN:-}" ]; then
+            printf '%s\n' "$KNOWN" > ~/.ssh/known_hosts
+          else
+            HOST="${{ vars.VM_HOST || vars.ECS_HOST || secrets.ECS_HOST }}"
+            ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          fi
+
+      - name: Push script and apply env on VM
+        env:
+          HOST: ${{ vars.VM_HOST || vars.ECS_HOST }}
+          USER: ${{ vars.VM_USER || vars.ECS_USER || 'root' }}
+          PORT: ${{ vars.VM_SSH_PORT || '22' }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID || vars.CLOUDFLARE_ACCOUNT_ID || 'a4248a5738df319996a70092fe598d37' }}
+          PEBBLE_DIAGNOSTICS_BUCKET: ${{ vars.PEBBLE_DIAGNOSTICS_BUCKET || 'nebutra-pebble-diagnostics' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOST:-}" ]; then
+            echo "::error::Set vars.VM_HOST or vars.ECS_HOST"
+            exit 1
+          fi
+          scp -i ~/.ssh/id_deploy -P "$PORT" -o StrictHostKeyChecking=yes \
+            infra/ops/scripts/configure-api-r2-env.sh \
+            "${USER}@${HOST}:/tmp/configure-api-r2-env.sh"
+          ssh -i ~/.ssh/id_deploy -p "$PORT" -o StrictHostKeyChecking=yes \
+            "${USER}@${HOST}" \
+            "R2_ACCESS_KEY_ID=$(printf %q "$R2_ACCESS_KEY_ID") \
+             R2_SECRET_ACCESS_KEY=$(printf %q "$R2_SECRET_ACCESS_KEY") \
+             R2_ACCOUNT_ID=$(printf %q "$R2_ACCOUNT_ID") \
+             PEBBLE_DIAGNOSTICS_BUCKET=$(printf %q "$PEBBLE_DIAGNOSTICS_BUCKET") \
+             bash /tmp/configure-api-r2-env.sh && rm -f /tmp/configure-api-r2-env.sh"
+
+      - name: Smoke diagnostics upload
+        run: |
+          set -euo pipefail
+          BODY=$(printf '%s\n' '{"event":"r2-config-smoke"}')
+          LEN=$(printf '%s' "$BODY" | wc -c | tr -d ' ')
+          RESP=$(curl -sS -X POST 'https://api.nebutra.com/pebble/diagnostics/token' \
+            -H 'Content-Type: application/json' \
+            -d "{\"bundle_submission_id\":\"r2-smoke-$(date +%s)\",\"bytes\":$LEN}")
+          echo "$RESP"
+          URL=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["upload_url"])')
+          TOKEN=$(echo "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+          test "$URL" = "https://api.nebutra.com/pebble/diagnostics/upload"
+          code=$(curl -sS -o /tmp/up.json -w '%{http_code}' -X POST "$URL" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/x-ndjson' \
+            -H "Content-Length: $LEN" \
+            --data-binary "$BODY")
+          echo "upload HTTP $code $(cat /tmp/up.json)"
+          test "$code" = "200"

--- a/docs/ops/ecs-mvp-env.md
+++ b/docs/ops/ecs-mvp-env.md
@@ -30,15 +30,20 @@ deployment path. The deploy workflow forwards these values from the GitHub
 
 ### R2 Uploads
 
-Use these when `UPLOAD_PROVIDER=r2`:
+Use these when `UPLOAD_PROVIDER=r2` or `UPLOAD_PROVIDER=s3` with R2:
 
 ```env
 R2_ACCOUNT_ID=
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
+R2_ENDPOINT=https://<account_id>.r2.cloudflarestorage.com
 R2_BUCKET_UPLOADS=
 R2_PUBLIC_URL=
+# Pebble diagnostic bundles (private)
+PEBBLE_DIAGNOSTICS_BUCKET=nebutra-pebble-diagnostics
 ```
+
+See [pebble-support-intake.md](./pebble-support-intake.md) for provisioning + ECS apply.
 
 ### Resend Email
 

--- a/docs/ops/pebble-support-intake.md
+++ b/docs/ops/pebble-support-intake.md
@@ -48,22 +48,81 @@ curl -sS -X POST 'https://pebble.nebutra.com/diagnostics/token' \
   -H 'Content-Type: application/json' \
   -d '{"bundle_submission_id":"smoke-b2","bytes":12}'
 # → 200 upload_url must be https://pebble.nebutra.com/diagnostics/upload
+
+# Upload (exact Content-Length)
+BODY=$'{"event":"smoke"}\n'
+LEN=$(printf '%s' "$BODY" | wc -c | tr -d ' ')
+# re-issue token with bytes=$LEN then:
+# curl -X POST "$upload_url" -H "Authorization: Bearer $token" \
+#   -H 'Content-Type: application/x-ndjson' -H "Content-Length: $LEN" --data-binary "$BODY"
+# → 200 {"ticket_id":"…"}
 ```
 
 ## Diagnostic object storage
 
-Upload path stores NDJSON privately:
+### Default (current)
 
-1. **Cloud** when any of `R2_*` / `AWS_*` / `S3_ENDPOINT` / `BLOB_READ_WRITE_TOKEN` / `UPLOAD_PROVIDER=s3|blob` is set (presigned PUT with the exact object key).
-2. **Local disk** otherwise: `PEBBLE_DIAGNOSTICS_DIR` (default `./data/pebble-diagnostics` or `LOCAL_UPLOAD_DIR`). Fine for single-node ECS; switch to R2 when multi-node or durable off-box storage is required.
+Without cloud credentials, bundles land on **local disk** on the API VM:
 
-Bucket name: `PEBBLE_DIAGNOSTICS_BUCKET` (default `nebutra-pebble-diagnostics`).
+- `PEBBLE_DIAGNOSTICS_DIR` (default under process cwd / `LOCAL_UPLOAD_DIR`)
+- Fine for **single-node** ECS; not shared across hosts.
+
+### R2 (recommended for multi-node / off-box)
+
+**Bucket:** `nebutra-pebble-diagnostics` (private)
+
+```bash
+# 1) Create bucket (needs CLOUDFLARE_API_TOKEN with R2 Admin)
+export CLOUDFLARE_API_TOKEN=…
+export CLOUDFLARE_ACCOUNT_ID=a4248a5738df319996a70092fe598d37
+bash infra/ops/scripts/provision-pebble-diagnostics-r2.sh
+
+# 2) Dashboard: R2 → Manage R2 API Tokens → Object Read & Write on that bucket
+#    Copy Access Key ID + Secret
+
+# 3a) GitHub secrets (once)
+printf '%s' "$R2_ACCESS_KEY_ID"     | gh secret set R2_ACCESS_KEY_ID -R Nebutra/Nebutra-Sailor
+printf '%s' "$R2_SECRET_ACCESS_KEY" | gh secret set R2_SECRET_ACCESS_KEY -R Nebutra/Nebutra-Sailor
+# optional: gh secret set R2_ACCOUNT_ID …
+
+# 3b) Apply to ECS api-gateway env + restart
+gh workflow run "Configure Pebble R2 on ECS" -R Nebutra/Nebutra-Sailor
+```
+
+Manual on the VM (equivalent of the workflow):
+
+```bash
+# on ECS
+export R2_ACCESS_KEY_ID=… R2_SECRET_ACCESS_KEY=…
+export R2_ACCOUNT_ID=a4248a5738df319996a70092fe598d37
+export PEBBLE_DIAGNOSTICS_BUCKET=nebutra-pebble-diagnostics
+bash /path/to/configure-api-r2-env.sh
+# writes /var/www/nebutra/api/.env and pm2 restart api-gateway
+```
+
+Env keys consumed by gateway:
+
+```env
+UPLOAD_PROVIDER=s3   # or r2 (alias)
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_ENDPOINT=https://<account_id>.r2.cloudflarestorage.com
+PEBBLE_DIAGNOSTICS_BUCKET=nebutra-pebble-diagnostics
+```
 
 ## Deploy surfaces
 
-- Gateway code: `backends/gateway` → ECS PM2 `api-gateway`.
-  - **Important:** `deploy-ecs.yml` **push-to-main auto-CI is forge-only**. Ship gateway with:
-    ```bash
-    gh workflow run deploy-ecs.yml -R Nebutra/Nebutra-Sailor -f apps=api -f reason="…"
-    ```
-- Brand nginx: `infra/runtime/nginx/conf.d/pebble.nebutra.com.conf` (must ship `X-Original-URI` + `Host $host` on support locations).
+| Change | How it ships |
+|--------|----------------|
+| `backends/gateway/**` | **Auto** on `main` push via `deploy-ecs.yml` (`api`) |
+| `apps/forge/**`, `apps/router/**`, `apps/pebble/**` | **Auto** on `main` push |
+| nginx vhosts only | Auto via forge (or any auto-CI app that matches nginx paths) |
+| Other apps (web, auth, …) | Manual: `gh workflow run deploy-ecs.yml -f apps=…` |
+
+```bash
+# explicit gateway deploy (still valid anytime)
+gh workflow run deploy-ecs.yml -R Nebutra/Nebutra-Sailor -f apps=api -f reason="…"
+```
+
+Brand nginx: `infra/runtime/nginx/conf.d/pebble.nebutra.com.conf` must keep `Host $host` + `X-Original-URI` on support locations.

--- a/infra/iac/cloudflare/r2/README.md
+++ b/infra/iac/cloudflare/r2/README.md
@@ -9,6 +9,11 @@ Object storage for user uploads, static assets, and media files.
 | `nebutra-assets` | Public static assets | ✅ Yes | `cdn.nebutra.com` |
 | `nebutra-uploads` | User uploads (private) | ❌ No | Signed URLs |
 | `nebutra-backups` | Database backups | ❌ No | Internal only |
+| `nebutra-pebble-diagnostics` | Pebble desktop diagnostic NDJSON | ❌ No | Server-side only |
+
+Pebble diagnostics: [docs/ops/pebble-support-intake.md](../../../../docs/ops/pebble-support-intake.md) ·  
+`infra/ops/scripts/provision-pebble-diagnostics-r2.sh` ·  
+`gh workflow run ops-configure-pebble-r2.yml`
 
 ## Setup
 

--- a/infra/ops/scripts/configure-api-r2-env.sh
+++ b/infra/ops/scripts/configure-api-r2-env.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Merge R2 / Pebble diagnostics env into ECS api-gateway env file and restart PM2.
+#
+# Run on the VM (or via SSH from CI):
+#   R2_ACCESS_KEY_ID=… R2_SECRET_ACCESS_KEY=… \
+#   bash configure-api-r2-env.sh
+#
+# Env file default: /var/www/nebutra/api/.env
+set -euo pipefail
+
+ENV_FILE="${API_ENV_FILE:-/var/www/nebutra/api/.env}"
+ACCOUNT_ID="${R2_ACCOUNT_ID:-${CLOUDFLARE_ACCOUNT_ID:-a4248a5738df319996a70092fe598d37}}"
+BUCKET="${PEBBLE_DIAGNOSTICS_BUCKET:-nebutra-pebble-diagnostics}"
+ENDPOINT="${R2_ENDPOINT:-https://${ACCOUNT_ID}.r2.cloudflarestorage.com}"
+
+if [ -z "${R2_ACCESS_KEY_ID:-}" ] || [ -z "${R2_SECRET_ACCESS_KEY:-}" ]; then
+  echo "R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY are required" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$ENV_FILE")"
+touch "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+upsert() {
+  local key="$1" val="$2"
+  if grep -qE "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    # portable in-place replace
+    local tmp
+    tmp="$(mktemp)"
+    awk -v k="$key" -v v="$val" 'BEGIN{FS=OFS="="} $1==k {$0=k"="v} {print}' "$ENV_FILE" >"$tmp"
+    mv "$tmp" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$val" >>"$ENV_FILE"
+  fi
+}
+
+upsert "UPLOAD_PROVIDER" "s3"
+upsert "R2_ACCOUNT_ID" "$ACCOUNT_ID"
+upsert "R2_ACCESS_KEY_ID" "$R2_ACCESS_KEY_ID"
+upsert "R2_SECRET_ACCESS_KEY" "$R2_SECRET_ACCESS_KEY"
+upsert "R2_ENDPOINT" "$ENDPOINT"
+upsert "PEBBLE_DIAGNOSTICS_BUCKET" "$BUCKET"
+if [ -n "${PEBBLE_DIAGNOSTICS_DIR:-}" ]; then
+  upsert "PEBBLE_DIAGNOSTICS_DIR" "$PEBBLE_DIAGNOSTICS_DIR"
+fi
+
+chmod 600 "$ENV_FILE"
+echo "Updated $ENV_FILE (R2 + PEBBLE_DIAGNOSTICS_BUCKET)"
+
+if command -v pm2 >/dev/null 2>&1; then
+  pm2 restart api-gateway --update-env || pm2 restart api-gateway
+  pm2 save || true
+  echo "pm2 restarted api-gateway"
+else
+  echo "pm2 not found — restart api-gateway manually"
+fi

--- a/infra/ops/scripts/provision-pebble-diagnostics-r2.sh
+++ b/infra/ops/scripts/provision-pebble-diagnostics-r2.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Provision Cloudflare R2 bucket for Pebble diagnostic bundles.
+#
+# Prerequisites:
+#   CLOUDFLARE_API_TOKEN   — Account API token with R2 Admin (or Workers R2 Write)
+#   CLOUDFLARE_ACCOUNT_ID  — default a4248a5738df319996a70092fe598d37
+#
+# Creates bucket nebutra-pebble-diagnostics (private). S3 API tokens for the
+# gateway must still be created in the CF dashboard (Object Read & Write).
+#
+# Usage:
+#   CLOUDFLARE_API_TOKEN=… bash infra/ops/scripts/provision-pebble-diagnostics-r2.sh
+set -euo pipefail
+
+TOKEN="${CLOUDFLARE_API_TOKEN:-${CLOUDFLARE_WORKERS_API_TOKEN:-}}"
+ACCOUNT_ID="${CLOUDFLARE_ACCOUNT_ID:-a4248a5738df319996a70092fe598d37}"
+BUCKET="${PEBBLE_DIAGNOSTICS_BUCKET:-nebutra-pebble-diagnostics}"
+
+if [ -z "$TOKEN" ]; then
+  echo "Set CLOUDFLARE_API_TOKEN (R2 Admin / write)" >&2
+  exit 1
+fi
+
+auth() {
+  curl -sS -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "$@"
+}
+
+echo "=== list existing R2 buckets ==="
+LIST=$(auth "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2/buckets")
+echo "$LIST" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+if not d.get("success"):
+  print("list_failed", d.get("errors")); sys.exit(2)
+names=[b.get("name") for b in (d.get("result") or {}).get("buckets") or d.get("result") or []]
+# API shape: result.buckets | result as list
+if isinstance(d.get("result"), list):
+  names=[b.get("name") for b in d["result"]]
+elif isinstance(d.get("result"), dict):
+  names=[b.get("name") for b in (d["result"].get("buckets") or [])]
+print("buckets:", ", ".join(n for n in names if n) or "(none)")
+open("/tmp/r2-buckets.txt","w").write("\n".join(n for n in names if n))
+'
+
+if grep -qx "$BUCKET" /tmp/r2-buckets.txt 2>/dev/null; then
+  echo "bucket already exists: $BUCKET"
+else
+  echo "=== create bucket $BUCKET ==="
+  CREATE=$(auth -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2/buckets" \
+    --data "{\"name\":\"${BUCKET}\"}")
+  echo "$CREATE" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+print("create", d.get("success"), d.get("errors") or d.get("result"))
+raise SystemExit(0 if d.get("success") else 3)
+'
+fi
+
+echo ""
+echo "=== next: S3 API token (dashboard, one-time) ==="
+echo "1. https://dash.cloudflare.com/${ACCOUNT_ID}/r2/api-tokens"
+echo "2. Create API token → Object Read & Write → include bucket ${BUCKET}"
+echo "3. Copy Access Key ID + Secret Access Key"
+echo "4. Apply on ECS api-gateway env:"
+echo ""
+cat <<EOF
+# /var/www/nebutra/api/.env  (or gh workflow ops-configure-pebble-r2)
+UPLOAD_PROVIDER=s3
+R2_ACCOUNT_ID=${ACCOUNT_ID}
+R2_ACCESS_KEY_ID=<from dashboard>
+R2_SECRET_ACCESS_KEY=<from dashboard>
+R2_ENDPOINT=https://${ACCOUNT_ID}.r2.cloudflarestorage.com
+PEBBLE_DIAGNOSTICS_BUCKET=${BUCKET}
+# optional override for local fallback path
+# PEBBLE_DIAGNOSTICS_DIR=/var/www/nebutra/data/pebble-diagnostics
+EOF
+echo ""
+echo "Or: gh workflow run ops-configure-pebble-r2.yml  (after setting GH secrets R2_*)"
+echo "Docs: docs/ops/pebble-support-intake.md"

--- a/packages/integrations/uploads/src/factory.ts
+++ b/packages/integrations/uploads/src/factory.ts
@@ -53,8 +53,19 @@ function createUploadProviderByType(
  * Auto-detect provider based on environment
  */
 function autoDetectProvider(config?: ProviderConfig): UploadProvider {
-  // Priority 1: Check explicit UPLOAD_PROVIDER
-  const explicitProvider = process.env.UPLOAD_PROVIDER as UploadProviderType | undefined;
+  // Priority 1: Check explicit UPLOAD_PROVIDER (r2 is an alias for S3-compatible)
+  const explicitRaw = process.env.UPLOAD_PROVIDER?.trim().toLowerCase();
+  if (explicitRaw === "r2") {
+    logger.info("Using explicit upload provider", { provider: "r2→s3" });
+    return new S3UploadProvider({
+      accessKeyId: process.env.R2_ACCESS_KEY_ID || "",
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || "",
+      region: "auto",
+      ...(process.env.R2_ENDPOINT !== undefined ? { endpoint: process.env.R2_ENDPOINT } : {}),
+      ...(process.env.R2_PUBLIC_URL !== undefined ? { publicUrl: process.env.R2_PUBLIC_URL } : {}),
+    });
+  }
+  const explicitProvider = explicitRaw as UploadProviderType | undefined;
   if (explicitProvider) {
     logger.info("Using explicit upload provider", { provider: explicitProvider });
     return createUploadProviderByType(explicitProvider, config);


### PR DESCRIPTION
## Summary
1. **deploy-ecs auto-CI** no longer forge-only: main push deploys **api** (`backends/gateway/**`), **forge**, **router**, **pebble**. Shared nginx/workflow-only changes still ship via forge.
2. **R2 path for Pebble diagnostics**: provision script, ECS env merge script, workflow `ops-configure-pebble-r2`.
3. `UPLOAD_PROVIDER=r2` alias in uploads factory.

## After merge
```bash
# optional: create bucket (uses CLOUDFLARE_API_TOKEN; needs R2 Admin on token)
# S3 API keys still require CF dashboard once:
#   R2 → Manage R2 API Tokens → Object Read & Write
printf '%s' "$R2_ACCESS_KEY_ID" | gh secret set R2_ACCESS_KEY_ID -R Nebutra/Nebutra-Sailor
printf '%s' "$R2_SECRET_ACCESS_KEY" | gh secret set R2_SECRET_ACCESS_KEY -R Nebutra/Nebutra-Sailor
gh workflow run "Configure Pebble R2 on ECS" -R Nebutra/Nebutra-Sailor
```

Docs: `docs/ops/pebble-support-intake.md`