### PR TITLE
feat(agent-runtime): map ExternalSandbox to Carina JSON-RPC

### DIFF
--- a/docs/architecture/2026-08-03-carina-track-b-upstream.md
+++ b/docs/architecture/2026-08-03-carina-track-b-upstream.md
@@ -1,0 +1,79 @@
+# ADR 2026-08-03 — Carina as Track-B Upstream for Agent Execution
+
+## Status
+
+Accepted.
+
+## Context
+
+Sailor ships `@nebutra/agent-runtime` as a multi-tenant **runtime grammar**
+(thread/turn/item, approval × capability policy, tool/MCP routing, event-sourced
+rollout). It is designed dual-track:
+
+- **Track A** — TypeScript control plane inside Sailor (this monorepo).
+- **Track B** — a decoupled isolator / kernel that actually runs untrusted
+  side effects behind `ExternalSandbox`.
+
+Carina (`Nebutra/carina`, Go/Rust/Zig, local-first) owns the capability kernel,
+OS sandbox backends, audit chain, and cloud boundary. Sailor must not grow a
+second kernel.
+
+Carina issue [#27](https://github.com/Nebutra/carina/issues/27) closed **not
+planned**: foundations live as product-agnostic RPC + SDKs (v0.8.1+), not a
+parallel `protocol/product-adapter/` package. Sailor docks to the **existing
+catalog**, not a Sailor-only API.
+
+## Decision
+
+**Dock, do not replace.** Carina is the **upstream maintainer** of the Track-B
+kernel. Sailor keeps `@nebutra/agent-runtime` and ships only a **thin adapter**.
+
+```text
+Nebutra Cloud (Sailor)
+  @nebutra/agents          → model routing
+  @nebutra/agent-runtime   → turn/policy/rollout (Track A)
+        │  createCarinaSandbox  (JSON-RPC mapping, owned in Sailor)
+        ▼
+Carina kernel (upstream)   → command.exec, capability kernel, audit
+```
+
+### Ownership
+
+| Concern | Owner |
+|---------|--------|
+| Kernel RPC catalog, capability profiles, OS sandbox | **Carina** |
+| Multi-tenant turn grammar, approval rail, rollout | **Sailor** |
+| `ExternalSandbox` + `createCarinaSandbox` mapping | **Sailor** |
+| Default fail-closed without Carina endpoint | **Sailor** (`REFUSING_SANDBOX`) |
+
+## Appendix A — v0.8.1 wire mapping
+
+| Sailor | Carina (catalog) |
+|--------|------------------|
+| Hello / version pin | `gateway.hello` `{ protocol_version, client_id }` → require `protocol_version >= 1` |
+| `SandboxExecRequest.threadId` | `command.exec` `session_id` (session must already exist) |
+| `SandboxExecRequest.command` | `argv: ["/bin/sh", "-c", command]` (kernel still sees joined string) |
+| `SandboxExecRequest.tenantId` | sent as extension `tenant_id` + `correlation_id` (scope/audit hint; **not** a privilege grant) |
+| allowed + `CommandResult` | `exitCode` ← `exit_code`, `aggregatedOutput` ← stdout+stderr join |
+| `decision: denied` | `SandboxDelegationError` status 403 |
+| `decision: requires_approval` | `SandboxDelegationError` status 409, code `requires_approval` (host must call `task.action.approve` / `deny` — not implemented in the thin adapter yet) |
+| `executedOn` | adapter default `"carina"` |
+| Transport | HTTP POST JSON-RPC 2.0 to a connector/`baseUrl` (unix socket is Carina-native; products typically bridge) |
+
+Bearer tokens are **Gateway / product credentials**, never local owner tokens
+(Carina cloud boundary).
+
+## Consequences
+
+- Production injects Carina only when `CARINA_JSONRPC_URL` (or product config)
+  is set; otherwise fail closed.
+- Protocol breaks require Carina version bump + Sailor adapter pin update.
+- Approval UI bridge and session lifecycle (`session.create`) remain host
+  responsibilities layered on top of this exec adapter.
+
+## Related
+
+- Carina `docs/nebutra-cloud-boundary.md`, `docs/rpc-api.md`,
+  `protocol/jsonrpc/methods.json`
+- Carina issue #27 (closed not planned — use catalog, not product-adapter package)
+- `@nebutra/agent-runtime` `src/sandbox.ts`

--- a/packages/ai/agent-runtime/README.md
+++ b/packages/ai/agent-runtime/README.md
@@ -24,9 +24,10 @@ them.
 
 - **Track A (this package)** — policy, protocol contract, model, rollout. All
   tenant-scoped. Runs inside Sailor's TS web runtime.
-- **Track B (decoupled, not this repo)** — an optional self-hosted isolator /
-  kernel sidecar that implements `ExternalSandbox` over the `./protocol`
-  contract. The protocol is the only coupling seam.
+- **Track B (Carina upstream)** — `Nebutra/carina` is the sole product kernel.
+  Sailor docks via `createCarinaSandbox` (JSON-RPC: `gateway.hello` +
+  `command.exec`). Kernel protocol is maintained in Carina; this package only
+  maps. See `docs/architecture/2026-08-03-carina-track-b-upstream.md`.
 
 ## Modules
 

--- a/packages/ai/agent-runtime/src/agent-runtime.test.ts
+++ b/packages/ai/agent-runtime/src/agent-runtime.test.ts
@@ -11,6 +11,8 @@ import {
 } from "./rollout";
 import {
   assertSafePosture,
+  CarinaProtocolError,
+  createCarinaSandbox,
   createHttpSandbox,
   NoExecutorConfiguredError,
   REFUSING_SANDBOX,
@@ -156,6 +158,118 @@ describe("sandbox", () => {
         capabilityPolicy: DEFAULT_CAPABILITY_POLICY,
       }),
     ).rejects.toBeInstanceOf(SandboxDelegationError);
+  });
+
+  it("createCarinaSandbox speaks Carina JSON-RPC (hello + command.exec)", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      bodies.push(body);
+      if (body.method === "gateway.hello") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocol_version: 1 } }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "command.exec") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              decision: { decision_id: "perm_1", decision: "allowed" },
+              result: {
+                exit_code: 0,
+                stdout: ["hi\n"],
+                stderr: [],
+                timed_out: false,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: body.id, error: { code: -32601, message: "no" } }),
+        {
+          status: 200,
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    const sandbox = createCarinaSandbox({
+      baseUrl: "http://carina.local:7420/jsonrpc",
+      token: "gw1_test",
+      fetchImpl: fakeFetch,
+    });
+    const result = await sandbox.exec({
+      tenantId: "org_a",
+      threadId: "sess_1",
+      command: "echo hi",
+      capabilityPolicy: DEFAULT_CAPABILITY_POLICY,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.aggregatedOutput).toBe("hi\n");
+    expect(result.executedOn).toBe("carina");
+    expect(result.decisionId).toBe("perm_1");
+    expect(bodies[0]?.method).toBe("gateway.hello");
+    expect(bodies[1]?.method).toBe("command.exec");
+    const execParams = bodies[1]?.params as { session_id: string; argv: string[] };
+    expect(execParams.session_id).toBe("sess_1");
+    expect(execParams.argv).toEqual(["/bin/sh", "-c", "echo hi"]);
+  });
+
+  it("createCarinaSandbox fails closed on denied and low protocol version", async () => {
+    const deniedFetch = (async (_i: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string; id?: number };
+      if (body.method === "gateway.hello") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocol_version: 1 } }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { decision: { decision: "denied", reason: "policy" } },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createCarinaSandbox({
+        baseUrl: "http://carina.local",
+        fetchImpl: deniedFetch,
+      }).exec({
+        tenantId: "t",
+        threadId: "s",
+        command: "rm -rf /",
+        capabilityPolicy: DEFAULT_CAPABILITY_POLICY,
+      }),
+    ).rejects.toMatchObject({ name: "SandboxDelegationError", status: 403 });
+
+    const oldHello = (async (_i: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { id?: number };
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocol_version: 0 } }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(
+      createCarinaSandbox({
+        baseUrl: "http://carina.local",
+        fetchImpl: oldHello,
+        minProtocolVersion: 1,
+      }).exec({
+        tenantId: "t",
+        threadId: "s",
+        command: "echo",
+        capabilityPolicy: DEFAULT_CAPABILITY_POLICY,
+      }),
+    ).rejects.toBeInstanceOf(CarinaProtocolError);
   });
 });
 

--- a/packages/ai/agent-runtime/src/sandbox.ts
+++ b/packages/ai/agent-runtime/src/sandbox.ts
@@ -6,12 +6,14 @@
  * infrastructure. It only:
  *   1. carries the capability policy (see ./policy),
  *   2. delegates execution to an external isolator behind this interface
- *      (a self-hosted kernel sidecar — Track B — or any other executor),
+ *      (Track B = **Carina** upstream kernel),
  *   3. records the outcome as a `command_execution` item (see ./model).
  *
  * The upstream OS enforcers (Seatbelt / Landlock / bubblewrap / Windows
  * restricted token) are deliberately NOT ported — they are single-host and
  * out of scope for a multi-tenant web product.
+ *
+ * @see docs/architecture/2026-08-03-carina-track-b-upstream.md
  */
 
 import type { CapabilityPolicy } from "./policy";
@@ -32,11 +34,15 @@ export interface SandboxExecResult {
   readonly aggregatedOutput: string;
   /** Identifier of the isolator that actually ran the command. */
   readonly executedOn: string;
+  /** Carina permission decision id when present (audit correlation). */
+  readonly decisionId?: string;
+  /** Host correlation id sent on the wire (JSON-RPC id or extension). */
+  readonly correlationId?: string;
 }
 
 /**
  * The only thing Track A depends on for execution. Implemented by a decoupled
- * isolator over the ./protocol contract; never implemented in-process here.
+ * isolator over Carina's public RPC catalog; never implemented in-process here.
  */
 export interface ExternalSandbox {
   exec(request: SandboxExecRequest): Promise<SandboxExecResult>;
@@ -50,7 +56,7 @@ export class NoExecutorConfiguredError extends Error {
   constructor() {
     super(
       "No ExternalSandbox configured. This runtime never executes untrusted " +
-        "code in-process; delegate to a decoupled isolator (Track B).",
+        "code in-process; delegate to Carina (Track B) via createCarinaSandbox.",
     );
     this.name = "NoExecutorConfiguredError";
   }
@@ -66,23 +72,30 @@ export class SandboxDelegationError extends Error {
   constructor(
     message: string,
     readonly status: number,
+    readonly code?: string,
   ) {
     super(message);
     this.name = "SandboxDelegationError";
   }
 }
 
+export class CarinaProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CarinaProtocolError";
+  }
+}
+
 /**
- * The concrete Track-B coupling: delegate execution over HTTP to the decoupled
- * Rust isolator (`backends/rust/sandbox`, `POST /api/v1/sandbox/exec`). The
- * isolator is fail-closed; a non-2xx (e.g. 403 refusal) is surfaced as an
- * error and never coerced into a fabricated result.
+ * Generic HTTP POST of a Sailor-shaped body. Prefer {@link createCarinaSandbox}
+ * for production Track B — Carina owns the kernel and speaks JSON-RPC.
  */
 export function createHttpSandbox(
   baseUrl: string,
   fetchImpl: typeof fetch = fetch,
+  path = "/api/v1/sandbox/exec",
 ): ExternalSandbox {
-  const endpoint = `${baseUrl.replace(/\/$/, "")}/api/v1/sandbox/exec`;
+  const endpoint = `${baseUrl.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
   return {
     async exec(request: SandboxExecRequest): Promise<SandboxExecResult> {
       const response = await fetchImpl(endpoint, {
@@ -97,7 +110,243 @@ export function createHttpSandbox(
           response.status,
         );
       }
-      return (await response.json()) as SandboxExecResult;
+      const body = (await response.json()) as SandboxExecResult;
+      if (!body.executedOn) {
+        return { ...body, executedOn: "http-sandbox" };
+      }
+      return body;
+    },
+  };
+}
+
+// ── Carina v0.8.1 JSON-RPC mapping ───────────────────────────────────────────
+
+/** Minimum `protocol_version` we accept from `gateway.hello` (Carina catalog). */
+export const CARINA_MIN_PROTOCOL_VERSION = 1;
+
+type JsonRpcSuccess<T> = {
+  jsonrpc: "2.0";
+  id: string | number;
+  result: T;
+  error?: undefined;
+};
+
+type JsonRpcFailure = {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: { code: number; message: string; data?: unknown };
+  result?: undefined;
+};
+
+type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcFailure;
+
+type CarinaDecision = {
+  decision_id?: string;
+  decision?: "allowed" | "denied" | "requires_approval";
+  reason?: string;
+};
+
+type CarinaCommandResult = {
+  exit_code?: number;
+  duration_ms?: number;
+  stdout?: string[];
+  stderr?: string[];
+  timed_out?: boolean;
+};
+
+type CarinaExecWire = {
+  decision?: CarinaDecision;
+  result?: CarinaCommandResult;
+};
+
+type CarinaHello = {
+  protocol_version?: number;
+  version?: string;
+  features?: unknown;
+  methods?: unknown;
+};
+
+export type CarinaSandboxOptions = {
+  /**
+   * Base URL of a Carina JSON-RPC endpoint reachable over HTTP POST.
+   * Typically a local daemon bridge or product connector that forwards to
+   * `~/.carina/daemon.sock` / Gateway WS — not a public multi-tenant API.
+   */
+  readonly baseUrl: string;
+  /**
+   * Gateway token (`gw1`, transport-bound) or product connector credential.
+   * Never a local owner/admin unlock token.
+   */
+  readonly token?: string;
+  readonly fetchImpl?: typeof fetch;
+  /**
+   * Path under baseUrl for JSON-RPC POST. Default `""` posts to baseUrl itself.
+   * Connectors often use `/jsonrpc` or `/rpc`.
+   */
+  readonly rpcPath?: string;
+  /** Fail closed if hello reports a lower protocol_version. Default {@link CARINA_MIN_PROTOCOL_VERSION}. */
+  readonly minProtocolVersion?: number;
+  /** Skip gateway.hello (tests only). Production should leave this false. */
+  readonly skipHello?: boolean;
+  /** Label when the wire body has no node id. */
+  readonly executedOn?: string;
+  /** Map Sailor thread → Carina `session_id`. Default: `threadId`. */
+  readonly resolveSessionId?: (request: SandboxExecRequest) => string;
+  /**
+   * Optional client metadata sent on hello (discovery only — not an auth grant).
+   */
+  readonly clientId?: string;
+};
+
+/**
+ * Track-B adapter: Sailor control plane → **Carina** public RPC catalog (v0.8.1+).
+ *
+ * Mapping (Sailor → Carina, never the reverse ownership):
+ * - `threadId` → `command.exec` `session_id` (session must exist in Carina)
+ * - `command` → `argv` via `/bin/sh -c` (kernel still gates the joined command string)
+ * - denied / requires_approval → {@link SandboxDelegationError} (fail closed)
+ * - allowed + CommandResult → {@link SandboxExecResult}
+ *
+ * Kernel protocol is maintained in `Nebutra/carina`. This file only maps.
+ *
+ * @see docs/architecture/2026-08-03-carina-track-b-upstream.md
+ */
+export function createCarinaSandbox(options: CarinaSandboxOptions): ExternalSandbox {
+  const {
+    baseUrl,
+    token,
+    fetchImpl = fetch,
+    rpcPath = "",
+    minProtocolVersion = CARINA_MIN_PROTOCOL_VERSION,
+    skipHello = false,
+    executedOn = "carina",
+    resolveSessionId = (r) => r.threadId,
+    clientId = "nebutra-sailor",
+  } = options;
+
+  const endpoint = `${baseUrl.replace(/\/$/, "")}${
+    !rpcPath ? "" : rpcPath.startsWith("/") ? rpcPath : `/${rpcPath}`
+  }`;
+
+  let helloDone: Promise<void> | null = null;
+  let rpcId = 0;
+
+  async function rpcCall<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const id = ++rpcId;
+    const headers = new Headers({ "content-type": "application/json" });
+    if (token) {
+      headers.set("authorization", `Bearer ${token}`);
+    }
+    const response = await fetchImpl(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params,
+      }),
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new SandboxDelegationError(
+        `Carina transport error (${response.status}): ${detail}`,
+        response.status,
+        "transport_error",
+      );
+    }
+    const body = (await response.json()) as JsonRpcResponse<T>;
+    if (body.error) {
+      throw new SandboxDelegationError(
+        `Carina RPC ${method} failed (${body.error.code}): ${body.error.message}`,
+        502,
+        String(body.error.code),
+      );
+    }
+    if (!("result" in body)) {
+      throw new CarinaProtocolError(`Carina RPC ${method} returned no result`);
+    }
+    return body.result;
+  }
+
+  async function ensureHello(): Promise<void> {
+    if (skipHello) return;
+    if (!helloDone) {
+      helloDone = (async () => {
+        const hello = await rpcCall<CarinaHello>("gateway.hello", {
+          protocol_version: minProtocolVersion,
+          client_id: clientId,
+        });
+        const version = hello.protocol_version ?? 0;
+        if (typeof version !== "number" || version < minProtocolVersion) {
+          throw new CarinaProtocolError(
+            `Carina protocol_version ${String(hello.protocol_version)} ` +
+              `below required ${minProtocolVersion}`,
+          );
+        }
+      })().catch((err) => {
+        helloDone = null;
+        throw err;
+      });
+    }
+    await helloDone;
+  }
+
+  return {
+    async exec(request: SandboxExecRequest): Promise<SandboxExecResult> {
+      assertSafePosture(request.capabilityPolicy);
+
+      await ensureHello();
+
+      const sessionId = resolveSessionId(request);
+      const argv = ["/bin/sh", "-c", request.command];
+      const wire = await rpcCall<CarinaExecWire>("command.exec", {
+        session_id: sessionId,
+        argv,
+        // Host correlation for audit — ignored if kernel drops unknown fields.
+        correlation_id: `${request.tenantId}:${request.threadId}`,
+        tenant_id: request.tenantId,
+      });
+
+      const decision = wire.decision?.decision ?? "denied";
+      const decisionId = wire.decision?.decision_id;
+
+      if (decision === "denied") {
+        throw new SandboxDelegationError(
+          `Carina denied command: ${wire.decision?.reason ?? "denied"}`,
+          403,
+          "denied",
+        );
+      }
+      if (decision === "requires_approval") {
+        throw new SandboxDelegationError(
+          `Carina requires approval` + (decisionId ? ` (decision_id=${decisionId})` : ""),
+          409,
+          "requires_approval",
+        );
+      }
+
+      const cr = wire.result;
+      if (!cr) {
+        throw new SandboxDelegationError(
+          "Carina allowed exec but returned no CommandResult",
+          502,
+          "missing_result",
+        );
+      }
+
+      const stdout = (cr.stdout ?? []).join("");
+      const stderr = (cr.stderr ?? []).join("");
+      const aggregatedOutput =
+        stderr.length > 0 ? `${stdout}${stdout ? "\n" : ""}${stderr}` : stdout;
+
+      return {
+        exitCode: cr.exit_code ?? (cr.timed_out ? 124 : 0),
+        aggregatedOutput,
+        executedOn,
+        decisionId,
+        correlationId: `${request.tenantId}:${request.threadId}`,
+      };
     },
   };
 }


### PR DESCRIPTION
## Summary

Docks Sailor Track B to **Carina v0.8.1 public RPC catalog** (per [carina#27](https://github.com/Nebutra/carina/issues/27) closed *not planned* — no parallel `product-adapter` package).

- `createCarinaSandbox` now speaks **JSON-RPC 2.0** over HTTP POST (product connector / bridge URL), not a fictional REST `/api/v1/sandbox/exec`.
- Handshake: `gateway.hello` + `protocol_version` pin (`CARINA_MIN_PROTOCOL_VERSION = 1`); fail closed if too low.
- Exec: `command.exec` with `session_id ← threadId`, `argv ← ["/bin/sh","-c", command]`.
- `denied` → 403; `requires_approval` → 409 (host must use Carina approve/deny; not auto-approved).
- ADR `docs/architecture/2026-08-03-carina-track-b-upstream.md` + mapping appendix.
- Tests: hello+exec happy path, deny, low protocol version (17/17).

## Ownership (hard-correct)

| Layer | Owner |
|-------|--------|
| Kernel / capability / OS sandbox | **Carina** (upstream) |
| Multi-tenant grammar | `@nebutra/agent-runtime` |
| Thin adapter only | this PR |

## Out of scope (follow-ups)

- Gateway/Startup OS env injection (`CARINA_JSONRPC_URL`)
- Session lifecycle (`session.create`) when thread has no Carina session
- Headless approval bridge UI

## Test plan

- [x] `vitest` `packages/ai/agent-runtime` sandbox suite
- [ ] Review mapping vs `Nebutra/carina` `protocol/jsonrpc/methods.json`
- [ ] Optional: run against local `carina-daemon` bridge once available