### PR TITLE
fix(cli): restore npx create-sailor (drop workspace:* prod deps)

### DIFF
--- a/.changeset/fix-create-sailor-npx-workspace.md
+++ b/.changeset/fix-create-sailor-npx-workspace.md
@@ -1,0 +1,10 @@
+---
+"create-sailor": patch
+"nebutra": patch
+---
+
+Make `npx create-sailor` / `npx nebutra` installable again when the published package.json still carries monorepo protocols.
+
+`create-sailor@1.9.1` (and `nebutra@0.4.1`) shipped `"@nebutra/brand": "workspace:*"` as a production dependency. npm cannot resolve that protocol, so `npx create-sailor@latest` fails with `EUNSUPPORTEDPROTOCOL`.
+
+Fix: keep `@nebutra/*` as build-time devDependencies, bundle them into the CLI via tsup `noExternal`, and reject monorepo-only protocols on CLI production deps in `verify:release-surface`.

--- a/packages/ai/forge-runtime/README.md
+++ b/packages/ai/forge-runtime/README.md
@@ -1,6 +1,6 @@
 # @nebutra/forge-runtime
 
-Status: active — registry + dual-surface invoke ship; product host `apps/forge` is live.
+Status: **WIP** — registry + dual-surface invoke ship; product host `apps/forge` is live (remaining gaps in package.json nebutra.gaps).
 
 Hard-correct gate (`docs/plans/tools/_hard-correct-decisions.md`):
 

--- a/packages/ops/cli/package.json
+++ b/packages/ops/cli/package.json
@@ -35,13 +35,13 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",
-    "@nebutra/brand": "workspace:*",
     "commander": "^12.1.0",
     "node-fetch": "^3.3.2",
     "p-timeout": "^6.1.4",
     "picocolors": "^1.1.0"
   },
   "devDependencies": {
+    "@nebutra/brand": "workspace:*",
     "@nebutra/theme": "workspace:*",
     "@nebutra/ui": "workspace:*",
     "@types/node": "catalog:",

--- a/packages/ops/cli/package.json
+++ b/packages/ops/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebutra",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Governance-first CLI for Nebutra Sailor topology scaffolding, registry-backed feature installs, and platform operations.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ops/cli/package.json
+++ b/packages/ops/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebutra",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Governance-first CLI for Nebutra Sailor topology scaffolding, registry-backed feature installs, and platform operations.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ops/cli/src/commands/create.ts
+++ b/packages/ops/cli/src/commands/create.ts
@@ -1,7 +1,7 @@
+import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
 import { ExitCode } from "../utils/exit-codes";
@@ -10,104 +10,65 @@ import { logger } from "../utils/logger";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Resolve create-sailor binary from multiple sources:
- * 1. Sibling package in monorepo (development)
- * 2. Installed as dependency in node_modules
- * 3. Global system PATH
+ * Resolve create-sailor binary:
+ * 1. Sibling package in monorepo (development / workspace)
+ * 2. Fallback to PATH (`create-sailor`)
  */
 function resolveCreateSailorBinary(): string {
-  const strategies = [
-    // Strategy 1: Monorepo sibling (pnpm/yarn workspace)
-    () => {
-      const siblingPath = resolve(__dirname, "../../../create-sailor/dist/index.js");
-      return siblingPath;
-    },
-  ];
-
-  for (const strategy of strategies) {
-    try {
-      const path = strategy();
-      return path;
-    } catch (error) {
-      logger.debug("create-sailor binary resolution strategy failed", { error });
-    }
-  }
-
-  // Fallback: try to find via 'which' or assume it's in PATH
+  const siblingPath = resolve(__dirname, "../../../create-sailor/dist/index.js");
+  if (existsSync(siblingPath)) return siblingPath;
   return "create-sailor";
 }
 
-interface SpawnError extends Error {
-  code?: string;
-  signal?: string;
-}
-
-function _isSpawnError(error: unknown): error is SpawnError {
-  return error instanceof Error && "code" in error;
+/**
+ * Forward argv after `create` so flags like `--region=cn` reach create-sailor.
+ * Commander does not put unknown options into `cmd.args` reliably.
+ */
+function passthroughArgs(dir: string | undefined): string[] {
+  const raw = process.argv.slice(2);
+  const createIdx = raw.findIndex((a) => a === "create");
+  if (createIdx < 0) return dir ? [dir] : [];
+  return raw.slice(createIdx + 1);
 }
 
 export function registerCreateCommand(program: Command) {
   program
     .command("create [dir]")
-    .description("Scaffold a new Nebutra-Sailor project")
+    .description("Scaffold a new Sailor project (delegates to create-sailor)")
     .allowUnknownOption(true)
-    .action(async (dir: string | undefined, _options: Record<string, unknown>, cmd: Command) => {
-      p.intro(pc.bgCyan(pc.black(" nebutra create ")));
+    .allowExcessArguments(true)
+    .action(async (dir: string | undefined) => {
+      // Thin wrapper: no second banner/outro — create-sailor owns the UX.
+      const createSailorBin = resolveCreateSailorBinary();
+      const args = passthroughArgs(dir);
+      const useNode = createSailorBin.endsWith(".js");
 
-      try {
-        const createSailorBin = resolveCreateSailorBinary();
+      const child = useNode
+        ? spawn(process.execPath, [createSailorBin, ...args], {
+            stdio: "inherit",
+            env: { ...process.env },
+          })
+        : spawn(createSailorBin, args, {
+            stdio: "inherit",
+            env: { ...process.env },
+            shell: true,
+          });
 
-        // Build arguments: if dir is provided, pass it; include any remaining args
-        const args = dir ? [dir] : [];
+      child.on("close", (code) => {
+        process.exit(code ?? 0);
+      });
 
-        // Add any additional arguments passed to the command
-        if (cmd.args && cmd.args.length > (dir ? 1 : 0)) {
-          const additionalArgs = cmd.args.slice(dir ? 1 : 0);
-          args.push(...additionalArgs);
+      child.on("error", (err: NodeJS.ErrnoException) => {
+        logger.error(`Failed to launch create-sailor: ${err.message}`);
+        if (err.code === "ENOENT") {
+          process.stderr.write(
+            `\n${pc.yellow("Tip:")} install the scaffolder:\n` +
+              `  ${pc.cyan("npm i -g create-sailor")}\n` +
+              `  ${pc.cyan("npx create-sailor@latest")}\n\n`,
+          );
+          process.exit(ExitCode.NOT_FOUND);
         }
-
-        const spinner = p.spinner();
-        spinner.start(pc.cyan(`Launching create-sailor${dir ? ` in ${dir}` : ""}...`));
-
-        const child = spawn(process.execPath, [createSailorBin, ...args], {
-          stdio: "inherit",
-          env: { ...process.env },
-        });
-
-        child.on("close", (code) => {
-          spinner.stop();
-          if (code === 0) {
-            p.outro(
-              pc.green(
-                "Project created successfully! Run 'npm install && npm run dev' to get started.",
-              ),
-            );
-          }
-          process.exit(code ?? 0);
-        });
-
-        child.on("error", (err: SpawnError) => {
-          spinner.stop();
-          logger.error(`\nFailed to launch create-sailor: ${err.message}`);
-
-          if (err.code === "ENOENT") {
-            logger.warn("\nTip: Ensure create-sailor is installed or available in your PATH.");
-            logger.info("  Install globally: npm install -g create-sailor");
-            process.exit(ExitCode.NOT_FOUND);
-          }
-
-          process.exit(ExitCode.ERROR);
-        });
-      } catch (error: unknown) {
-        p.log.error(
-          pc.red("Error: Unable to start create-sailor. Ensure it is properly installed."),
-        );
-
-        if (error instanceof Error) {
-          logger.error(error.message);
-        }
-
         process.exit(ExitCode.ERROR);
-      }
+      });
     });
 }

--- a/packages/ops/cli/src/commands/upgrade.ts
+++ b/packages/ops/cli/src/commands/upgrade.ts
@@ -1,8 +1,16 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import { ExitCode } from "../utils/exit-codes";
 import { logger } from "../utils/logger";
 import { checkForUpdate } from "../utils/update-notifier";
+
+const PKG_JSON_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
+const CURRENT_VERSION = (
+  JSON.parse(readFileSync(PKG_JSON_PATH, "utf8")) as { version: string }
+).version;
 
 interface UpgradeOptions {
   yes?: boolean;
@@ -47,8 +55,6 @@ function upgradeCommandFor(installer: Installer): string {
       return "npm i -g nebutra@latest";
   }
 }
-
-const CURRENT_VERSION = "0.1.0";
 
 async function handleUpgrade(options: UpgradeOptions) {
   const installer = detectInstaller();

--- a/packages/ops/cli/src/index.ts
+++ b/packages/ops/cli/src/index.ts
@@ -289,6 +289,16 @@ export function buildProgram(options: BuildProgramOptions): Command {
           );
         }
 
+        // Post-scaffold golden path when create-sailor marker is present
+        if (fs.existsSync(scaffoldMetaFile) || fs.existsSync(path.join(root, "nebutra.config.json"))) {
+          logger.info("");
+          logger.info("Golden path to a running app:");
+          logger.info("  1. Fill .env.local (copy keys from .env.example)");
+          logger.info("  2. pnpm infra:up     # local Postgres/Redis if needed");
+          logger.info("  3. pnpm db:migrate && pnpm db:seed");
+          logger.info("  4. pnpm dev          # http://localhost:3000");
+        }
+
         if (hasErrors) {
           throw new CommandError({
             code: "doctor_failed",

--- a/packages/ops/cli/src/utils/first-run.ts
+++ b/packages/ops/cli/src/utils/first-run.ts
@@ -3,6 +3,7 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { brand } from "@nebutra/brand/metadata";
 import { getBrandOrigin } from "@nebutra/brand/metadata-helpers";
+import pc from "picocolors";
 
 function getConfigDir(): string {
   if (platform() === "win32") {
@@ -16,6 +17,15 @@ function getConfigDir(): string {
 function isTelemetryExplicitlyOff(): boolean {
   const v = process.env.NEBUTRA_TELEMETRY;
   return v === "0" || v === "false" || v === "no";
+}
+
+function writeMarker(dir: string, marker: string): void {
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(marker, "");
+  } catch {
+    // ignore
+  }
 }
 
 export function maybeShowFirstRunBanner(): void {
@@ -32,19 +42,15 @@ export function maybeShowFirstRunBanner(): void {
   }
 
   if (isTelemetryExplicitlyOff()) {
-    try {
-      mkdirSync(dir, { recursive: true });
-      writeFileSync(marker, "");
-    } catch {
-      // ignore
-    }
+    writeMarker(dir, marker);
     return;
   }
 
+  const info = pc.cyan("ℹ");
   const lines = [
-    `[36mℹ[0m ${brand.name} collects anonymous usage analytics to improve the CLI.`,
-    "  Opt out at any time:  export NEBUTRA_TELEMETRY=0",
-    `  Privacy policy:       ${getBrandOrigin("landing")}/legal/cli-analytics`,
+    `${info} ${brand.name} collects anonymous usage analytics to improve the CLI.`,
+    `  Opt out at any time:  ${pc.dim("export NEBUTRA_TELEMETRY=0")}`,
+    `  Privacy policy:       ${pc.dim(`${getBrandOrigin("landing")}/legal/cli-analytics`)}`,
     "",
   ];
   try {
@@ -53,10 +59,5 @@ export function maybeShowFirstRunBanner(): void {
     // ignore
   }
 
-  try {
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(marker, "");
-  } catch {
-    // silently ignore - banner is informational
-  }
+  writeMarker(dir, marker);
 }

--- a/packages/ops/create-sailor/README.md
+++ b/packages/ops/create-sailor/README.md
@@ -38,7 +38,14 @@ bunx create-sailor@latest
 npx create-sailor@latest
 ```
 
-Interactive flow starts with **where to create** (new folder vs current directory — defaults based on whether cwd looks empty), then **project name** (only for a new folder), then region / auth / AI topology. Everything else uses region-aware smart defaults.
+Interactive flow:
+
+1. **Where** — new folder (name, default `my-app`) or current directory (smart default if cwd is empty)
+2. **Region / Auth / AI topology**
+3. **Plan** — compact summary; confirm or customize payment · email · storage · deploy
+4. **Done** — short golden path (`cd` → env → migrate → dev)
+
+Everything else uses region-aware smart defaults (`--yes` skips prompts).
 
 ```bash
 npx create-sailor@latest my-app   # new folder

--- a/packages/ops/create-sailor/README.md
+++ b/packages/ops/create-sailor/README.md
@@ -38,7 +38,12 @@ bunx create-sailor@latest
 npx create-sailor@latest
 ```
 
-Asks just 4 questions: **project name / region / auth / AI topology**. Everything else uses region-aware smart defaults.
+Interactive flow starts with **where to create** (new folder vs current directory — defaults based on whether cwd looks empty), then **project name** (only for a new folder), then region / auth / AI topology. Everything else uses region-aware smart defaults.
+
+```bash
+npx create-sailor@latest my-app   # new folder
+npx create-sailor@latest .        # current directory
+```
 
 The AI prompt is topology-first:
 

--- a/packages/ops/create-sailor/package.json
+++ b/packages/ops/create-sailor/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@clack/prompts": "^1.5.0",
     "@mrleebo/prisma-ast": "^0.16.0",
-    "@nebutra/brand": "workspace:*",
     "cfonts": "^3.3.0",
     "commander": "^15.0.0",
     "gradient-string": "^3.0.0",
@@ -33,6 +32,7 @@
     "update-notifier": "^7.3.1"
   },
   "devDependencies": {
+    "@nebutra/brand": "workspace:*",
     "@types/node": "catalog:",
     "@types/update-notifier": "^6.0.8",
     "tsup": "catalog:",

--- a/packages/ops/create-sailor/package.json
+++ b/packages/ops/create-sailor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sailor",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Governed AI-native SaaS scaffolder for Nebutra Sailor. Bootstrap a production-ready Next.js + Hono + Prisma monorepo with multi-tenant foundations, region-aware defaults, and AI integrations.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ops/create-sailor/package.json
+++ b/packages/ops/create-sailor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sailor",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Governed AI-native SaaS scaffolder for Nebutra Sailor. Bootstrap a production-ready Next.js + Hono + Prisma monorepo with multi-tenant foundations, region-aware defaults, and AI integrations.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ops/create-sailor/package.json
+++ b/packages/ops/create-sailor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sailor",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Governed AI-native SaaS scaffolder for Nebutra Sailor. Bootstrap a production-ready Next.js + Hono + Prisma monorepo with multi-tenant foundations, region-aware defaults, and AI integrations.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ops/create-sailor/src/index.ts
+++ b/packages/ops/create-sailor/src/index.ts
@@ -16,7 +16,6 @@
 
 import { execSync } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { buildProgram } from "./steps/cli-setup";
@@ -29,6 +28,11 @@ import { showHelp } from "./ui/help";
 import { printProgressLine } from "./ui/progress";
 import { SOCIAL_LOGIN_PROVIDERS } from "./utils/auth-social";
 import { maybeShowFirstRunBanner } from "./utils/first-run";
+import {
+  DEFAULT_PROJECT_NAME,
+  promptProjectTarget,
+  resolveTargetFromInput,
+} from "./utils/project-target";
 import { VERSION } from "./version";
 
 // ---------------------------------------------------------------------------
@@ -220,40 +224,41 @@ async function run(): Promise<void> {
     }
   }
 
-  // ---- Project-name resolution ----
-  const targetDir = nameArg ?? (autoYes ? "./my-saas-app" : undefined);
-  let resolvedTarget: string;
+  // ---- Project location resolution ----
+  // Interactive: pick "new folder" vs "current directory" (smart default from
+  // cwd emptiness). Non-interactive / --yes: ./my-app. CLI arg: name or path.
+  const cancel = (): never => {
+    process.stdout.write(pc.red("✘ Cancelled\n"));
+    process.exit(130);
+  };
 
-  if (!targetDir) {
-    if (nonInteractive) {
-      resolvedTarget = "./my-saas-app";
-    } else {
-      const project = await p.group(
-        {
-          name: () =>
-            p.text({
-              message: "Where should we create your project?",
-              placeholder: "./my-saas-app",
-              defaultValue: "./my-saas-app",
-              validate: (value) => {
-                if (!value?.length) return "Please enter a path.";
-              },
-            }),
-        },
-        {
-          onCancel: () => {
-            process.stdout.write(pc.red("✘ Cancelled\n"));
-            process.exit(130);
-          },
-        },
-      );
-      resolvedTarget = String(project.name);
+  let resolvedTarget: string;
+  let projectName: string;
+
+  if (nameArg) {
+    try {
+      const resolved = resolveTargetFromInput(nameArg);
+      resolvedTarget = resolved.targetDir;
+      projectName = resolved.projectName;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`\n${pc.red("✘")} ${msg}\n\n`);
+      emitJson(useJson, { event: "error", code: "INVALID_PROJECT_NAME", message: msg });
+      process.exit(1);
     }
+  } else if (nonInteractive) {
+    const resolved = resolveTargetFromInput(DEFAULT_PROJECT_NAME);
+    resolvedTarget = resolved.targetDir;
+    projectName = resolved.projectName;
   } else {
-    resolvedTarget = targetDir;
+    const resolved = await promptProjectTarget({ onCancel: cancel });
+    resolvedTarget = resolved.targetDir;
+    projectName = resolved.projectName;
+    if (!useJson) {
+      process.stdout.write(pc.dim(`  → ${resolved.absoluteDir}\n`));
+    }
   }
 
-  const projectName = path.basename(path.resolve(resolvedTarget));
   const resolvedPm = opts.pm ?? detectPm();
 
   // ---- Config resolution (interactive or non-interactive) ----

--- a/packages/ops/create-sailor/src/index.ts
+++ b/packages/ops/create-sailor/src/index.ts
@@ -33,6 +33,7 @@ import {
   promptProjectTarget,
   resolveTargetFromInput,
 } from "./utils/project-target";
+import { confirmAndMaybeReview } from "./utils/review-defaults";
 import { VERSION } from "./version";
 
 // ---------------------------------------------------------------------------
@@ -262,48 +263,46 @@ async function run(): Promise<void> {
   const resolvedPm = opts.pm ?? detectPm();
 
   // ---- Config resolution (interactive or non-interactive) ----
-  const resolved = await resolveConfig(opts, useJson);
+  let resolved = await resolveConfig(opts, useJson);
 
-  // ---- Progress summary table ----
+  // ---- Compact summary (core + region defaults) ----
   const steps: Array<[string, string]> = [
-    ["Project name", projectName],
+    ["Project", projectName],
     ["Region", resolved.region],
     ["Auth", resolved.auth],
-    [
-      "Social login",
-      resolved.socialLoginIds.length > 0
-        ? resolved.socialLoginIds
-            .map((id) => SOCIAL_LOGIN_PROVIDERS.find((p) => p.id === id)?.name ?? id)
-            .join(", ")
-        : "none",
-    ],
-    ["ORM", resolved.orm],
-    ["Database", resolved.database],
-    ["Database Host", resolved.databaseHost],
     ["Payment", resolved.paymentChoice],
     [
-      "AI topology",
-      `${resolved.aiMode}${resolved.aiProviders.length > 0 ? ` (${resolved.aiProviders.join(", ")} seed)` : ""}${
-        resolved.customAiEndpoint ? " + custom endpoint" : ""
-      }`,
+      "AI",
+      `${resolved.aiMode}${resolved.aiProviders.length > 0 ? ` (${resolved.aiProviders.join(", ")})` : ""}`,
     ],
+    ["Database", `${resolved.database} · ${resolved.databaseHost}`],
     ["Email", resolved.email],
     ["Storage", resolved.storage],
-    ["Monitoring", resolved.monitoring],
-    ["Analytics", resolved.analytics],
-    ["SMS", resolved.sms],
-    ["Deploy Target", resolved.deployTarget],
-    ["Docs Framework", resolved.docs],
-    ["Access gate", resolved.accessGate],
+    ["Deploy", resolved.deployTarget],
   ];
+  if (resolved.socialLoginIds.length > 0) {
+    steps.push([
+      "Social login",
+      resolved.socialLoginIds
+        .map((id) => SOCIAL_LOGIN_PROVIDERS.find((p) => p.id === id)?.name ?? id)
+        .join(", "),
+    ]);
+  }
   if (!useJson) {
+    process.stdout.write(pc.dim("\n  Plan\n"));
     steps.forEach(([label, value], i) => {
       printProgressLine({ index: i + 1, total: steps.length, label, value });
     });
+    process.stdout.write("\n");
   } else {
     steps.forEach(([label, value], i) => {
       emitJson(true, { event: "step", step: label, value, index: i + 1, total: steps.length });
     });
+  }
+
+  // Confirm / customize before writing (interactive only; --yes / CI skip).
+  if (!nonInteractive && !useJson) {
+    resolved = await confirmAndMaybeReview(resolved, cancel);
   }
 
   // ---- Dry run ----

--- a/packages/ops/create-sailor/src/steps/cli-setup.ts
+++ b/packages/ops/create-sailor/src/steps/cli-setup.ts
@@ -17,7 +17,11 @@ export function buildProgram(): Command {
     .description("Nebutra-Sailor — AI-Native SaaS template")
     .version(VERSION, "-v, --version")
     .helpOption(false) // we render our own help
-    .argument("[name]", "project directory", undefined)
+    .argument(
+      "[name]",
+      "project name or path (default: my-app; use . for current directory)",
+      undefined,
+    )
     .option("-p, --pm <id>", "npm | pnpm | yarn | bun")
     .option("--region <id>", "global | cn | hybrid")
     .option(

--- a/packages/ops/create-sailor/src/steps/resolve-config.ts
+++ b/packages/ops/create-sailor/src/steps/resolve-config.ts
@@ -98,9 +98,9 @@ async function runInteractivePrompts(
       p.select({
         message: "Target region?",
         options: [
-          { value: "global", label: "global — 海外优先" },
-          { value: "cn", label: "cn     — 国内优先" },
-          { value: "hybrid", label: "hybrid — 双轨（国内+出海）" },
+          { value: "global", label: "Global", hint: "Stripe · Resend · R2 defaults" },
+          { value: "cn", label: "China", hint: "WeChat Pay · Aliyun DM/OSS defaults" },
+          { value: "hybrid", label: "Hybrid", hint: "global + CN dual track" },
         ],
         initialValue: "global",
       }) as Promise<unknown>;

--- a/packages/ops/create-sailor/src/steps/scaffold.ts
+++ b/packages/ops/create-sailor/src/steps/scaffold.ts
@@ -541,13 +541,19 @@ export async function runScaffold(ctx: ScaffoldContext): Promise<void> {
         stdio: useJson ? "ignore" : "inherit",
       });
       emitJson(useJson, { event: "step", step: "install", status: "ok" });
+      if (!useJson) {
+        process.stdout.write(pc.green(`  ✓ Dependencies installed (${resolvedPm})\n`));
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (useJson) {
         emitJson(true, { event: "step", step: "install", status: "error", error: msg });
       } else {
         process.stdout.write(
-          pc.yellow(`  ⚠ install failed — run '${resolvedPm} install' manually.\n`),
+          pc.yellow(
+            `\n  ⚠ Install failed — the project files are ready, but deps are incomplete.\n` +
+              `    Fix: ${pc.cyan(`cd ${resolvedTarget} && ${resolvedPm} install`)}\n\n`,
+          ),
         );
       }
       // Non-fatal — project was still scaffolded.
@@ -624,9 +630,10 @@ export async function runScaffold(ctx: ScaffoldContext): Promise<void> {
     showDone({
       elapsedSec,
       targetDir: resolvedTarget,
+      packageManager: resolvedPm,
       skippedInstall: opts.install === false,
+      hasDatabase: database !== "none",
       previewSelections,
-      waveFeatures: waveToggles,
     });
   }
 

--- a/packages/ops/create-sailor/src/ui/done.test.ts
+++ b/packages/ops/create-sailor/src/ui/done.test.ts
@@ -13,7 +13,7 @@ describe("showDone", () => {
     }
   });
 
-  it("prints only scaffolded pnpm next steps", () => {
+  it("prints a short golden path with db steps when database is enabled", () => {
     process.env.NO_COLOR = "1";
 
     let output = "";
@@ -25,19 +25,41 @@ describe("showDone", () => {
     showDone({
       elapsedSec: 12,
       targetDir: "demo-app",
+      packageManager: "pnpm",
       skippedInstall: true,
+      hasDatabase: true,
     });
 
-    expect(output).toContain("pnpm install");
     expect(output).toContain("cd demo-app");
+    expect(output).toContain("pnpm install");
     expect(output).toContain("pnpm db:migrate");
-    expect(output).toContain("pnpm db:seed");
-    expect(output).toContain("pnpm brand:init");
-    expect(output).toContain("pnpm brand:apply");
-    expect(output).toContain("pnpm preset:env");
-    expect(output).toContain("pnpm generate:api-types");
-    expect(output).not.toContain("pnpm sailor");
-    expect(output).not.toContain("sailor add");
+    expect(output).toContain("pnpm dev");
+    expect(output).toContain("nebutra doctor");
+    // Advanced noise removed from golden path
+    expect(output).not.toContain("pnpm brand:init");
+    expect(output).not.toContain("pnpm audit");
+    expect(output).not.toContain("Free license");
+  });
+
+  it("omits db steps when database is none", () => {
+    process.env.NO_COLOR = "1";
+
+    let output = "";
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write);
+
+    showDone({
+      elapsedSec: 3,
+      targetDir: "demo-app",
+      skippedInstall: false,
+      hasDatabase: false,
+    });
+
+    expect(output).not.toContain("db:migrate");
+    expect(output).not.toContain("infra:up");
+    expect(output).toContain("pnpm dev");
   });
 
   it("skips cd when scaffolded into the current directory", () => {
@@ -53,6 +75,7 @@ describe("showDone", () => {
       elapsedSec: 3,
       targetDir: ".",
       skippedInstall: false,
+      hasDatabase: true,
     });
 
     expect(output).toContain("· .");

--- a/packages/ops/create-sailor/src/ui/done.test.ts
+++ b/packages/ops/create-sailor/src/ui/done.test.ts
@@ -29,6 +29,7 @@ describe("showDone", () => {
     });
 
     expect(output).toContain("pnpm install");
+    expect(output).toContain("cd demo-app");
     expect(output).toContain("pnpm db:migrate");
     expect(output).toContain("pnpm db:seed");
     expect(output).toContain("pnpm brand:init");
@@ -37,5 +38,24 @@ describe("showDone", () => {
     expect(output).toContain("pnpm generate:api-types");
     expect(output).not.toContain("pnpm sailor");
     expect(output).not.toContain("sailor add");
+  });
+
+  it("skips cd when scaffolded into the current directory", () => {
+    process.env.NO_COLOR = "1";
+
+    let output = "";
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write);
+
+    showDone({
+      elapsedSec: 3,
+      targetDir: ".",
+      skippedInstall: false,
+    });
+
+    expect(output).toContain("· .");
+    expect(output).not.toMatch(/cd \./);
   });
 });

--- a/packages/ops/create-sailor/src/ui/done.ts
+++ b/packages/ops/create-sailor/src/ui/done.ts
@@ -30,17 +30,23 @@ export function showDone(opts: DoneOptions): void {
   const star = decor ? "★" : "*";
   const mail = decor ? "📧" : "*";
 
-  const title = decor
-    ? pc.bold(`${anchor}  Done in ${opts.elapsedSec}s · ${opts.targetDir}/`)
-    : `${anchor} Done in ${opts.elapsedSec}s · ${opts.targetDir}/`;
+  const isCwd = opts.targetDir === "." || opts.targetDir === "./" || opts.targetDir === ".\\";
+  const locationLabel = isCwd
+    ? "."
+    : opts.targetDir.endsWith("/")
+      ? opts.targetDir
+      : `${opts.targetDir}/`;
 
-  const lines: string[] = [
-    "",
-    `   ${title}`,
-    "",
-    `   ${decor ? pc.bold("Next:") : "Next:"}`,
-    `     ${arrow} cd ${opts.targetDir}`,
-  ];
+  const title = decor
+    ? pc.bold(`${anchor}  Done in ${opts.elapsedSec}s · ${locationLabel}`)
+    : `${anchor} Done in ${opts.elapsedSec}s · ${locationLabel}`;
+
+  const lines: string[] = ["", `   ${title}`, "", `   ${decor ? pc.bold("Next:") : "Next:"}`];
+
+  // Skip a no-op `cd .` when the user scaffolded into the current directory.
+  if (!isCwd) {
+    lines.push(`     ${arrow} cd ${opts.targetDir}`);
+  }
 
   if (opts.skippedInstall) {
     lines.push(`     ${arrow} pnpm install       (if --no-install was set)`);

--- a/packages/ops/create-sailor/src/ui/done.ts
+++ b/packages/ops/create-sailor/src/ui/done.ts
@@ -1,34 +1,31 @@
 import pc from "picocolors";
 import { describeStatus, formatStatusBadge, type PreviewSelection } from "../utils/package-status";
 
-export interface WaveFeatureSummary {
-  cronJobs?: boolean;
-  auditLog?: boolean;
-  apiKeys?: boolean;
-  commandPalette?: boolean;
-  cookieConsent?: boolean;
-  legalPages?: boolean;
-  chinaCompliance?: boolean;
-}
-
 export interface DoneOptions {
   elapsedSec: number;
   targetDir: string;
+  /** Package manager used for install (pnpm/npm/yarn/bun). */
+  packageManager?: string;
   skippedInstall: boolean;
+  /** When false, hide db:migrate / db:seed. Default true for backward compat. */
+  hasDatabase?: boolean;
   previewSelections?: PreviewSelection[];
-  waveFeatures?: WaveFeatureSummary;
 }
 
 function shouldUseDecor(): boolean {
   return !process.env.NO_COLOR && !!process.stdout.isTTY;
 }
 
+/**
+ * Golden-path completion screen.
+ * Only the minimum steps to get a running app; advanced scripts live in docs.
+ */
 export function showDone(opts: DoneOptions): void {
   const decor = shouldUseDecor();
   const anchor = decor ? "⚓" : "-";
   const arrow = decor ? "▸" : "->";
-  const star = decor ? "★" : "*";
-  const mail = decor ? "📧" : "*";
+  const pm = opts.packageManager ?? "pnpm";
+  const hasDatabase = opts.hasDatabase !== false;
 
   const isCwd = opts.targetDir === "." || opts.targetDir === "./" || opts.targetDir === ".\\";
   const locationLabel = isCwd
@@ -41,80 +38,50 @@ export function showDone(opts: DoneOptions): void {
     ? pc.bold(`${anchor}  Done in ${opts.elapsedSec}s · ${locationLabel}`)
     : `${anchor} Done in ${opts.elapsedSec}s · ${locationLabel}`;
 
-  const lines: string[] = ["", `   ${title}`, "", `   ${decor ? pc.bold("Next:") : "Next:"}`];
+  const dim = (s: string) => (decor ? pc.dim(s) : s);
+  const bold = (s: string) => (decor ? pc.bold(s) : s);
 
-  // Skip a no-op `cd .` when the user scaffolded into the current directory.
+  const lines: string[] = ["", `   ${title}`, "", `   ${bold("Next:")}`];
+
   if (!isCwd) {
     lines.push(`     ${arrow} cd ${opts.targetDir}`);
   }
 
   if (opts.skippedInstall) {
-    lines.push(`     ${arrow} pnpm install       (if --no-install was set)`);
+    lines.push(`     ${arrow} ${pm} install`);
   }
 
   lines.push(
-    `     ${arrow} fill in .env.local ${decor ? pc.dim("→ add provider keys before booting apps") : "-> add provider keys before booting apps"}`,
-    `     ${arrow} pnpm db:migrate    ${decor ? pc.dim("→ sync Prisma schema") : "-> sync Prisma schema"}`,
-    `     ${arrow} pnpm db:seed       ${decor ? pc.dim("→ load example tenants and records") : "-> load example tenants and records"}`,
-    `     ${arrow} pnpm dev           ${decor ? pc.dim("→ http://localhost:3000") : "-> http://localhost:3000"}`,
-    "",
-    `   ${decor ? pc.bold("Customize:") : "Customize:"}`,
-    `     ${arrow} pnpm brand:init    ${decor ? pc.dim("→ create brand.config.ts") : "-> create brand.config.ts"}`,
-    `     ${arrow} pnpm brand:apply   ${decor ? pc.dim("→ propagate brand changes") : "-> propagate brand changes"}`,
-    `     ${arrow} pnpm preset:env    ${decor ? pc.dim("→ review preset env requirements") : "-> review preset env requirements"}`,
-    "",
-    `   ${decor ? pc.bold("Useful scripts:") : "Useful scripts:"}`,
-    `     ${arrow} pnpm infra:up      ${decor ? pc.dim("→ start local PostgreSQL/Redis/ClickHouse") : "-> start local PostgreSQL/Redis/ClickHouse"}`,
-    `     ${arrow} pnpm generate:api-types ${decor ? pc.dim("→ refresh shared API client types") : "-> refresh shared API client types"}`,
-    `     ${arrow} pnpm lint          ${decor ? pc.dim("→ quick repo sanity check") : "-> quick repo sanity check"}`,
-    `     ${arrow} pnpm audit         ${decor ? pc.dim("→ scan deps for known CVEs") : "-> scan deps for known CVEs"}`,
+    `     ${arrow} fill .env.local  ${dim("→ provider keys from .env.example")}`,
   );
 
-  // Preview-status providers: call them out so the user knows they
-  // scaffolded stub-level packages and won't be surprised at runtime.
-  const preview = opts.previewSelections ?? [];
-  if (preview.length > 0) {
-    const header = decor
-      ? pc.bold(pc.yellow("⚠  Preview features selected:"))
-      : "!! Preview features selected:";
-    lines.push("", `   ${header}`);
-    for (const sel of preview) {
-      const badge = formatStatusBadge(sel.status);
-      const line = `     ${arrow} ${sel.flag} (${sel.provider}) ${badge}`;
-      lines.push(decor ? pc.yellow(line) : line);
-    }
+  if (hasDatabase) {
     lines.push(
-      "",
-      `     ${decor ? pc.dim(describeStatus("foundation")) : describeStatus("foundation")}`,
-      `     ${decor ? pc.dim("You may need to contribute the provider integration yourself.") : "You may need to contribute the provider integration yourself."}`,
-      `     ${decor ? pc.dim("See: https://github.com/Nebutra/Nebutra-Sailor/blob/main/docs/package-status.md") : "See: https://github.com/Nebutra/Nebutra-Sailor/blob/main/docs/package-status.md"}`,
+      `     ${arrow} ${pm} infra:up     ${dim("→ local Postgres (optional)")}`,
+      `     ${arrow} ${pm} db:migrate   ${dim("→ apply Prisma schema")}`,
     );
   }
 
-  // What you can do next — surface the most discoverable wave 3-5 features.
-  const features = opts.waveFeatures ?? {};
-  const enabled = (v: boolean | undefined): boolean => v !== false;
-  const nextHints: string[] = [];
-  if (enabled(features.apiKeys)) nextHints.push("Manage API keys at /settings/api-keys");
-  if (enabled(features.auditLog)) nextHints.push("View audit log at /settings/audit-log");
-  nextHints.push("Configure webhooks at /settings/webhooks");
-  if (enabled(features.commandPalette))
-    nextHints.push("Press Cmd/Ctrl+K to open the command palette");
-  nextHints.push("Edit notification preferences at /settings/notifications");
-  nextHints.push("Export your data at /settings/account/export");
-  if (features.chinaCompliance)
-    nextHints.push("China deployments — see packages/ops/china-compliance/README.md");
-
-  lines.push("", `   ${decor ? pc.bold("What you can do next:") : "What you can do next:"}`);
-  for (const hint of nextHints) lines.push(`     ${arrow} ${hint}`);
-
   lines.push(
+    `     ${arrow} ${pm} dev          ${dim("→ http://localhost:3000")}`,
     "",
-    `   ${decor ? pc.bold("Ship faster:") : "Ship faster:"}`,
-    `     ${star} Star us       https://github.com/nebutra/nebutra-sailor`,
-    `     ${mail} Free license https://nebutra.com/get-license`,
-    "",
+    `   ${dim("More:")} ${dim("nebutra doctor")} ${dim("·")} ${dim("docs.nebutra.com")}`,
   );
 
+  const preview = opts.previewSelections ?? [];
+  if (preview.length > 0) {
+    const header = decor
+      ? pc.bold(pc.yellow("⚠  Preview / foundation providers:"))
+      : "!! Preview / foundation providers:";
+    lines.push("", `   ${header}`);
+    for (const sel of preview) {
+      const badge = formatStatusBadge(sel.status);
+      const line = `     ${arrow} ${sel.flag}=${sel.provider} ${badge}`;
+      lines.push(decor ? pc.yellow(line) : line);
+    }
+    lines.push(`     ${dim(describeStatus("foundation"))}`);
+  }
+
+  lines.push("");
   process.stdout.write(lines.join("\n") + "\n");
 }

--- a/packages/ops/create-sailor/src/ui/help.ts
+++ b/packages/ops/create-sailor/src/ui/help.ts
@@ -63,12 +63,19 @@ Toggles:
   -h, --help                show this help
   -v, --version             show version
 
+Interactive flow:
+  1. Location — new folder (name) or current directory
+  2. Region / Auth / AI topology
+  3. Plan summary — confirm or customize payment · email · storage · deploy
+  4. Scaffold + golden-path next steps
+
 Examples:
   $ npx create-sailor@latest
   $ npx create-sailor@latest my-app -y
+  $ npx create-sailor@latest . --region=cn
   $ npx create-sailor@latest my-app --region=cn --auth=clerk
   $ npx create-sailor@latest my-app --region=hybrid --ai=openai,deepseek
-  $ npm create sailor@latest --dry-run --region=cn
+  $ npx create-sailor@latest my-app --dry-run --region=cn
 `;
 
 export function showHelp(): void {

--- a/packages/ops/create-sailor/src/ui/help.ts
+++ b/packages/ops/create-sailor/src/ui/help.ts
@@ -1,7 +1,7 @@
 export const HELP_TEXT = `Usage: create-sailor [name] [options]
 
 Arguments:
-  name                      project directory (default: ./my-saas-app)
+  name                      project name or path (default: my-app; use . for cwd)
 
 Core options:
   -p, --pm <id>             npm | pnpm | yarn | bun (auto-detected)

--- a/packages/ops/create-sailor/src/utils/__tests__/project-target.test.ts
+++ b/packages/ops/create-sailor/src/utils/__tests__/project-target.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_PROJECT_NAME,
+  hasBlockingProjectMarkers,
+  isCurrentDirToken,
+  isDirEffectivelyEmpty,
+  preferCurrentDirectory,
+  resolveTargetFromInput,
+  validateProjectName,
+} from "../project-target";
+
+const tmpDirs: string[] = [];
+
+function makeTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cs-target-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("isCurrentDirToken", () => {
+  it("recognizes . and ./", () => {
+    expect(isCurrentDirToken(".")).toBe(true);
+    expect(isCurrentDirToken("./")).toBe(true);
+    expect(isCurrentDirToken("my-app")).toBe(false);
+  });
+});
+
+describe("isDirEffectivelyEmpty", () => {
+  it("treats missing and empty dirs as empty", () => {
+    const dir = makeTmp();
+    expect(isDirEffectivelyEmpty(dir)).toBe(true);
+    expect(isDirEffectivelyEmpty(path.join(dir, "nope"))).toBe(true);
+  });
+
+  it("ignores .git and OS junk", () => {
+    const dir = makeTmp();
+    fs.mkdirSync(path.join(dir, ".git"));
+    fs.writeFileSync(path.join(dir, ".DS_Store"), "");
+    expect(isDirEffectivelyEmpty(dir)).toBe(true);
+  });
+
+  it("detects real content", () => {
+    const dir = makeTmp();
+    fs.writeFileSync(path.join(dir, "README.md"), "hi");
+    expect(isDirEffectivelyEmpty(dir)).toBe(false);
+  });
+});
+
+describe("hasBlockingProjectMarkers", () => {
+  it("flags package.json / lockfiles / node_modules", () => {
+    const dir = makeTmp();
+    expect(hasBlockingProjectMarkers(dir)).toBe(false);
+    fs.writeFileSync(path.join(dir, "package.json"), "{}");
+    expect(hasBlockingProjectMarkers(dir)).toBe(true);
+  });
+});
+
+describe("preferCurrentDirectory", () => {
+  it("prefers current when empty, new folder when busy", () => {
+    const empty = makeTmp();
+    expect(preferCurrentDirectory(empty)).toBe(true);
+
+    const busy = makeTmp();
+    fs.writeFileSync(path.join(busy, "notes.txt"), "x");
+    expect(preferCurrentDirectory(busy)).toBe(false);
+  });
+});
+
+describe("validateProjectName", () => {
+  it("accepts common names", () => {
+    expect(validateProjectName("my-app")).toBeUndefined();
+    expect(validateProjectName("Acme_1")).toBeUndefined();
+  });
+
+  it("rejects empty and illegal chars", () => {
+    expect(validateProjectName("")).toBeTruthy();
+    expect(validateProjectName("  ")).toBeTruthy();
+    expect(validateProjectName("my app")).toBeTruthy();
+  });
+});
+
+describe("resolveTargetFromInput", () => {
+  it("defaults bare empty to my-app", () => {
+    const r = resolveTargetFromInput("", "/tmp/work");
+    expect(r).toEqual({
+      targetDir: `./${DEFAULT_PROJECT_NAME}`,
+      projectName: DEFAULT_PROJECT_NAME,
+      absoluteDir: path.resolve("/tmp/work", DEFAULT_PROJECT_NAME),
+    });
+  });
+
+  it("maps bare names to ./name", () => {
+    const r = resolveTargetFromInput("acme", "/home/me");
+    expect(r.targetDir).toBe("./acme");
+    expect(r.projectName).toBe("acme");
+    expect(r.absoluteDir).toBe(path.resolve("/home/me", "acme"));
+  });
+
+  it("maps . to current directory basename", () => {
+    const r = resolveTargetFromInput(".", "/home/me/acme");
+    expect(r.targetDir).toBe(".");
+    expect(r.projectName).toBe("acme");
+    expect(r.absoluteDir).toBe(path.resolve("/home/me/acme"));
+  });
+
+  it("keeps explicit relative paths", () => {
+    const r = resolveTargetFromInput("./apps/web", "/repo");
+    expect(r.targetDir).toBe("./apps/web");
+    expect(r.projectName).toBe("web");
+  });
+});

--- a/packages/ops/create-sailor/src/utils/__tests__/review-defaults.test.ts
+++ b/packages/ops/create-sailor/src/utils/__tests__/review-defaults.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedConfig } from "../../steps/resolve-config";
+import { applyProviderOverrides } from "../review-defaults";
+
+function baseResolved(): ResolvedConfig {
+  // Minimal stand-in — only fields applyProviderOverrides touches must be valid.
+  return {
+    region: "global",
+    orm: "prisma",
+    database: "postgresql",
+    databaseHost: "local",
+    payment: "stripe",
+    paymentChoice: "stripe",
+    auth: "clerk",
+    socialLoginIds: [],
+    aiMode: "gateway",
+    aiRouting: {
+      profile: "multi-provider-gateway",
+      providerSeed: [],
+      runtimeGovernance: true,
+    },
+    aiProviders: [],
+    deployTarget: "vercel",
+    deployTargets: {} as ResolvedConfig["deployTargets"],
+    docs: "fumadocs",
+    i18n: true,
+    email: "resend",
+    storage: "r2",
+    monitoring: "sentry",
+    analytics: "posthog",
+    sms: "twilio",
+    queue: "none",
+    search: "none",
+    cache: "upstash-redis",
+    notifications: "none",
+    webhooks: "none",
+    cms: "none",
+    featureFlags: "none",
+    captcha: "none",
+    mcp: "on",
+    metering: "auto",
+    billingMode: "usage",
+    idp: "clerk",
+    accessGate: "none",
+    waveToggles: {
+      cronJobs: true,
+      auditLog: true,
+      apiKeys: true,
+      commandPalette: true,
+      cookieConsent: true,
+      legalPages: true,
+      chinaCompliance: false,
+    },
+    previewSelections: [],
+    config: {
+      region: "global",
+      orm: "prisma",
+      database: "postgresql",
+      databaseHost: "local",
+      payment: "stripe",
+      aiMode: "gateway",
+      aiProviders: [],
+      deployTarget: "vercel",
+      deployTargets: {} as ResolvedConfig["deployTargets"],
+      docs: "fumadocs",
+      i18n: true,
+      email: "resend",
+      storage: "r2",
+      monitoring: "sentry",
+      analytics: "posthog",
+      sms: "twilio",
+    },
+  } as ResolvedConfig;
+}
+
+describe("applyProviderOverrides", () => {
+  it("updates payment/email/storage/deploy and syncs config", () => {
+    const next = applyProviderOverrides(baseResolved(), {
+      payment: "wechat",
+      email: "aliyun-dm",
+      storage: "aliyun-oss",
+      deploy: "selfhost",
+    });
+
+    expect(next.paymentChoice).toBe("wechat");
+    expect(next.email).toBe("aliyun-dm");
+    expect(next.storage).toBe("aliyun-oss");
+    expect(next.deployTarget).toBe("selfhost");
+    expect(next.config.email).toBe("aliyun-dm");
+    expect(next.config.storage).toBe("aliyun-oss");
+    expect(next.config.deployTarget).toBe("selfhost");
+  });
+});

--- a/packages/ops/create-sailor/src/utils/first-run.ts
+++ b/packages/ops/create-sailor/src/utils/first-run.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import pc from "picocolors";
 
 // Deliberately a duplicate of packages/ops/cli/src/utils/first-run.ts.
 // Keeping the implementation inline (rather than depending on the nebutra
@@ -23,6 +24,15 @@ function isTelemetryExplicitlyOff(): boolean {
   return v === "0" || v === "false" || v === "no";
 }
 
+function writeMarker(dir: string, marker: string): void {
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(marker, "");
+  } catch {
+    // ignore
+  }
+}
+
 export function maybeShowFirstRunBanner(): void {
   if (!process.stderr.isTTY || !process.stdin.isTTY) return;
   if (process.env.CI) return;
@@ -37,19 +47,16 @@ export function maybeShowFirstRunBanner(): void {
   }
 
   if (isTelemetryExplicitlyOff()) {
-    try {
-      mkdirSync(dir, { recursive: true });
-      writeFileSync(marker, "");
-    } catch {
-      // ignore
-    }
+    writeMarker(dir, marker);
     return;
   }
 
+  // Use picocolors — never raw ANSI escapes (breaks some terminals / themes).
+  const info = pc.cyan("ℹ");
   const lines = [
-    "[36mℹ[0m Nebutra collects anonymous usage analytics to improve the scaffolder.",
-    "  Opt out at any time:  export NEBUTRA_TELEMETRY=0",
-    "  Privacy policy:       https://nebutra.com/legal/cli-analytics",
+    `${info} Nebutra collects anonymous usage analytics to improve the scaffolder.`,
+    `  Opt out at any time:  ${pc.dim("export NEBUTRA_TELEMETRY=0")}`,
+    `  Privacy policy:       ${pc.dim("https://nebutra.com/legal/cli-analytics")}`,
     "",
   ];
   try {
@@ -58,10 +65,5 @@ export function maybeShowFirstRunBanner(): void {
     // ignore
   }
 
-  try {
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(marker, "");
-  } catch {
-    // silently ignore - banner is informational
-  }
+  writeMarker(dir, marker);
 }

--- a/packages/ops/create-sailor/src/utils/project-target.ts
+++ b/packages/ops/create-sailor/src/utils/project-target.ts
@@ -1,0 +1,277 @@
+/**
+ * Project location resolution for create-sailor.
+ *
+ * Two real user intents:
+ *   1. "I'm in a parent/home dir" → create a new folder (name only, no path UX)
+ *   2. "I already cd'd into an empty dir" → scaffold here (.)
+ *
+ * Path syntax (`./foo`, `/abs`, `../x`) is still accepted when the user types
+ * it or passes a CLI arg — but interactive prompts never force it.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import * as p from "@clack/prompts";
+
+/** Default folder name when the user just hits Enter / --yes. */
+export const DEFAULT_PROJECT_NAME = "my-app";
+
+/** Entries that do not count as "content" when deciding if cwd is empty. */
+const HARMLESS_ENTRIES = new Set([
+  ".DS_Store",
+  ".Spotlight-V100",
+  ".Trashes",
+  "Thumbs.db",
+  "desktop.ini",
+]);
+
+/** Presence of these means: never scaffold into current dir without a hard stop. */
+const BLOCKING_ENTRIES = new Set([
+  "package.json",
+  "node_modules",
+  "pnpm-workspace.yaml",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "package-lock.json",
+  "bun.lockb",
+  "turbo.json",
+]);
+
+export type LocationChoice = "new" | "current";
+
+export interface ResolvedProjectTarget {
+  /** Relative or absolute path passed to scaffold (e.g. `./my-app`, `.`). */
+  targetDir: string;
+  /** Basename used for package.json name, banners, etc. */
+  projectName: string;
+  /** Absolute path for display / existence checks. */
+  absoluteDir: string;
+}
+
+export function isCurrentDirToken(value: string): boolean {
+  const v = value.trim();
+  return v === "." || v === "./" || v === ".\\";
+}
+
+/**
+ * Returns true when the directory has no meaningful project content
+ * (empty, missing, or only OS junk / a bare .git).
+ */
+export function isDirEffectivelyEmpty(dir: string): boolean {
+  if (!fs.existsSync(dir)) return true;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return false;
+  }
+  return entries.every((name) => HARMLESS_ENTRIES.has(name) || name === ".git");
+}
+
+/**
+ * Returns true when scaffolding into this dir would almost certainly clobber
+ * an existing app/monorepo.
+ */
+export function hasBlockingProjectMarkers(dir: string): boolean {
+  if (!fs.existsSync(dir)) return false;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return true;
+  }
+  return entries.some((name) => BLOCKING_ENTRIES.has(name));
+}
+
+/**
+ * Prefer "current directory" when cwd looks empty (user already mkdir+cd'd).
+ * Prefer "new folder" when cwd is busy (home, monorepo parent, etc.).
+ */
+export function preferCurrentDirectory(cwd: string = process.cwd()): boolean {
+  return isDirEffectivelyEmpty(cwd) && !hasBlockingProjectMarkers(cwd);
+}
+
+/**
+ * Validate a bare project *name* (not a path).
+ * Allows letters, digits, `_`, `.`, `-` — same spirit as npm package names.
+ */
+export function validateProjectName(name: string): string | undefined {
+  const trimmed = name.trim();
+  if (!trimmed) return "Please enter a project name.";
+  if (trimmed.length > 128) return "Name is too long (max 128 characters).";
+  if (isCurrentDirToken(trimmed)) return undefined;
+  if (/[\\/]/.test(trimmed) || path.isAbsolute(trimmed)) {
+    // Path-shaped input is validated elsewhere.
+    return undefined;
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(trimmed)) {
+    return "Use letters, numbers, dots, underscores, or hyphens (start with a letter or number).";
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a CLI arg or typed value into a scaffold target.
+ *
+ * - `.` / `./` → current directory
+ * - path with `/` or `\` or absolute → treat as path
+ * - bare name → `./name`
+ */
+export function resolveTargetFromInput(
+  input: string,
+  cwd: string = process.cwd(),
+): ResolvedProjectTarget {
+  const raw = input.trim() || DEFAULT_PROJECT_NAME;
+
+  if (isCurrentDirToken(raw)) {
+    const absoluteDir = path.resolve(cwd);
+    return {
+      targetDir: ".",
+      projectName: path.basename(absoluteDir) || DEFAULT_PROJECT_NAME,
+      absoluteDir,
+    };
+  }
+
+  const looksLikePath =
+    path.isAbsolute(raw) ||
+    raw.startsWith("./") ||
+    raw.startsWith(".\\") ||
+    raw.startsWith("../") ||
+    raw.startsWith("..\\") ||
+    raw.includes("/") ||
+    raw.includes("\\");
+
+  if (looksLikePath) {
+    const absoluteDir = path.resolve(cwd, raw);
+    return {
+      targetDir: raw,
+      projectName: path.basename(absoluteDir) || DEFAULT_PROJECT_NAME,
+      absoluteDir,
+    };
+  }
+
+  const nameError = validateProjectName(raw);
+  if (nameError) {
+    throw new Error(nameError);
+  }
+
+  const targetDir = `./${raw}`;
+  const absoluteDir = path.resolve(cwd, raw);
+  return {
+    targetDir,
+    projectName: raw,
+    absoluteDir,
+  };
+}
+
+export interface PromptProjectTargetOptions {
+  /** Pre-bound cancel handler (exit process etc.). */
+  onCancel?: () => void;
+  cwd?: string;
+}
+
+/**
+ * Interactive location flow:
+ *   1. Create in a new folder? Or current directory?
+ *   2. If new folder → project name (default my-app)
+ *   3. If current → empty check / confirm when not empty
+ */
+export async function promptProjectTarget(
+  opts: PromptProjectTargetOptions = {},
+): Promise<ResolvedProjectTarget> {
+  const cwd = opts.cwd ?? process.cwd();
+  const onCancel =
+    opts.onCancel ??
+    (() => {
+      process.stdout.write("Cancelled\n");
+      process.exit(130);
+    });
+
+  const preferCurrent = preferCurrentDirectory(cwd);
+
+  const cwdLabel = path.basename(cwd) || cwd;
+
+  const location = await p.select({
+    message: "Create the project…",
+    options: [
+      {
+        value: "new" as const,
+        label: "In a new folder",
+        hint: preferCurrent ? undefined : "recommended from home or a parent directory",
+      },
+      {
+        value: "current" as const,
+        label: "In the current directory",
+        hint: preferCurrent ? `${cwdLabel} looks empty — good to go` : cwd,
+      },
+    ],
+    initialValue: preferCurrent ? ("current" as const) : ("new" as const),
+  });
+
+  if (p.isCancel(location)) onCancel();
+
+  if (location === "current") {
+    if (hasBlockingProjectMarkers(cwd)) {
+      const markers = fs
+        .readdirSync(cwd)
+        .filter((name) => BLOCKING_ENTRIES.has(name))
+        .slice(0, 4)
+        .join(", ");
+      p.log.error(
+        `Current directory already looks like a project (${markers}). ` +
+          `Choose a new folder, or pass a different path: create-sailor my-app`,
+      );
+      onCancel();
+    }
+
+    if (!isDirEffectivelyEmpty(cwd)) {
+      const cont = await p.confirm({
+        message: "Current directory is not empty. Scaffold files will be mixed in — continue?",
+        initialValue: false,
+      });
+      if (p.isCancel(cont) || !cont) onCancel();
+    }
+
+    return resolveTargetFromInput(".", cwd);
+  }
+
+  // New folder
+  const name = await p.text({
+    message: "What should we call your project?",
+    placeholder: DEFAULT_PROJECT_NAME,
+    defaultValue: DEFAULT_PROJECT_NAME,
+    validate: (value) => {
+      const v = (value ?? "").trim() || DEFAULT_PROJECT_NAME;
+      if (isCurrentDirToken(v) || /[\\/]/.test(v) || path.isAbsolute(v)) {
+        // Allow power-users to type a path in the name field.
+        try {
+          resolveTargetFromInput(v, cwd);
+          return undefined;
+        } catch (err) {
+          return err instanceof Error ? err.message : "Invalid path.";
+        }
+      }
+      return validateProjectName(v);
+    },
+  });
+
+  if (p.isCancel(name)) onCancel();
+
+  const resolved = resolveTargetFromInput(String(name).trim() || DEFAULT_PROJECT_NAME, cwd);
+
+  if (fs.existsSync(resolved.absoluteDir) && !isDirEffectivelyEmpty(resolved.absoluteDir)) {
+    if (hasBlockingProjectMarkers(resolved.absoluteDir)) {
+      p.log.error(
+        `Folder "${resolved.projectName}" already exists and looks like a project. Pick another name.`,
+      );
+      onCancel();
+    }
+    const cont = await p.confirm({
+      message: `Folder "${resolved.projectName}" is not empty. Continue?`,
+      initialValue: false,
+    });
+    if (p.isCancel(cont) || !cont) onCancel();
+  }
+
+  return resolved;
+}

--- a/packages/ops/create-sailor/src/utils/review-defaults.ts
+++ b/packages/ops/create-sailor/src/utils/review-defaults.ts
@@ -1,0 +1,209 @@
+/**
+ * Post-summary confirmation + optional customization of region-defaulted
+ * providers. Keeps the main wizard short while making silent defaults visible
+ * and editable before any files are written.
+ */
+
+import * as p from "@clack/prompts";
+import type { NebutraConfig } from "./config";
+import { EMAIL_PROVIDERS } from "./email-meta";
+import { collectPreviewSelections } from "./package-status";
+import type { PaymentChoice } from "./payment";
+import { STORAGE_PROVIDERS } from "./storage-meta";
+import type { ResolvedConfig } from "../steps/resolve-config";
+import { mapDeploy, mapPayment, resolvePaymentChoice } from "../steps/mappers";
+import { resolveScaffoldDeployTargets } from "./deploy";
+
+export type ReviewOutcome = "proceed" | "cancelled";
+
+function rebuildConfig(resolved: ResolvedConfig): NebutraConfig {
+  return {
+    ...resolved.config,
+    region: resolved.region,
+    orm: resolved.orm,
+    database: resolved.database,
+    databaseHost: resolved.databaseHost,
+    payment: resolved.payment,
+    aiMode: resolved.aiMode,
+    aiRouting: resolved.aiRouting,
+    aiProviders: resolved.aiProviders,
+    customAiEndpoint: resolved.customAiEndpoint,
+    deployTarget: resolved.deployTarget,
+    deployTargets: resolved.deployTargets,
+    docs: resolved.docs,
+    i18n: resolved.i18n,
+    email: resolved.email,
+    storage: resolved.storage,
+    monitoring: resolved.monitoring,
+    analytics: resolved.analytics,
+    sms: resolved.sms,
+    queue: resolved.queue as NebutraConfig["queue"],
+    search: resolved.search as NebutraConfig["search"],
+    cache: resolved.cache as NebutraConfig["cache"],
+    notifications: resolved.notifications as NebutraConfig["notifications"],
+    webhooks: resolved.webhooks as NebutraConfig["webhooks"],
+    cms: resolved.cms as NebutraConfig["cms"],
+    featureFlags: resolved.featureFlags as NebutraConfig["featureFlags"],
+    captcha: resolved.captcha as NebutraConfig["captcha"],
+    mcp: resolved.mcp as NebutraConfig["mcp"],
+    metering: resolved.metering as NebutraConfig["metering"],
+    billingMode: resolved.billingMode,
+    idp: resolved.idp,
+    accessGate: resolved.accessGate,
+  };
+}
+
+function refreshPreview(resolved: ResolvedConfig): void {
+  resolved.previewSelections = collectPreviewSelections([
+    { flag: "queue", provider: resolved.queue },
+    { flag: "search", provider: resolved.search },
+    { flag: "notifications", provider: resolved.notifications },
+    { flag: "webhooks", provider: resolved.webhooks },
+    { flag: "feature-flags", provider: resolved.featureFlags },
+    { flag: "captcha", provider: resolved.captcha },
+    { flag: "access-gate", provider: resolved.accessGate },
+  ]);
+  resolved.config = rebuildConfig(resolved);
+}
+
+async function customizeProviders(
+  resolved: ResolvedConfig,
+  onCancel: () => never,
+): Promise<void> {
+  const payment = await p.select({
+    message: "Payment provider",
+    options: [
+      { value: "stripe", label: "Stripe", hint: "global default" },
+      { value: "lemon", label: "Lemon Squeezy" },
+      { value: "wechat", label: "WeChat Pay", hint: "CN" },
+      { value: "alipay", label: "Alipay", hint: "CN" },
+      { value: "none", label: "None" },
+    ],
+    initialValue: resolved.paymentChoice,
+  });
+  if (p.isCancel(payment)) onCancel();
+  const paymentRaw = String(payment);
+  resolved.payment = mapPayment(paymentRaw);
+  resolved.paymentChoice = resolvePaymentChoice(paymentRaw);
+
+  const email = await p.select({
+    message: "Email provider",
+    options: EMAIL_PROVIDERS.map((e) => ({
+      value: e.id,
+      label: e.name,
+      hint: e.region === "cn" ? "CN" : e.id === "none" ? undefined : "global",
+    })),
+    initialValue: resolved.email,
+  });
+  if (p.isCancel(email)) onCancel();
+  resolved.email = String(email);
+
+  const storage = await p.select({
+    message: "Object storage",
+    options: STORAGE_PROVIDERS.map((s) => ({
+      value: s.id,
+      label: s.name,
+      hint: s.region === "cn" ? "CN" : s.id === "none" ? undefined : "global",
+    })),
+    initialValue: resolved.storage,
+  });
+  if (p.isCancel(storage)) onCancel();
+  resolved.storage = String(storage);
+
+  const deploy = await p.select({
+    message: "Deploy target",
+    options: [
+      { value: "vercel", label: "Vercel", hint: "recommended for Next.js" },
+      { value: "railway", label: "Railway" },
+      { value: "cloudflare", label: "Cloudflare" },
+      { value: "selfhost", label: "Self-host / Docker" },
+    ],
+    initialValue: resolved.deployTarget,
+  });
+  if (p.isCancel(deploy)) onCancel();
+  resolved.deployTarget = mapDeploy(String(deploy));
+  resolved.deployTargets = resolveScaffoldDeployTargets(resolved.deployTarget);
+
+  refreshPreview(resolved);
+}
+
+/**
+ * Interactive: confirm region defaults; optionally customize payment/email/storage/deploy.
+ * Non-interactive callers should not invoke this.
+ */
+export async function confirmAndMaybeReview(
+  resolved: ResolvedConfig,
+  onCancel: () => never,
+): Promise<ResolvedConfig> {
+  // Work on a shallow clone of field bag so we can rebuild config safely.
+  const draft: ResolvedConfig = {
+    ...resolved,
+    config: { ...resolved.config },
+    aiProviders: [...resolved.aiProviders],
+    socialLoginIds: [...resolved.socialLoginIds],
+    previewSelections: [...resolved.previewSelections],
+    deployTargets: { ...resolved.deployTargets },
+    waveToggles: { ...resolved.waveToggles },
+  };
+
+  const action = await p.select({
+    message: "Create project with these settings?",
+    options: [
+      {
+        value: "proceed",
+        label: "Yes, create project",
+        hint: "use region defaults above",
+      },
+      {
+        value: "customize",
+        label: "Customize key providers",
+        hint: "payment · email · storage · deploy",
+      },
+      { value: "cancel", label: "Cancel" },
+    ],
+    initialValue: "proceed",
+  });
+
+  if (p.isCancel(action) || action === "cancel") onCancel();
+
+  if (action === "customize") {
+    await customizeProviders(draft, onCancel);
+    p.log.success("Defaults updated — scaffolding with your choices.");
+  }
+
+  return draft;
+}
+
+/** Pure helper for tests: apply payment/email/storage/deploy overrides onto a resolved config. */
+export function applyProviderOverrides(
+  resolved: ResolvedConfig,
+  overrides: {
+    payment?: PaymentChoice;
+    email?: string;
+    storage?: string;
+    deploy?: string;
+  },
+): ResolvedConfig {
+  const draft: ResolvedConfig = {
+    ...resolved,
+    config: { ...resolved.config },
+    aiProviders: [...resolved.aiProviders],
+    socialLoginIds: [...resolved.socialLoginIds],
+    previewSelections: [...resolved.previewSelections],
+    deployTargets: { ...resolved.deployTargets },
+    waveToggles: { ...resolved.waveToggles },
+  };
+
+  if (overrides.payment) {
+    draft.payment = mapPayment(overrides.payment);
+    draft.paymentChoice = resolvePaymentChoice(overrides.payment);
+  }
+  if (overrides.email) draft.email = overrides.email;
+  if (overrides.storage) draft.storage = overrides.storage;
+  if (overrides.deploy) {
+    draft.deployTarget = mapDeploy(overrides.deploy);
+    draft.deployTargets = resolveScaffoldDeployTargets(draft.deployTarget);
+  }
+  refreshPreview(draft);
+  return draft;
+}

--- a/packages/ops/create-sailor/tsup.config.ts
+++ b/packages/ops/create-sailor/tsup.config.ts
@@ -3,10 +3,16 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
+  platform: "node",
   target: "node18",
   clean: true,
   minify: true,
   // CLI is a binary, not a library — no consumer imports types from it.
   // DTS generation also fails on some upstream type drift that would block publish.
   dts: false,
+  // Bundle @nebutra/* workspace packages into dist/. They are build-time
+  // (devDependency) only so the published package.json never asks npm to
+  // resolve `workspace:*` — create-sailor@1.9.1 on npm broke `npx` with
+  // EUNSUPPORTEDPROTOCOL when that protocol was left unrewritten.
+  noExternal: [/^@nebutra\//],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4609,9 +4609,6 @@ importers:
       '@clack/prompts':
         specifier: ^0.7.0
         version: 0.7.0
-      '@nebutra/brand':
-        specifier: workspace:*
-        version: link:../../design/brand
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -4625,6 +4622,9 @@ importers:
         specifier: ^1.1.0
         version: 1.1.1
     devDependencies:
+      '@nebutra/brand':
+        specifier: workspace:*
+        version: link:../../design/brand
       '@nebutra/theme':
         specifier: workspace:*
         version: link:../../design/theme
@@ -4655,9 +4655,6 @@ importers:
       '@mrleebo/prisma-ast':
         specifier: ^0.16.0
         version: 0.16.0
-      '@nebutra/brand':
-        specifier: workspace:*
-        version: link:../../design/brand
       cfonts:
         specifier: ^3.3.0
         version: 3.3.1
@@ -4677,6 +4674,9 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1
     devDependencies:
+      '@nebutra/brand':
+        specifier: workspace:*
+        version: link:../../design/brand
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1

--- a/scripts/lib/release-surface.mjs
+++ b/scripts/lib/release-surface.mjs
@@ -123,6 +123,13 @@ function fileReferenceIncludedByFiles(reference, files) {
   return false;
 }
 
+/** Protocols that only resolve inside a pnpm/yarn monorepo — not on the public npm registry. */
+function isMonorepoOnlyProtocol(range) {
+  return (
+    typeof range === "string" && (range.startsWith("workspace:") || range.startsWith("catalog:"))
+  );
+}
+
 export function getReleaseSurfaceDiagnostics(root = process.cwd()) {
   const packages = readWorkspacePackages(root);
   const byName = new Map(packages.map((entry) => [entry.manifest.name, entry]));
@@ -133,9 +140,26 @@ export function getReleaseSurfaceDiagnostics(root = process.cwd()) {
   );
 
   const privateRuntimeDependencies = [];
+  const monorepoProtocolRuntimeDependencies = [];
   for (const entry of publishable) {
     for (const field of ["dependencies", "optionalDependencies"]) {
-      for (const dependencyName of Object.keys(entry.manifest[field] ?? {})) {
+      for (const [dependencyName, range] of Object.entries(entry.manifest[field] ?? {})) {
+        if (typeof range === "string" && isMonorepoOnlyProtocol(range)) {
+          // Unscoped CLI bins (`npx create-sailor`, `npx nebutra`) are installed
+          // by plain npm, which cannot resolve workspace:/catalog:. Keep those
+          // protocols out of production deps and bundle workspace packages at
+          // build time. Scoped @nebutra/* packages (and libraries) may keep
+          // workspace:* — pnpm publish rewrites them on a correct release.
+          if (entry.manifest.bin && !entry.manifest.name.startsWith("@")) {
+            monorepoProtocolRuntimeDependencies.push({
+              packageName: entry.manifest.name,
+              dependencyName,
+              field,
+              range,
+            });
+          }
+        }
+
         const dependency = byName.get(dependencyName);
         if (dependency?.manifest.private === true) {
           privateRuntimeDependencies.push({
@@ -211,6 +235,7 @@ export function getReleaseSurfaceDiagnostics(root = process.cwd()) {
     publishable,
     missingChangesetPackages,
     privateRuntimeDependencies,
+    monorepoProtocolRuntimeDependencies,
     requiredMetadataMissing,
     manifestRuntimeFilesExcludedByFiles,
   };

--- a/scripts/verify-release-surface.mjs
+++ b/scripts/verify-release-surface.mjs
@@ -12,6 +12,10 @@ const failures = [
     (entry) =>
       `${entry.packageName} ${entry.field} includes private workspace package ${entry.dependencyName} (${entry.dependencyDir})`,
   ),
+  ...diagnostics.monorepoProtocolRuntimeDependencies.map(
+    (entry) =>
+      `${entry.packageName} ${entry.field}.${entry.dependencyName} is "${entry.range}" — CLI packages must not declare monorepo-only protocols as production deps (npm cannot resolve workspace:/catalog:; bundle via tsup noExternal and keep the dep in devDependencies)`,
+  ),
   ...diagnostics.requiredMetadataMissing.map(
     (entry) => `${entry.packageName} is missing ${entry.field}; expected ${entry.expected}`,
   ),


### PR DESCRIPTION
## Summary

- **`npx create-sailor@latest` is broken** on npm: `create-sailor@1.9.1` ships `"@nebutra/brand": "workspace:*"`, which plain npm cannot resolve (`EUNSUPPORTEDPROTOCOL`). Same issue on `nebutra@0.4.1`.
- Move `@nebutra/brand` to **devDependencies** and bundle `@nebutra/*` into the CLI via tsup `noExternal` (create-sailor now matches the nebutra CLI pattern).
- Add a **release-surface guard**: unscoped CLI packages must not declare `workspace:` / `catalog:` as production deps.

## Test plan

- [x] `pnpm verify:release-surface` passes
- [x] `pnpm --filter create-sailor test` — 105 tests pass
- [x] `pnpm --filter create-sailor build` + `node dist/index.js --help`
- [x] `pnpm pack` → production deps have **no** monorepo protocols and **no** `@nebutra/brand`
- [x] `npm install` of the packed tarball succeeds; `npx create-sailor --help` works
- [ ] After merge: run **Release** workflow so `create-sailor@1.9.2` / `nebutra@0.4.2` publish (changeset included)
- [ ] Verify: `npx create-sailor@latest --help` works on a clean machine

## Workaround until release

```bash
npx create-sailor@1.9.0
```