### PR TITLE
fix(template): strip product apps/CI from Sailor-Template

### DIFF
--- a/.changeset/template-product-strip.md
+++ b/.changeset/template-product-strip.md
@@ -1,0 +1,6 @@
+---
+"create-sailor": patch
+"nebutra": patch
+---
+
+Strip Nebutra product apps, product CI/DNS, and product backends from the Sailor-Template surface; raise create-sailor Node engine floor to >=22 to match the monorepo.

--- a/.templateignore
+++ b/.templateignore
@@ -65,6 +65,8 @@ apps/web/src/lib/__tests__/audit-remediation.test.ts
 # Nebutra-owned apps (not reusable skeleton)
 # Community = Sleptons forum. tsekaluk-dev = personal site.
 # design-docs + docs-hub + studio are Nebutra-authored content systems.
+# Product lines (forge/router/pebble/typelens/design/admin/auth-center) ship
+# only in the monorepo — customers get web + landing + idp + mail-preview.
 # ---------------------------------------------------------------------------
 apps/sleptons/
 apps/tsekaluk-dev/
@@ -72,6 +74,13 @@ apps/design-docs/content/
 apps/docs-hub/
 apps/studio/
 apps/docs/
+apps/forge/
+apps/router/
+apps/pebble/
+apps/typelens/
+apps/design/
+apps/admin/
+apps/auth/
 
 # ---------------------------------------------------------------------------
 # Marketing, PR, and changelog content
@@ -199,6 +208,46 @@ tests/load/
 .github/workflows/visual-acceptance.yml
 .github/workflows/ui-governance.yml
 .github/workflows/docker-build-push.yml
+# Product deploy targets + Nebutra DNS ops (secrets / account-bound)
+.github/workflows/deploy-auth-vercel.yml
+.github/workflows/deploy-carina-ecs.yml
+.github/workflows/deploy-carina-vercel.yml
+.github/workflows/deploy-gateway.yml
+.github/workflows/deploy-landing-vercel.yml
+.github/workflows/deploy-origin-ecs.yml
+.github/workflows/deploy-pebble-vercel.yml
+.github/workflows/deploy-sailor-docs.yml
+.github/workflows/deploy-typelens.yml
+.github/workflows/deploy-web-vercel.yml
+.github/workflows/ops-auth-console-setup.yml
+.github/workflows/ops-configure-pebble-r2.yml
+.github/workflows/ops-db-inventory.yml
+.github/workflows/point-auth-dns.yml
+.github/workflows/point-carina-dns.yml
+.github/workflows/point-docs-dns.yml
+.github/workflows/point-forge-dns.yml
+.github/workflows/point-pebble-dns.yml
+.github/workflows/point-router-dns.yml
+.github/workflows/point-www-dns.yml
+.github/workflows/tmp-vercel-git-deploy-docs.yml
+.github/workflows/public-url-check.yml
+.github/workflows/route-lastmod.yml
+.github/workflows/i18n-translate.yml
+.github/workflows/i18n-orphan-report.yml
+
+# ---------------------------------------------------------------------------
+# Nebutra product backends / infra (not a generic SaaS skeleton)
+# Keep backends/gateway (pruned of product routes below) + backends/python/*.
+# ---------------------------------------------------------------------------
+backends/go/
+backends/rust/
+infra/nebutra-router/
+infra/platforms/
+
+# Product-only gateway routes (generic billing/auth/ai/webhooks stay)
+backends/gateway/src/routes/pebble/
+backends/gateway/src/routes/startup-os/
+backends/gateway/src/routes/agent-runtime/
 
 # ---------------------------------------------------------------------------
 # Template meta files (strip the ignore file itself after apply)

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -31,12 +31,13 @@ my-app/ contains only the reusable skeleton
 
 ## What gets stripped
 
-- **Marketing pages** — `apps/landing/src/app/[lang]/(marketing)/*`
-- **Legal pages** — `apps/landing/src/app/[lang]/(legal)/*`
-- **Nebutra landing components** — `apps/landing/src/components/landing/`
-- **Dashboard business pages** — admin, billing, tenants, chat, etc.
-- **Nebutra-owned apps** — `apps/sleptons`, `apps/studio`,
-  content from `apps/design-docs` and `apps/docs`
+- **Marketing / legal** — landing marketing + legal routes and brand assets
+- **Dashboard business pages** — admin, billing, tenants, chat, feature-flags, …
+- **Nebutra product apps** — `forge`, `router`, `pebble`, `typelens`, `design`,
+  `admin`, `auth` (auth-center), `sleptons`, `studio`, `sailor-docs`
+- **Product backends / infra** — `backends/go`, `backends/rust`,
+  `infra/nebutra-router`, gateway routes for pebble / startup-os
+- **Product CI / DNS** — `deploy-pebble*`, `deploy-carina*`, `point-*-dns`, …
 - **Press / PR** — `marketing/`, `changelog/`
 - **Internal planning / governance** — `docs/plans/`, `governance/*.current.json`
 - **Build artifacts** — `artifacts/`, `playwright-report/`, `test-results/`
@@ -45,12 +46,19 @@ my-app/ contains only the reusable skeleton
 ## What is preserved
 
 - Every `packages/*` primitive (UI, tokens, queue, search, metering, vault, …)
+- Scaffold apps: `web`, `landing` (shell), `idp`, `mail-preview`, `storybook`,
+  `design-docs` (shell without Nebutra content)
 - App shells: `layout.tsx`, `globals.css`, `package.json`, `next.config.ts`
 - Build config: `turbo.json`, `pnpm-workspace.yaml`, `tsconfig.base.json`,
   `biome.json`
 - The `create-sailor` CLI itself
-- API gateway skeleton (`backends/gateway`)
+- API gateway core (`backends/gateway`, minus product-only routes)
+- Python AI backend tree when present (`backends/python`)
 - `e2e/` and `tests/` (skeleton tests, minus Nebutra-only specs)
+- Generic CI: `ci`, `codeql`, `secrets-scan`, `dependency-review`, …
+
+> **Contract:** Sailor-Template is a *skeleton monorepo*, not a fork of every
+> Nebutra product surface. Product apps stay in `Nebutra-Sailor` only.
 
 ## Adding new Nebutra business code
 

--- a/packages/ops/cli/src/commands/dev.ts
+++ b/packages/ops/cli/src/commands/dev.ts
@@ -33,19 +33,30 @@ interface TypecheckOptions extends DevOptions {
 }
 
 /**
- * List of valid app filters for turbo dev
+ * Valid turbo `--filter` short names for monorepo apps/backends.
+ * Product apps (forge/router/…) exist only in Nebutra-Sailor; scaffolded
+ * projects omit them via .templateignore — filter will simply no-op if missing.
  */
 const VALID_APPS = [
+  // Scaffold core
   "landing",
   "web",
   "storybook",
   "design-docs",
-  "sailor-docs",
-  "studio",
-  "docs",
   "idp",
   "mail-preview",
   "gateway",
+  // Monorepo product surfaces (stripped from Sailor-Template)
+  "admin",
+  "auth",
+  "design",
+  "forge",
+  "router",
+  "pebble",
+  "typelens",
+  "sailor-docs",
+  "studio",
+  "sleptons",
 ];
 
 /**

--- a/packages/ops/create-sailor/package.json
+++ b/packages/ops/create-sailor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sailor",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Governed AI-native SaaS scaffolder for Nebutra Sailor. Bootstrap a production-ready Next.js + Hono + Prisma monorepo with multi-tenant foundations, region-aware defaults, and AI integrations.",
   "type": "module",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "sailor",

--- a/packages/ops/create-sailor/src/ui/help.ts
+++ b/packages/ops/create-sailor/src/ui/help.ts
@@ -63,6 +63,8 @@ Toggles:
   -h, --help                show this help
   -v, --version             show version
 
+Requires Node.js >= 22 (same floor as the monorepo).
+
 Interactive flow:
   1. Location — new folder (name) or current directory
   2. Region / Auth / AI topology

--- a/scripts/template-check.ts
+++ b/scripts/template-check.ts
@@ -59,6 +59,19 @@ const MUST_STRIP = [
   "apps/docs",
   "apps/studio",
   "apps/sailor-docs",
+  // Product lines — must never ship in create-sailor output
+  "apps/forge",
+  "apps/router",
+  "apps/pebble",
+  "apps/typelens",
+  "apps/design",
+  "apps/admin",
+  "apps/auth",
+  "backends/go",
+  "backends/rust",
+  "infra/nebutra-router",
+  "backends/gateway/src/routes/pebble",
+  "backends/gateway/src/routes/startup-os",
   "docs/plans",
   "docs/DOMAINS.md",
   ".env",
@@ -77,6 +90,10 @@ const MUST_STRIP = [
   "apps/web/src/app/[locale]/(app)/feature-flags",
   "apps/landing/public/brand/logo.svg",
   "apps/landing/public/og",
+  // Product deploy / DNS (sample — globs cover the rest in .templateignore)
+  ".github/workflows/deploy-pebble-vercel.yml",
+  ".github/workflows/point-forge-dns.yml",
+  ".github/workflows/deploy-carina-ecs.yml",
 ];
 
 type Matcher = ReturnType<typeof ignore>;


### PR DESCRIPTION
## Summary

Closes the P0 skeleton-boundary drift between monorepo infrastructure and what `create-sailor` ships via `Sailor-Template`.

- **Strip product apps** from the template surface: `forge`, `router`, `pebble`, `typelens`, `design`, `admin`, `auth`
- **Strip product backends/infra**: `backends/go`, `backends/rust`, `infra/nebutra-router`, product-only gateway routes (`pebble`, `startup-os`, `agent-runtime`)
- **Strip product CI/DNS** workflows (`deploy-pebble*`, `deploy-carina*`, `point-*-dns`, …)
- **create-sailor** `engines.node` → `>=22.0.0` (match monorepo)
- **nebutra dev --app** recognizes monorepo product apps
- **template-check** MUST_STRIP updated; `pnpm template:check` passes (7725 preserved / 109 stripped)

## Test plan

- [x] `node --import tsx scripts/template-check.ts` PASS
- [ ] After merge: confirm `sync-template` workflow updates `Nebutra/Sailor-Template` without product apps
- [ ] `npx create-sailor@latest` tree has no `apps/forge` / `apps/pebble`