### PR TITLE
fix(pebble): download links use .deb assets

### DIFF
--- a/apps/pebble/src/app/download/page.tsx
+++ b/apps/pebble/src/app/download/page.tsx
@@ -9,8 +9,8 @@ export const metadata: Metadata = {
 const rows = [
   { label: "macOS Universal", href: DOWNLOADS.macosUniversal, badge: ".dmg" },
   { label: "Windows x64", href: DOWNLOADS.windowsX64, badge: ".exe" },
-  { label: "Linux x64 AppImage", href: DOWNLOADS.linuxX64AppImage, badge: "AppImage" },
-  { label: "Linux arm64 AppImage", href: DOWNLOADS.linuxArm64AppImage, badge: "AppImage" },
+  { label: "Linux x64", href: DOWNLOADS.linuxX64Deb, badge: ".deb" },
+  { label: "Linux arm64", href: DOWNLOADS.linuxArm64Deb, badge: ".deb" },
 ] as const;
 
 export default function DownloadPage() {

--- a/apps/pebble/src/lib/releases.ts
+++ b/apps/pebble/src/lib/releases.ts
@@ -1,11 +1,16 @@
-/** GitHub Releases artifact URLs for the download surface. */
+/**
+ * GitHub Releases artifact URLs for the download surface.
+ * Names must match `STABLE_DIRECT_DOWNLOAD_ASSETS` in
+ * pebble `config/scripts/verify-release-required-assets.mjs`
+ * (desktop ships `.deb` on Linux, not AppImage).
+ */
 export const GITHUB_RELEASES = "https://github.com/Nebutra/pebble/releases/latest";
 
 export const DOWNLOADS = {
   macosUniversal: `${GITHUB_RELEASES}/download/pebble-macos-universal.dmg`,
   windowsX64: `${GITHUB_RELEASES}/download/pebble-windows-x86_64-setup.exe`,
-  linuxX64AppImage: `${GITHUB_RELEASES}/download/pebble-linux-x86_64.AppImage`,
-  linuxArm64AppImage: `${GITHUB_RELEASES}/download/pebble-linux-aarch64.AppImage`,
+  linuxX64Deb: `${GITHUB_RELEASES}/download/pebble-linux-x86_64.deb`,
+  linuxArm64Deb: `${GITHUB_RELEASES}/download/pebble-linux-aarch64.deb`,
   all: GITHUB_RELEASES,
 } as const;
 


### PR DESCRIPTION
## Summary
Brand `/download` linked to AppImage names that the desktop release pipeline never publishes. Match required assets: `.dmg`, `-setup.exe`, `.deb`.

## Test plan
- [ ] After stable release, each download URL returns 200