### PR TITLE
fix(pebble): enable macOS Universal DMG on download surface

### DIFF
--- a/apps/pebble/src/app/download/page.tsx
+++ b/apps/pebble/src/app/download/page.tsx
@@ -3,7 +3,7 @@ import { DOWNLOAD_ROWS, GITHUB_RELEASES } from "@/lib/releases";
 
 export const metadata: Metadata = {
   title: "Download",
-  description: "Download Pebble for Linux now; macOS and Windows installers follow.",
+  description: "Download Pebble for Linux and macOS; Windows installer follows.",
 };
 
 export default function DownloadPage() {
@@ -15,8 +15,9 @@ export default function DownloadPage() {
           <h1>Download Pebble</h1>
           <p className="lead">
             Installers ship from GitHub Releases — this origin never becomes the artifact authority.
-            Linux <code className="inline">.deb</code> packages are live; signed macOS and Windows
-            builds land as soon as release signing is restored.
+            Linux <code className="inline">.deb</code> and macOS Universal{" "}
+            <code className="inline">.dmg</code> are live. Windows setup lands once code-signing is
+            restored.
           </p>
           <div className="actions">
             <a className="btn btn-primary" href={GITHUB_RELEASES}>
@@ -41,6 +42,7 @@ export default function DownloadPage() {
       </ul>
 
       <p className="muted" style={{ marginTop: "1.5rem" }}>
+        macOS is Developer ID signed. If Gatekeeper blocks first open, right-click the app → Open.
         Package managers: <code className="inline">brew install --cask nebutra/pebble/pebble</code>
         {" · "}
         AUR <code className="inline">nebutra-pebble-bin</code>

--- a/apps/pebble/src/lib/releases.test.ts
+++ b/apps/pebble/src/lib/releases.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DOCS_BASE, DOWNLOADS, GITHUB_RELEASES } from "./releases";
+import { DOCS_BASE, DOWNLOAD_ROWS, DOWNLOADS, GITHUB_RELEASES } from "./releases";
 
 describe("pebble brand front release links", () => {
   it("points download artifacts at GitHub Releases, not the brand origin", () => {
@@ -7,6 +7,16 @@ describe("pebble brand front release links", () => {
     for (const url of Object.values(DOWNLOADS)) {
       expect(url.startsWith("https://github.com/")).toBe(true);
     }
+  });
+
+  it("exposes live Linux and macOS installers; Windows stays soon until signed", () => {
+    const byLabel = Object.fromEntries(DOWNLOAD_ROWS.map((r) => [r.label, r]));
+    expect(byLabel["Linux x64"]?.available).toBe(true);
+    expect(byLabel["Linux arm64"]?.available).toBe(true);
+    expect(byLabel["macOS Universal"]?.available).toBe(true);
+    expect(byLabel["macOS Universal"]?.href).toBe(DOWNLOADS.macosUniversal);
+    expect(byLabel["macOS Universal"]?.badge).toBe(".dmg");
+    expect(byLabel["Windows x64"]?.available).toBe(false);
   });
 
   it("keeps docs on the platform docs host under /pebble", () => {

--- a/apps/pebble/src/lib/releases.ts
+++ b/apps/pebble/src/lib/releases.ts
@@ -4,8 +4,8 @@
  * pebble `config/scripts/verify-release-required-assets.mjs`
  * (desktop ships `.deb` on Linux, not AppImage).
  *
- * macOS / Windows installers ship once CI code-signing secrets are healthy.
- * Until then, only Linux debs are linked as direct downloads.
+ * Live on v1.4.124+: Linux debs + macOS Universal DMG.
+ * Windows setup.exe waits on WINDOWS_CERTIFICATE secrets.
  */
 export const GITHUB_RELEASES = "https://github.com/Nebutra/pebble/releases/latest";
 
@@ -41,9 +41,9 @@ export const DOWNLOAD_ROWS: readonly DownloadRow[] = [
   },
   {
     label: "macOS Universal",
-    href: GITHUB_RELEASES,
-    badge: "soon",
-    available: false,
+    href: DOWNLOADS.macosUniversal,
+    badge: ".dmg",
+    available: true,
   },
   {
     label: "Windows x64",


### PR DESCRIPTION
## Summary
- Link `pebble-macos-universal.dmg` as available on `/download` (v1.4.124 public asset).
- Keep Windows as coming soon until `WINDOWS_CERTIFICATE` secrets are set.
- Update copy + Gatekeeper note for Developer ID signed (not yet notarized) builds.

## Test plan
- [x] `vitest` releases.test.ts
- [ ] After merge: `https://pebble.nebutra.com/download` shows macOS `.dmg` link (not soon)
- [ ] Link returns 200 to GitHub release asset