### PR TITLE
fix(pebble): publish 1.4.124 changelog feed

### DIFF
--- a/apps/pebble/public/whats-new/changelog.json
+++ b/apps/pebble/public/whats-new/changelog.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-30T00:00:00.000Z",
+  "generatedAt": "2026-08-03T02:45:00.000Z",
   "entries": [
     {
-      "version": "0.0.0",
-      "tag": "placeholder",
-      "title": "Changelog feed is live",
-      "summary": "This feed is served from the Pebble brand front. Release notes continue to originate on GitHub Releases; desktop clients read this JSON without redirects.",
-      "releaseNotesUrl": "https://github.com/Nebutra/pebble/releases",
-      "publishedAt": "2026-07-30T00:00:00.000Z"
+      "version": "1.4.124",
+      "tag": "v1.4.124",
+      "title": "Pebble 1.4.124 — production soft launch",
+      "summary": "Linux .deb and macOS Universal installers are live on GitHub Releases. In-app updater covers darwin; diagnostics and feedback land on api.nebutra.com/pebble/*; product telemetry uses PostHog and Sentry in stable builds. Windows installers follow when code-signing is configured.",
+      "releaseNotesUrl": "https://github.com/Nebutra/pebble/releases/tag/v1.4.124",
+      "publishedAt": "2026-07-31T10:46:03.000Z"
     }
   ]
 }

--- a/apps/pebble/src/app/download/page.tsx
+++ b/apps/pebble/src/app/download/page.tsx
@@ -42,7 +42,7 @@ export default function DownloadPage() {
       </ul>
 
       <p className="muted" style={{ marginTop: "1.5rem" }}>
-        macOS is Developer ID signed. If Gatekeeper blocks first open, right-click the app → Open.
+        macOS builds are Developer ID signed and notarized when release CI completes successfully.
         Package managers: <code className="inline">brew install --cask nebutra/pebble/pebble</code>
         {" · "}
         AUR <code className="inline">nebutra-pebble-bin</code>


### PR DESCRIPTION
## Summary
- Replace placeholder `whats-new/changelog.json` with v1.4.124 soft-launch entry.
- Download page notes notarized macOS builds (Windows remains soon).

## Test plan
- [ ] After deploy: `https://pebble.nebutra.com/whats-new/changelog.json` shows 1.4.124