### PR TITLE
docs(ai): close Carina Track-B Phase 1 and align SSOT

### DIFF
--- a/backends/gateway/src/routes/agent-runtime/index.ts
+++ b/backends/gateway/src/routes/agent-runtime/index.ts
@@ -11,8 +11,10 @@
  *  - ApprovalGate is fail-closed (auto-denies prompts) — human-in-the-loop
  *    transport is future work; unapproved tools are never dispatched.
  *  - No command-exec tool is registered here yet, so the external-sandbox
- *    seam has nothing to delegate; it is wired the moment such a tool is
- *    added (`createHttpSandbox(AGENT_SANDBOX_URL)`), not before.
+ *    seam has nothing to delegate. Product Track B is Carina:
+ *    `createCarinaSandbox({ baseUrl: process.env.CARINA_JSONRPC_URL })` when
+ *    the endpoint is set; otherwise fail-closed. Host wiring (session + tool)
+ *    tracked in Nebutra-Sailor#384 — not `createHttpSandbox(AGENT_SANDBOX_URL)`.
  *  - RolloutStore is process-local `InMemoryRolloutStore`. The durable
  *    tenant-scoped store needs a DB model (infra change) and is deliberately
  *    deferred — not faked. Use `PersistentRolloutStore` + a real port adapter

--- a/docs/DOMAINS.md
+++ b/docs/DOMAINS.md
@@ -63,6 +63,7 @@ and do **not** get a parallel `api.carina.*` origin.
 |---|---|
 | Product docs / LLM surface | `carina.nebutra.com` (**CF A → ECS** `106.15.4.31`, proxied — same pattern as pebble) |
 | Skills / catalog URLs | `carina.nebutra.com/llms.txt`, `/data/rpc-catalog-*.json` |
+| Agent **execution** (Track B) | **Not this host.** Self-deployed Carina daemon; Sailor docks via private JSON-RPC (`CARINA_JSONRPC_URL`). See ADR 2026-08-03 + issue #384 |
 | Staging | **no host** — preview deploys / project isolation only |
 
 **Owner topology (2026-07-30):** DNS **A** record is correct — do **not** point carina at Vercel CNAME.

--- a/docs/architecture/2026-08-03-carina-track-b-upstream.md
+++ b/docs/architecture/2026-08-03-carina-track-b-upstream.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Accepted.
+**Accepted.** Phase 1 (catalog adapter) **closed**. Phase 2 (gateway product
+wiring) tracked in [Nebutra-Sailor#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384).
+
+| Phase | Scope | State |
+|-------|--------|--------|
+| **1 — Dock** | `createCarinaSandbox` JSON-RPC map, fail-closed default, ADR, package tests | **Done** ([#382](https://github.com/Nebutra/Nebutra-Sailor/pull/382)) |
+| **2 — Wire** | Gateway inject, `session.create`, command-exec tool, optional approval UI | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
 
 ## Context
 
@@ -14,9 +20,8 @@ rollout). It is designed dual-track:
 - **Track B** — a decoupled isolator / kernel that actually runs untrusted
   side effects behind `ExternalSandbox`.
 
-Carina (`Nebutra/carina`, Go/Rust/Zig, local-first) owns the capability kernel,
-OS sandbox backends, audit chain, and cloud boundary. Sailor must not grow a
-second kernel.
+Carina (`Nebutra/carina`, local-first) owns the capability kernel, OS sandbox
+backends, audit chain, and cloud boundary. Sailor must not grow a second kernel.
 
 Carina issue [#27](https://github.com/Nebutra/carina/issues/27) closed **not
 planned**: foundations live as product-agnostic RPC + SDKs (v0.8.1+), not a
@@ -34,7 +39,11 @@ Nebutra Cloud (Sailor)
   @nebutra/agent-runtime   → turn/policy/rollout (Track A)
         │  createCarinaSandbox  (JSON-RPC mapping, owned in Sailor)
         ▼
-Carina kernel (upstream)   → command.exec, capability kernel, audit
+  HTTP JSON-RPC baseUrl     → self-deployed reachability
+        │  (local HTTP bridge / private net / optional CF Tunnel)
+        ▼
+Carina daemon (upstream)    → capability kernel, command.exec, audit
+  typical native listen: ~/.carina/daemon.sock
 ```
 
 ### Ownership
@@ -45,35 +54,68 @@ Carina kernel (upstream)   → command.exec, capability kernel, audit
 | Multi-tenant turn grammar, approval rail, rollout | **Sailor** |
 | `ExternalSandbox` + `createCarinaSandbox` mapping | **Sailor** |
 | Default fail-closed without Carina endpoint | **Sailor** (`REFUSING_SANDBOX`) |
+| Self-deploy daemon + reachable HTTP endpoint | **Operator** (product / customer node) |
+| Gateway inject + session lifecycle + exec tool | **Sailor** host (Phase 2 / #384) |
 
-## Appendix A — v0.8.1 wire mapping
+### Deployment topology (honest)
+
+| Surface | What it is | Not |
+|---------|------------|-----|
+| `carina.nebutra.com` | Product **docs** (ECS static) | Not the exec API |
+| Carina daemon | Self-deployed local-first runtime | Not multi-tenant SaaS sandbox-as-a-service |
+| `CARINA_JSONRPC_URL` | HTTP POST JSON-RPC to a **reachable** connector | Not Unix socket from Node `fetch` |
+| Cloudflare | Optional DNS / Tunnel / Access in front of a real node | Not a Workers-hosted Carina kernel |
+
+Pattern matches normal SaaS agent docking: **control plane in Sailor, agent
+runtime self-deployed, then wired**. No public `api.carina.*` execution origin
+(see Carina `docs/nebutra-cloud-boundary.md`).
+
+Bearer tokens are **Gateway / product credentials**, never local owner tokens.
+
+## Appendix A — v0.8.1 wire mapping (Phase 1)
+
+Catalog baseline: **Carina v0.8.1**. Pin: `CARINA_MIN_PROTOCOL_VERSION = 1`.
 
 | Sailor | Carina (catalog) |
 |--------|------------------|
 | Hello / version pin | `gateway.hello` `{ protocol_version, client_id }` → require `protocol_version >= 1` |
-| `SandboxExecRequest.threadId` | `command.exec` `session_id` (session must already exist) |
+| `SandboxExecRequest.threadId` | `command.exec` `session_id` (**session must already exist**) |
 | `SandboxExecRequest.command` | `argv: ["/bin/sh", "-c", command]` (kernel still sees joined string) |
-| `SandboxExecRequest.tenantId` | sent as extension `tenant_id` + `correlation_id` (scope/audit hint; **not** a privilege grant) |
+| `SandboxExecRequest.tenantId` | extension `tenant_id` + `correlation_id` (scope/audit hint; **not** a privilege grant) |
 | allowed + `CommandResult` | `exitCode` ← `exit_code`, `aggregatedOutput` ← stdout+stderr join |
 | `decision: denied` | `SandboxDelegationError` status 403 |
-| `decision: requires_approval` | `SandboxDelegationError` status 409, code `requires_approval` (host must call `task.action.approve` / `deny` — not implemented in the thin adapter yet) |
+| `decision: requires_approval` | `SandboxDelegationError` status 409, code `requires_approval` (host must call `task.action.approve` / `deny` — Phase 2 optional) |
 | `executedOn` | adapter default `"carina"` |
-| Transport | HTTP POST JSON-RPC 2.0 to a connector/`baseUrl` (unix socket is Carina-native; products typically bridge) |
+| Transport | HTTP POST JSON-RPC 2.0 to connector/`baseUrl` |
 
-Bearer tokens are **Gateway / product credentials**, never local owner tokens
-(Carina cloud boundary).
+`createHttpSandbox` remains a **generic** Sailor-shaped HTTP helper for tests or
+non-Carina isolators. Production Track B **prefers** `createCarinaSandbox`.
+
+## Upstream updates
+
+| Change type | Sailor action | Operator action |
+|-------------|---------------|-----------------|
+| Compatible daemon / optional fields | None | Upgrade daemon |
+| Breaking `protocol_version` or method shape | Update `sandbox.ts` + `CARINA_MIN_PROTOCOL_VERSION` + tests, then ship | Upgrade daemon after adapter |
+| New optional RPC (session, approval, workers) | Add host wiring only if product needs it | Deploy matching daemon |
+
+Do **not** vendor Carina source into this monorepo. Follow
+`protocol/jsonrpc/methods.json` and Carina release notes.
 
 ## Consequences
 
-- Production injects Carina only when `CARINA_JSONRPC_URL` (or product config)
-  is set; otherwise fail closed.
+- Phase 1: adapter + tests on main; without endpoint, exec **fail-closed**.
+- Phase 2 (#384): production injects only when `CARINA_JSONRPC_URL` (or product
+  config) is set; host owns `session.create` and command-exec tool registration.
 - Protocol breaks require Carina version bump + Sailor adapter pin update.
-- Approval UI bridge and session lifecycle (`session.create`) remain host
-  responsibilities layered on top of this exec adapter.
+- Approval UI bridge remains optional on top of the exec adapter.
 
 ## Related
 
+- PR [#382](https://github.com/Nebutra/Nebutra-Sailor/pull/382) — Phase 1 adapter
+- Issue [#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384) — Phase 2 wire
+- `@nebutra/agent-runtime` `src/sandbox.ts`
 - Carina `docs/nebutra-cloud-boundary.md`, `docs/rpc-api.md`,
   `protocol/jsonrpc/methods.json`
 - Carina issue #27 (closed not planned — use catalog, not product-adapter package)
-- `@nebutra/agent-runtime` `src/sandbox.ts`
+- `docs/DOMAINS.md` — `carina.nebutra.com` is docs-only

--- a/docs/capabilities/agent-runtime/CAPABILITY_MAP.md
+++ b/docs/capabilities/agent-runtime/CAPABILITY_MAP.md
@@ -1,9 +1,11 @@
 # agent-runtime — Capability Map (P2, draft pending maintainer sign-off)
 
 > Codename: `agent-runtime`. Governance mainline: **dual-track decoupling**.
-> Track A = Sailor TS multi-tenant web (this repo). Track B = optional self-hosted
-> kernel sidecar, protocol-decoupled (not in this repo).
+> Track A = Sailor TS multi-tenant web (this repo). Track B = **Carina**
+> (`Nebutra/carina`) local-first kernel — upstream, self-deployed, docked via
+> public JSON-RPC catalog (not a second kernel in this monorepo).
 > Source identity is conversation-only; nothing here leaks a brand.
+> ADR: `docs/architecture/2026-08-03-carina-track-b-upstream.md`.
 
 ## Decision legend
 
@@ -28,65 +30,64 @@
 | 8 | Approval & sandbox **policy** layer | **WRAP** | `@nebutra/permissions` (CASL/OpenFGA) | two-axis model (approval tier × capability policy), `Decision`/`ReviewDecision` enums, execpolicy-as-data, declarative writable-roots. Policy only — enforcement is the boundary |
 | 9 | Tool / MCP abstraction | **WRAP** | `@nebutra/mcp` (WIP, `mcpClient`, `serverRegistry`, middleware) | activate; `ToolDefinition` + Responses-API tool union + deferred discovery; registry→router→orchestrator w/ hooks; MCP-as-adapter behind uniform tool iface |
 | 10 | Durable / resumable turn | **WRAP** | `@nebutra/queue` (`defineQueueJob`) | durable-turn job + state store on top of replay model |
-| 11 | **Sandboxed untrusted-code execution** | **PORT** | *nothing exists* | the only true greenfield piece — see governance fork below |
+| 11 | **Sandboxed untrusted-code execution** | **PORT (seam) + WRAP (Carina)** | Carina upstream + `createCarinaSandbox` | Seam + fail-closed in Sailor; enforcement in Carina. Phase 1 docked (#382); product wire #384 |
 
 ### Build status (honest ledger)
 
 - **Done (built + tested):** #5 contract types, #6 model, #7 rollout
   model+replay (in-mem ref store only), #8 policy, #9 tool/MCP abstraction
-  (interface; not yet wired to live `@nebutra/mcp`), #11 seam + Rust
-  fail-closed isolator, **plus the agent loop runner** (`runTurn` — the turn
-  engine: model→tool→approval→rollout, bounded, single-threaded, resumable
-  by replay).
+  (interface; not yet wired to live `@nebutra/mcp`), #11 **seam** + fail-closed
+  default, **plus the agent loop runner** (`runTurn` — model→tool→approval→
+  rollout, bounded, single-threaded, resumable by replay).
 - **Done (built + tested, runtime closure):** #10 durable/resumable turn
   (`createDurableTurn`), protocol dispatcher (`ProtocolDispatcher`,
   per-scope serialization — WS/SSE socket adapter still out of scope), MCP
   activation (`activateMcpTools` via injectable catalog port), production
   tenant-scoped rollout store (`PersistentRolloutStore` via injectable
-  persistence port). 59 package tests green.
+  persistence port).
 - **Done (live wiring):** gateway route `POST /api/v1/agent-runtime/turns`
   — tenant-scoped `runTurn` streamed over SSE, behind `requireAuth` +
   off-by-default `agent-runtime-demo` flag; `ModelInvoker` bridges
-  `@nebutra/agents`. Gateway typecheck clean.
+  `@nebutra/agents`.
 - **Done (adapters + durable store):** `@nebutra/agent-runtime/adapters/*`
-  (`mcp-catalog`, `dispatcher-sse`, `prisma-rollout` — 26 tests);
-  `AgentRolloutLine` Prisma model + additive migration
-  `20260519000000_add_agent_rollout_store` + ADR 2026-05-19; gateway route
-  store is env-gated (`AGENT_ROLLOUT_DURABLE=1` → durable Postgres
-  system-of-record, default in-memory). Gateway typecheck clean.
-- **Not yet built:** real isolation backend (Wasmtime/Firecracker Phase 2);
-  a command-exec tool (sandbox delegation activates the moment one is
-  registered). Durable-store activation = standard migrate+generate deploy
-  step (ADR 2026-05-19), not code change — intentionally not faked.
+  (`mcp-catalog`, `dispatcher-sse`, `prisma-rollout`); `AgentRolloutLine`
+  Prisma model + ADR 2026-05-19; gateway store env-gated
+  (`AGENT_ROLLOUT_DURABLE=1` → Postgres, default in-memory).
+- **Done (Track B Phase 1 — catalog dock):** `createCarinaSandbox` maps to
+  Carina v0.8.1 JSON-RPC (`gateway.hello` + `command.exec`); package tests;
+  ADR 2026-08-03; PR #382. Default remains `REFUSING_SANDBOX` when no endpoint.
+- **Not yet built (Track B Phase 2 — #384):** gateway inject of
+  `CARINA_JSONRPC_URL`, host `session.create`, command-exec tool registration,
+  optional approval bridge (`task.action.approve` / `deny`).
 - **Not deeply mapped:** model catalog manager, apply-patch grammar,
   compaction *generation* logic, tool_search discovery *mechanism*, hooks
   pipeline impl, web_search/image-gen handlers.
 
-## Track B — decoupled, in `backends/rust/sandbox/`
+## Track B — Carina upstream (`Nebutra/carina`)
 
-Correction to an earlier overstatement: Track B is **not** a separate repo.
-`backends/` is Sailor's documented polyglot split (`backends/README.md`:
-"Rust | Safety-critical isolation … | `rust/sandbox/`", decision rule
-"Touches user code execution or encryption? → Rust"). The TS-by-default ADR
-explicitly carves out specialized cases. So the Track-B isolator lives at
-`backends/rust/sandbox/` — same repo, protocol-decoupled, no new ADR needed,
-no app-infra touched (it is an isolated service like `backends/python/ai`).
+**Decision (2026-08-03):** Track B is **not** `backends/rust/sandbox/` and is
+**not** a Sailor-owned second kernel. Isolation, capability enforcement, OS
+backends, and audit chain live in **Carina** (separate repo, local-first,
+self-deployed). Sailor only ships a thin adapter over Carina's public catalog.
 
-Decoupling = the protocol/HTTP contract, **not** a repo boundary. Track A
-delegates over `POST /api/v1/sandbox/exec` via `createHttpSandbox()` in
-`agent-runtime/sandbox.ts`; the Rust service mirrors the
-`SandboxExecRequest`/`SandboxExecResult`/`CapabilityPolicy` shapes.
+| Piece | Location | Notes |
+|-------|----------|--------|
+| Kernel / daemon | `Nebutra/carina` | Upstream; operator self-deploys |
+| Public catalog | Carina `protocol/jsonrpc/methods.json` | v0.8.1+; no product-adapter package (Carina #27 not planned) |
+| Sailor adapter | `packages/ai/agent-runtime/src/sandbox.ts` → `createCarinaSandbox` | HTTP JSON-RPC; pin `CARINA_MIN_PROTOCOL_VERSION` |
+| Generic HTTP helper | `createHttpSandbox` | Tests / non-Carina isolators only; prefer Carina for product Track B |
+| Fail-closed default | `REFUSING_SANDBOX` | No endpoint → no untrusted exec |
+| Product wire | Gateway / host | [#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384) |
 
-The isolator is **fail-closed**: until a real backend (Wasmtime Phase 2 /
-Firecracker Phase 3) is wired it refuses every exec — a sandbox that does not
-isolate is more dangerous than none, so it is never faked. OS-specific
-enforcers from the source (Seatbelt/Landlock/bwrap/Windows token) are not
-ported; they are replaced by this service's future Wasm/microVM runner.
+Historical note: earlier drafts pointed at a same-repo Rust isolator and
+`POST /api/v1/sandbox/exec`. That path is **superseded** by Carina docking.
+Do not revive a parallel Sailor sandbox service for product Track B.
 
 ---
 
-## The one governance fork (item #11, touches "do not change Sailor infra")
+## The one governance fork (item #11)
 
-Sailor hard-constraint = don't touch infra; no sandbox primitive exists.
-How Track A handles untrusted exec is a maintainer call — see chat checkpoint.
-Everything else (SKIP/WRAP classification) is execution detail owned by the absorber.
+Untrusted exec never runs in the multi-tenant web process. Track A holds
+**policy + delegation seam** only; Track B enforcement is **Carina**. Phase 1
+adapter is closed (#382); Phase 2 product wire is #384. Everything else in the
+SKIP/WRAP table is absorber execution detail.

--- a/docs/capabilities/agent-runtime/REPLICATION_GUIDE.md
+++ b/docs/capabilities/agent-runtime/REPLICATION_GUIDE.md
@@ -111,18 +111,30 @@ backend. Nothing else changes.
 ## Step 6 — run code without running code
 
 ```ts
-import { REFUSING_SANDBOX, type ExternalSandbox } from "@nebutra/agent-runtime/sandbox";
+import {
+  createCarinaSandbox,
+  REFUSING_SANDBOX,
+  type ExternalSandbox,
+} from "@nebutra/agent-runtime/sandbox";
 
 // Default: refuses. That is correct — a multi-tenant web process must not
-// execute untrusted code. Provide a real isolator (a self-hosted sidecar,
-// a remote sandbox service, anything) implementing ExternalSandbox:
-const sandbox: ExternalSandbox = myDelegatedIsolator ?? REFUSING_SANDBOX;
+// execute untrusted code. Product Track B = self-deployed Carina:
+const sandbox: ExternalSandbox = process.env.CARINA_JSONRPC_URL
+  ? createCarinaSandbox({
+      baseUrl: process.env.CARINA_JSONRPC_URL,
+      token: process.env.CARINA_JSONRPC_TOKEN,
+    })
+  : REFUSING_SANDBOX;
+
 const result = await sandbox.exec({ tenantId, threadId, command, capabilityPolicy });
 ```
 
-This is the seam where a separate, isolated execution backend plugs in over
-the protocol contract. Your web tier never gains the ability to run arbitrary
-code; it only gains the ability to *ask something else to*.
+This is the seam where **Carina** (upstream kernel) plugs in over the public
+JSON-RPC catalog. Your web tier never gains the ability to run arbitrary code;
+it only gains the ability to *ask the self-deployed daemon to*. Host still must
+ensure a Carina session exists before `command.exec` (see #384).
+
+ADR: `docs/architecture/2026-08-03-carina-track-b-upstream.md`.
 
 ## What you did NOT have to build
 

--- a/packages/ai/agent-runtime/README.md
+++ b/packages/ai/agent-runtime/README.md
@@ -1,13 +1,17 @@
 # @nebutra/agent-runtime
 
-Status: **WIP**
+Status: **Track A live (grammar + gateway demo); Track B Phase 1 docked**
 
-> Status: WIP — not yet integrated into a production app. Track-B kernel
-> transport and durable-turn queue binding are interface-only.
+| Layer | State |
+|-------|--------|
+| Track A grammar (`runTurn`, policy, rollout, tools) | Shipped; gateway demo route behind `agent-runtime-demo` |
+| Track B adapter (`createCarinaSandbox` → Carina JSON-RPC) | **Phase 1 done** ([#382](https://github.com/Nebutra/Nebutra-Sailor/pull/382)) |
+| Track B product wire (gateway inject, session, exec tool) | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
+| Default without Carina endpoint | **Fail-closed** (`REFUSING_SANDBOX`) |
 
 Multi-tenant **agent-runtime grammar**. A faithful re-expression of a terminal
 coding-agent's runtime *design* into Sailor's grammar — TypeScript,
-multi-tenant, zero infra changes, **no in-process untrusted-code execution**.
+multi-tenant, zero in-process untrusted-code execution.
 
 ## Why this exists
 
@@ -24,10 +28,28 @@ them.
 
 - **Track A (this package)** — policy, protocol contract, model, rollout. All
   tenant-scoped. Runs inside Sailor's TS web runtime.
-- **Track B (Carina upstream)** — `Nebutra/carina` is the sole product kernel.
-  Sailor docks via `createCarinaSandbox` (JSON-RPC: `gateway.hello` +
-  `command.exec`). Kernel protocol is maintained in Carina; this package only
-  maps. See `docs/architecture/2026-08-03-carina-track-b-upstream.md`.
+- **Track B (Carina upstream)** — the **Nebutra/carina** kernel is the sole
+  product isolator. Self-deployed, local-first. Sailor docks via
+  `createCarinaSandbox` / `ExternalSandbox` — **kernel protocol is maintained
+  in Carina**, not reimplemented here.
+
+```ts
+import {
+  createCarinaSandbox,
+  REFUSING_SANDBOX,
+  type ExternalSandbox,
+} from "@nebutra/agent-runtime";
+
+// Production: only when a reachable Carina JSON-RPC base URL is configured.
+const sandbox: ExternalSandbox = process.env.CARINA_JSONRPC_URL
+  ? createCarinaSandbox({
+      baseUrl: process.env.CARINA_JSONRPC_URL,
+      token: process.env.CARINA_JSONRPC_TOKEN, // product/gateway cred — never owner unlock
+    })
+  : REFUSING_SANDBOX;
+```
+
+See `docs/architecture/2026-08-03-carina-track-b-upstream.md`.
 
 ## Modules
 
@@ -38,16 +60,16 @@ them.
 | `./protocol` | JSON-RPC contract | method registry, **tenant+thread serialization scope**, server-initiated approval requests, notifications |
 | `./tools` | uniform tool/MCP | `ToolRegistry` (registry→router→hooks), `adaptMcpTool` (MCP-as-adapter) |
 | `./rollout` | event-sourced trace | append-only typed log, replay-to-state, compaction marker, per-item persistence policy |
-| `./sandbox` | external-sandbox seam | `ExternalSandbox` delegation interface; fail-closed `REFUSING_SANDBOX` default |
+| `./sandbox` | external-sandbox seam | `ExternalSandbox`; `createCarinaSandbox` (Track B); `REFUSING_SANDBOX` default; `createHttpSandbox` generic helper |
 | `./adapters/*` | reusable concrete bindings | MCP catalog, Web-standard SSE transport, and Prisma rollout persistence without a separate package |
 
 ## Non-negotiables enforced here
 
 - **Multi-tenant**: every scope, store key, and dispatch carries `tenantId`;
   cross-tenant requests can never share a serialization scope.
-- **No infra change**: no sandbox runtime, no new datastore — only interfaces.
 - **No in-process untrusted exec**: the default executor refuses; real
-  execution is delegated to a decoupled isolator.
+  execution is delegated to self-deployed Carina (or another `ExternalSandbox`).
+- **No second kernel**: OS sandbox / capability enforcement stay in Carina.
 
 See `docs/capabilities/agent-runtime/` for the capability map and replication
 guide.


### PR DESCRIPTION
## Summary

High-quality **Phase 1 closure** for Carina Track-B docking (post #382). No runtime behavior change — docs + one gateway comment.

- ADR: done/open ledger, topology (self-deploy + optional CF tunnel), upstream upgrade policy, links to #382 / #384
- CAPABILITY_MAP: supersede obsolete `backends/rust/sandbox` Track B story with Carina
- REPLICATION_GUIDE + package README: `createCarinaSandbox` / fail-closed / Phase 2 pointer
- Gateway route comment: stop advertising `createHttpSandbox(AGENT_SANDBOX_URL)` as product path
- DOMAINS: `carina.nebutra.com` remains docs-only; exec is private JSON-RPC

## Test plan

- [x] Docs-only review
- [ ] Merge when green

Refs: #382 #384