### PR TITLE
fix(pebble): go-live Linux downloads; mac/win soon

### DIFF
--- a/apps/pebble/src/app/download/page.tsx
+++ b/apps/pebble/src/app/download/page.tsx
@@ -1,17 +1,10 @@
 import type { Metadata } from "next";
-import { DOWNLOADS, GITHUB_RELEASES } from "@/lib/releases";
+import { DOWNLOAD_ROWS, GITHUB_RELEASES } from "@/lib/releases";
 
 export const metadata: Metadata = {
   title: "Download",
-  description: "Download Pebble for macOS, Windows, and Linux.",
+  description: "Download Pebble for Linux now; macOS and Windows installers follow.",
 };
-
-const rows = [
-  { label: "macOS Universal", href: DOWNLOADS.macosUniversal, badge: ".dmg" },
-  { label: "Windows x64", href: DOWNLOADS.windowsX64, badge: ".exe" },
-  { label: "Linux x64", href: DOWNLOADS.linuxX64Deb, badge: ".deb" },
-  { label: "Linux arm64", href: DOWNLOADS.linuxArm64Deb, badge: ".deb" },
-] as const;
 
 export default function DownloadPage() {
   return (
@@ -22,7 +15,8 @@ export default function DownloadPage() {
           <h1>Download Pebble</h1>
           <p className="lead">
             Installers ship from GitHub Releases — this origin never becomes the artifact authority.
-            Prefer Homebrew or AUR when you can.
+            Linux <code className="inline">.deb</code> packages are live; signed macOS and Windows
+            builds land as soon as release signing is restored.
           </p>
           <div className="actions">
             <a className="btn btn-primary" href={GITHUB_RELEASES}>
@@ -33,10 +27,13 @@ export default function DownloadPage() {
       </section>
 
       <ul className="list">
-        {rows.map((row) => (
+        {DOWNLOAD_ROWS.map((row) => (
           <li key={row.label}>
-            <a href={row.href}>
-              <span>{row.label}</span>
+            <a href={row.href} aria-disabled={!row.available ? true : undefined}>
+              <span>
+                {row.label}
+                {!row.available ? " (coming soon)" : null}
+              </span>
               <span className="badge">{row.badge}</span>
             </a>
           </li>

--- a/apps/pebble/src/lib/releases.ts
+++ b/apps/pebble/src/lib/releases.ts
@@ -3,6 +3,9 @@
  * Names must match `STABLE_DIRECT_DOWNLOAD_ASSETS` in
  * pebble `config/scripts/verify-release-required-assets.mjs`
  * (desktop ships `.deb` on Linux, not AppImage).
+ *
+ * macOS / Windows installers ship once CI code-signing secrets are healthy.
+ * Until then, only Linux debs are linked as direct downloads.
  */
 export const GITHUB_RELEASES = "https://github.com/Nebutra/pebble/releases/latest";
 
@@ -13,6 +16,42 @@ export const DOWNLOADS = {
   linuxArm64Deb: `${GITHUB_RELEASES}/download/pebble-linux-aarch64.deb`,
   all: GITHUB_RELEASES,
 } as const;
+
+export type DownloadRow = {
+  label: string;
+  href: string;
+  badge: string;
+  /** When false, show as coming-soon (no broken direct asset link). */
+  available: boolean;
+};
+
+/** Rows rendered on /download — only `available` rows are direct installer links. */
+export const DOWNLOAD_ROWS: readonly DownloadRow[] = [
+  {
+    label: "Linux x64",
+    href: DOWNLOADS.linuxX64Deb,
+    badge: ".deb",
+    available: true,
+  },
+  {
+    label: "Linux arm64",
+    href: DOWNLOADS.linuxArm64Deb,
+    badge: ".deb",
+    available: true,
+  },
+  {
+    label: "macOS Universal",
+    href: GITHUB_RELEASES,
+    badge: "soon",
+    available: false,
+  },
+  {
+    label: "Windows x64",
+    href: GITHUB_RELEASES,
+    badge: "soon",
+    available: false,
+  },
+] as const;
 
 /** Prefer on-origin docs while docs.nebutra.com/pebble Worker is stale. */
 export const DOCS_BASE = "https://pebble.nebutra.com/docs";


### PR DESCRIPTION
## Summary
- Published pebble `v1.4.124` with Linux installers.
- Download page links only live `.deb` assets; macOS/Windows show coming soon until CI signing secrets work.

## Test plan
- [x] `pebble-linux-x86_64.deb` / `aarch64.deb` from `/releases/latest/download` return 200
- [ ] `/download` after deploy lists Linux as available, mac/win soon