### PR TITLE
fix(ci): sync lockfile so gateway can deploy

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1764,9 +1764,6 @@ importers:
 
   backends/gateway:
     dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.700.0
-        version: 3.1003.0
       '@clerk/backend':
         specifier: '>=3.2.14'
         version: 3.4.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary
- Gateway `package.json` no longer depends on `@aws-sdk/client-s3` (uses `@nebutra/uploads` instead).
- Lockfile still listed that dep → `pnpm install --frozen-lockfile` failed on deploy-ecs after #370.
- Regenerated lockfile (3-line remove under `backends/gateway`).

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds locally
- [ ] deploy-ecs `apps=api` green
- [ ] Configure Pebble R2 on ECS smoke upload 200