### PR TITLE
feat(agent-runtime): wire Carina host session + command_exec (Phase 2a)

### DIFF
--- a/backends/gateway/src/lib/carina-sandbox.test.ts
+++ b/backends/gateway/src/lib/carina-sandbox.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { REFUSING_SANDBOX, isCarinaSandbox } from "@nebutra/agent-runtime";
+import { createGatewayCarinaBundle } from "./carina-sandbox.js";
+
+describe("createGatewayCarinaBundle", () => {
+  it("fails closed with empty tools when Carina URL is unset", () => {
+    const bundle = createGatewayCarinaBundle({});
+    expect(bundle.carinaEnabled).toBe(false);
+    expect(bundle.sandbox).toBe(REFUSING_SANDBOX);
+    expect(bundle.tools.list()).toHaveLength(0);
+  });
+
+  it("registers command_exec when CARINA_JSONRPC_URL is set", () => {
+    const bundle = createGatewayCarinaBundle({
+      CARINA_JSONRPC_URL: "http://127.0.0.1:7420/jsonrpc",
+      CARINA_WORKSPACE_ROOT: "/var/carina/ws",
+    });
+    expect(bundle.carinaEnabled).toBe(true);
+    expect(isCarinaSandbox(bundle.sandbox)).toBe(true);
+    expect(bundle.tools.list().map((t) => t.definition.name)).toEqual(["command_exec"]);
+  });
+});

--- a/backends/gateway/src/lib/carina-sandbox.ts
+++ b/backends/gateway/src/lib/carina-sandbox.ts
@@ -1,0 +1,56 @@
+/**
+ * Gateway Track-B wiring — resolve Carina from env and attach command_exec.
+ *
+ * Env (operator / self-deployed daemon):
+ *   CARINA_JSONRPC_URL       HTTP JSON-RPC base (required to enable)
+ *   CARINA_JSONRPC_TOKEN     product/gateway Bearer (never local owner unlock)
+ *   CARINA_JSONRPC_PATH      optional path under base (e.g. /jsonrpc)
+ *   CARINA_WORKSPACE_ROOT    absolute path on Carina host for session.create
+ *   CARINA_CLIENT_ID         optional hello client_id
+ *
+ * Fail-closed: without CARINA_JSONRPC_URL, returns REFUSING_SANDBOX and an
+ * empty tool registry (no command_exec surface).
+ */
+
+import {
+  RuntimeToolRegistry,
+  isCarinaSandbox,
+  registerCommandExecTool,
+  resolveCarinaSandboxFromEnv,
+  type ExternalSandbox,
+} from "@nebutra/agent-runtime";
+
+export type GatewayCarinaBundle = {
+  readonly sandbox: ExternalSandbox;
+  readonly tools: RuntimeToolRegistry;
+  /** True when CARINA_JSONRPC_URL is set (sandbox is Carina, not refuse stub). */
+  readonly carinaEnabled: boolean;
+};
+
+/**
+ * Build sandbox + tools for an agent-runtime turn.
+ * Pure enough to unit-test with a synthetic env map.
+ */
+export function createGatewayCarinaBundle(
+  env: NodeJS.ProcessEnv = process.env,
+): GatewayCarinaBundle {
+  const sandbox = resolveCarinaSandboxFromEnv(env);
+  const tools = new RuntimeToolRegistry();
+  const carinaEnabled = isCarinaSandbox(sandbox);
+
+  if (carinaEnabled) {
+    const workspaceRoot = env.CARINA_WORKSPACE_ROOT?.trim();
+    registerCommandExecTool(tools, {
+      sandbox,
+      ...(workspaceRoot ? { workspaceRoot } : {}),
+    });
+  }
+
+  return { sandbox, tools, carinaEnabled };
+}
+
+export function gatewaySandboxOrRefuse(
+  env: NodeJS.ProcessEnv = process.env,
+): ExternalSandbox {
+  return resolveCarinaSandboxFromEnv(env);
+}

--- a/backends/gateway/src/routes/agent-runtime/index.ts
+++ b/backends/gateway/src/routes/agent-runtime/index.ts
@@ -10,15 +10,11 @@
  *    no provider re-port).
  *  - ApprovalGate is fail-closed (auto-denies prompts) — human-in-the-loop
  *    transport is future work; unapproved tools are never dispatched.
- *  - No command-exec tool is registered here yet, so the external-sandbox
- *    seam has nothing to delegate. Product Track B is Carina:
- *    `createCarinaSandbox({ baseUrl: process.env.CARINA_JSONRPC_URL })` when
- *    the endpoint is set; otherwise fail-closed. Host wiring (session + tool)
- *    tracked in Nebutra-Sailor#384 — not `createHttpSandbox(AGENT_SANDBOX_URL)`.
- *  - RolloutStore is process-local `InMemoryRolloutStore`. The durable
- *    tenant-scoped store needs a DB model (infra change) and is deliberately
- *    deferred — not faked. Use `PersistentRolloutStore` + a real port adapter
- *    once that lands.
+ *  - Track B (Carina): `createGatewayCarinaBundle()` reads CARINA_JSONRPC_URL.
+ *    When set, registers `command_exec` → createCarinaSandbox + session.create
+ *    (needs CARINA_WORKSPACE_ROOT). When unset, empty tools + fail-closed.
+ *    Approval bridge (task.action.approve) still open — see #384.
+ *  - RolloutStore: in-memory by default; AGENT_ROLLOUT_DURABLE=1 → Postgres.
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
@@ -28,7 +24,6 @@ import {
   PersistentRolloutStore,
   type RolloutStore,
   runTurn,
-  ToolRegistry,
   type TurnConfig,
 } from "@nebutra/agent-runtime";
 import {
@@ -41,6 +36,7 @@ import { getTenantDb } from "@nebutra/db";
 import { FLAGS, featureFlagMiddleware } from "@nebutra/feature-flags";
 import { streamSSE } from "hono/streaming";
 import { getGatewayOrchestrator } from "../../agents/orchestrator-singleton.js";
+import { createGatewayCarinaBundle } from "../../lib/carina-sandbox.js";
 import { requireAuth } from "../../middlewares/tenantContext.js";
 
 export const agentRuntimeRoutes = new OpenAPIHono();
@@ -152,13 +148,14 @@ agentRuntimeRoutes.openapi(turnRoute, async (c) => {
   };
 
   return streamSSE(c, async (stream) => {
+    const { tools } = createGatewayCarinaBundle();
     const events = runTurn(body.input, {
       tenantId,
       threadId: body.threadId,
       config,
       approvalPolicy: { kind: "on_request" },
       model: modelInvoker(orch, body.input, tenantId, tenant.userId ?? "anonymous", body.threadId),
-      tools: new ToolRegistry(),
+      tools,
       store: rolloutStore(),
       approvalGate: {
         async request() {

--- a/docs/architecture/2026-08-03-carina-track-b-upstream.md
+++ b/docs/architecture/2026-08-03-carina-track-b-upstream.md
@@ -8,7 +8,8 @@ wiring) tracked in [Nebutra-Sailor#384](https://github.com/Nebutra/Nebutra-Sailo
 | Phase | Scope | State |
 |-------|--------|--------|
 | **1 — Dock** | `createCarinaSandbox` JSON-RPC map, fail-closed default, ADR, package tests | **Done** ([#382](https://github.com/Nebutra/Nebutra-Sailor/pull/382)) |
-| **2 — Wire** | Gateway inject, `session.create`, command-exec tool, optional approval UI | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
+| **2a — Host wire** | Env resolve, `session.create` / ensureSession, `command_exec` tool, gateway bundle | **Done** (this tree; closes inject+session+tool in #384) |
+| **2b — Product HITL** | Approval UI + `task.action.approve` / `deny`, multi-tenant workspace routing | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
 
 ## Context
 
@@ -105,8 +106,11 @@ Do **not** vendor Carina source into this monorepo. Follow
 ## Consequences
 
 - Phase 1: adapter + tests on main; without endpoint, exec **fail-closed**.
-- Phase 2 (#384): production injects only when `CARINA_JSONRPC_URL` (or product
-  config) is set; host owns `session.create` and command-exec tool registration.
+- Phase 2a: gateway `createGatewayCarinaBundle()` injects when
+  `CARINA_JSONRPC_URL` is set; `command_exec` calls `ensureSession` then
+  `command.exec`. Requires `CARINA_WORKSPACE_ROOT` on the Carina host.
+- Phase 2b (#384 remainder): human approval bridge and per-tenant workspace
+  routing remain open.
 - Protocol breaks require Carina version bump + Sailor adapter pin update.
 - Approval UI bridge remains optional on top of the exec adapter.
 

--- a/docs/capabilities/agent-runtime/CAPABILITY_MAP.md
+++ b/docs/capabilities/agent-runtime/CAPABILITY_MAP.md
@@ -56,9 +56,11 @@
 - **Done (Track B Phase 1 — catalog dock):** `createCarinaSandbox` maps to
   Carina v0.8.1 JSON-RPC (`gateway.hello` + `command.exec`); package tests;
   ADR 2026-08-03; PR #382. Default remains `REFUSING_SANDBOX` when no endpoint.
-- **Not yet built (Track B Phase 2 — #384):** gateway inject of
-  `CARINA_JSONRPC_URL`, host `session.create`, command-exec tool registration,
-  optional approval bridge (`task.action.approve` / `deny`).
+- **Done (Track B Phase 2a — host wire):** `ensureSession` / `session.create`,
+  `resolveCarinaSandboxFromEnv`, `registerCommandExecTool` (`command_exec`),
+  gateway `createGatewayCarinaBundle` on agent-runtime turns.
+- **Not yet built (Track B Phase 2b — #384):** optional approval bridge
+  (`task.action.approve` / `deny` + product UI), per-tenant workspace routing.
 - **Not deeply mapped:** model catalog manager, apply-patch grammar,
   compaction *generation* logic, tool_search discovery *mechanism*, hooks
   pipeline impl, web_search/image-gen handlers.

--- a/packages/ai/agent-runtime/README.md
+++ b/packages/ai/agent-runtime/README.md
@@ -6,7 +6,8 @@ Status: **Track A live (grammar + gateway demo); Track B Phase 1 docked**
 |-------|--------|
 | Track A grammar (`runTurn`, policy, rollout, tools) | Shipped; gateway demo route behind `agent-runtime-demo` |
 | Track B adapter (`createCarinaSandbox` → Carina JSON-RPC) | **Phase 1 done** ([#382](https://github.com/Nebutra/Nebutra-Sailor/pull/382)) |
-| Track B product wire (gateway inject, session, exec tool) | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
+| Track B host wire (env, ensureSession, `command_exec`, gateway bundle) | **Phase 2a done** |
+| Track B HITL / multi-tenant workspace routing | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
 | Default without Carina endpoint | **Fail-closed** (`REFUSING_SANDBOX`) |
 
 Multi-tenant **agent-runtime grammar**. A faithful re-expression of a terminal

--- a/packages/ai/agent-runtime/src/agent-runtime.test.ts
+++ b/packages/ai/agent-runtime/src/agent-runtime.test.ts
@@ -10,12 +10,18 @@ import {
   sanitizeForPersist,
 } from "./rollout";
 import {
+  COMMAND_EXEC_TOOL_NAME,
+  registerCommandExecTool,
+} from "./command-exec";
+import {
   assertSafePosture,
   CarinaProtocolError,
   createCarinaSandbox,
   createHttpSandbox,
+  isCarinaSandbox,
   NoExecutorConfiguredError,
   REFUSING_SANDBOX,
+  resolveCarinaSandboxFromEnv,
   SandboxDelegationError,
 } from "./sandbox";
 import { ToolRegistry } from "./tools";
@@ -286,5 +292,140 @@ describe("tools", () => {
     await expect(
       reg.dispatch("echo", { v: 1 }, { tenantId: "t1", threadId: "th" }),
     ).rejects.toBeTruthy();
+  });
+});
+
+
+describe("Carina Phase 2 host helpers", () => {
+  it("resolveCarinaSandboxFromEnv fails closed without URL", () => {
+    expect(resolveCarinaSandboxFromEnv({})).toBe(REFUSING_SANDBOX);
+    expect(resolveCarinaSandboxFromEnv({ CARINA_JSONRPC_URL: "   " })).toBe(REFUSING_SANDBOX);
+  });
+
+  it("resolveCarinaSandboxFromEnv builds a Carina sandbox when URL is set", () => {
+    const sandbox = resolveCarinaSandboxFromEnv({
+      CARINA_JSONRPC_URL: "http://127.0.0.1:7420/jsonrpc",
+      CARINA_JSONRPC_TOKEN: "gw1_test",
+    });
+    expect(isCarinaSandbox(sandbox)).toBe(true);
+  });
+
+  it("ensureSession caches session_id and command.exec uses it", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      bodies.push(body);
+      if (body.method === "gateway.hello") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocol_version: 1 } }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "session.create") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: { id: "carina_sess_99", status: "active" },
+          }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "command.exec") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              decision: { decision: "allowed", decision_id: "d1" },
+              result: { exit_code: 0, stdout: ["ok\n"], stderr: [] },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: body.id, error: { code: -32601, message: "no" } }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const sandbox = createCarinaSandbox({
+      baseUrl: "http://carina.local",
+      fetchImpl: fakeFetch,
+    });
+
+    const sid1 = await sandbox.ensureSession({
+      threadId: "thread_a",
+      workspaceRoot: "/work/repo",
+      tenantId: "org_a",
+    });
+    expect(sid1).toBe("carina_sess_99");
+    // second call is cached — no extra session.create
+    const sid2 = await sandbox.ensureSession({
+      threadId: "thread_a",
+      workspaceRoot: "/work/repo",
+    });
+    expect(sid2).toBe("carina_sess_99");
+    expect(bodies.filter((b) => b.method === "session.create")).toHaveLength(1);
+
+    const result = await sandbox.exec({
+      tenantId: "org_a",
+      threadId: "thread_a",
+      command: "echo ok",
+      capabilityPolicy: DEFAULT_CAPABILITY_POLICY,
+    });
+    expect(result.exitCode).toBe(0);
+    const exec = bodies.find((b) => b.method === "command.exec");
+    expect((exec?.params as { session_id: string }).session_id).toBe("carina_sess_99");
+  });
+
+  it("registerCommandExecTool ensures session then execs", async () => {
+    const methods: string[] = [];
+    const fakeFetch = (async (_i: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string; id?: number };
+      methods.push(body.method ?? "");
+      if (body.method === "gateway.hello") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocol_version: 1 } }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "session.create") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { session_id: "s_42" } }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "command.exec") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              decision: { decision: "allowed" },
+              result: { exit_code: 0, stdout: ["done"], stderr: [] },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const sandbox = createCarinaSandbox({ baseUrl: "http://c", fetchImpl: fakeFetch });
+    const reg = new ToolRegistry();
+    registerCommandExecTool(reg, { sandbox, workspaceRoot: "/tmp/ws" });
+    expect(reg.list().map((t) => t.definition.name)).toContain(COMMAND_EXEC_TOOL_NAME);
+
+    const out = (await reg.dispatch(
+      COMMAND_EXEC_TOOL_NAME,
+      { command: "true" },
+      { tenantId: "org", threadId: "th1" },
+    )) as { exitCode: number; executedOn: string };
+
+    expect(out.exitCode).toBe(0);
+    expect(out.executedOn).toBe("carina");
+    expect(methods).toEqual(["gateway.hello", "session.create", "command.exec"]);
   });
 });

--- a/packages/ai/agent-runtime/src/command-exec.ts
+++ b/packages/ai/agent-runtime/src/command-exec.ts
@@ -1,0 +1,114 @@
+/**
+ * Native command-exec tool that delegates to {@link ExternalSandbox}.
+ * Product Track B: pair with {@link createCarinaSandbox} + ensureSession.
+ */
+
+import { z } from "zod";
+
+import { DEFAULT_CAPABILITY_POLICY, type CapabilityPolicy } from "./policy";
+import {
+  isCarinaSandbox,
+  type ExternalSandbox,
+  type SandboxExecResult,
+} from "./sandbox";
+import { RuntimeToolRegistry } from "./tools";
+
+export const COMMAND_EXEC_TOOL_NAME = "command_exec" as const;
+
+const commandExecInputSchema = z.object({
+  command: z.string().min(1),
+});
+
+export type CommandExecToolInput = z.infer<typeof commandExecInputSchema>;
+
+export type CommandExecToolOutput = {
+  readonly exitCode: number;
+  readonly aggregatedOutput: string;
+  readonly executedOn: string;
+  readonly decisionId?: string;
+};
+
+export type RegisterCommandExecToolOptions = {
+  readonly sandbox: ExternalSandbox;
+  /**
+   * Absolute workspace on the Carina host. Required when sandbox is Carina
+   * (session.create). Gateway reads `CARINA_WORKSPACE_ROOT`.
+   */
+  readonly workspaceRoot?: string;
+  readonly capabilityPolicy?: CapabilityPolicy;
+  readonly profile?: string;
+  readonly approvalMode?: string;
+};
+
+/**
+ * Register `command_exec` on a tool registry. For Carina sandboxes, ensures a
+ * session for the turn thread before `command.exec`.
+ */
+export function registerCommandExecTool(
+  registry: RuntimeToolRegistry,
+  options: RegisterCommandExecToolOptions,
+): void {
+  const {
+    sandbox,
+    workspaceRoot,
+    capabilityPolicy = DEFAULT_CAPABILITY_POLICY,
+    profile,
+    approvalMode,
+  } = options;
+
+  registry.register(
+    {
+      name: COMMAND_EXEC_TOOL_NAME,
+      description:
+        "Run a shell command in the external sandbox (Carina Track B). " +
+        "Never executes in the Sailor web process.",
+      inputSchema: commandExecInputSchema,
+    },
+    async (input, ctx): Promise<CommandExecToolOutput> => {
+      if (isCarinaSandbox(sandbox)) {
+        const root = workspaceRoot?.trim();
+        if (!root) {
+          throw new Error(
+            "command_exec: CARINA_WORKSPACE_ROOT / workspaceRoot required " +
+              "to create a Carina session before command.exec",
+          );
+        }
+        await sandbox.ensureSession({
+          threadId: ctx.threadId,
+          workspaceRoot: root,
+          tenantId: ctx.tenantId,
+          ...(profile ? { profile } : {}),
+          ...(approvalMode ? { approvalMode } : {}),
+        });
+      }
+
+      const result: SandboxExecResult = await sandbox.exec({
+        tenantId: ctx.tenantId,
+        threadId: ctx.threadId,
+        command: input.command,
+        capabilityPolicy,
+      });
+
+      return {
+        exitCode: result.exitCode,
+        aggregatedOutput: result.aggregatedOutput,
+        executedOn: result.executedOn,
+        ...(result.decisionId !== undefined ? { decisionId: result.decisionId } : {}),
+      };
+    },
+  );
+}
+
+/**
+ * Build a registry that includes `command_exec` delegated to the given sandbox.
+ * Prefer this only when a real isolator is configured; with
+ * {@link REFUSING_SANDBOX} the tool will throw NoExecutorConfiguredError on use.
+ */
+export function buildSandboxToolRegistry(
+  sandbox: ExternalSandbox,
+  options: Omit<RegisterCommandExecToolOptions, "sandbox"> = {},
+): RuntimeToolRegistry {
+  const registry = new RuntimeToolRegistry();
+  registerCommandExecTool(registry, { sandbox, ...options });
+  return registry;
+}

--- a/packages/ai/agent-runtime/src/index.ts
+++ b/packages/ai/agent-runtime/src/index.ts
@@ -8,14 +8,15 @@
  * untrusted-code execution.
  *
  * Track A (this package): policy + protocol + model + rollout, all tenant-scoped.
- * Track B (decoupled, not this repo): an optional isolator/kernel sidecar that
- * implements {@link ExternalSandbox} over the ./protocol contract.
+ * Track B (Carina upstream): self-deployed kernel docked via {@link createCarinaSandbox};
+ * product wire (gateway inject / session / command_exec) tracked in Nebutra-Sailor#384.
  */
 
 export * from "./artifact-stream";
 export * from "./channel-gateway";
 export * from "./code-review";
 export * from "./command-suggestions";
+export * from "./command-exec";
 export * from "./commands";
 export * from "./commit-message";
 export * from "./context-compaction";

--- a/packages/ai/agent-runtime/src/sandbox.ts
+++ b/packages/ai/agent-runtime/src/sandbox.ts
@@ -198,20 +198,61 @@ export type CarinaSandboxOptions = {
   readonly clientId?: string;
 };
 
+export type CarinaEnsureSessionRequest = {
+  /** Sailor thread id — used as cache key and default correlation. */
+  readonly threadId: string;
+  /** Absolute workspace path on the Carina host (catalog-required). */
+  readonly workspaceRoot: string;
+  readonly tenantId?: string;
+  readonly profile?: string;
+  /** Carina session approval_mode when supported by the daemon. */
+  readonly approvalMode?: string;
+};
+
+/**
+ * Track-B handle: {@link ExternalSandbox} plus host session lifecycle.
+ * `command.exec` requires a Carina session; call {@link CarinaSandbox.ensureSession}
+ * before the first exec for a thread (or let {@link registerCommandExecTool} do it).
+ */
+export interface CarinaSandbox extends ExternalSandbox {
+  /**
+   * Create (or reuse cached) Carina session for a Sailor thread.
+   * Maps `threadId` → Carina `session_id` for subsequent `command.exec`.
+   */
+  ensureSession(request: CarinaEnsureSessionRequest): Promise<string>;
+  /** Peek cached Carina session id for a Sailor thread, if any. */
+  resolveMappedSessionId(threadId: string): string | undefined;
+}
+
+function extractCarinaSessionId(session: unknown): string {
+  if (!session || typeof session !== "object") {
+    throw new CarinaProtocolError("Carina session.create returned non-object Session");
+  }
+  const rec = session as Record<string, unknown>;
+  for (const key of ["id", "session_id", "sessionId"] as const) {
+    const v = rec[key];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  throw new CarinaProtocolError(
+    "Carina session.create Session missing id/session_id/sessionId",
+  );
+}
+
 /**
  * Track-B adapter: Sailor control plane → **Carina** public RPC catalog (v0.8.1+).
  *
  * Mapping (Sailor → Carina, never the reverse ownership):
- * - `threadId` → `command.exec` `session_id` (session must exist in Carina)
+ * - `threadId` → `command.exec` `session_id` (via ensureSession cache, else threadId)
  * - `command` → `argv` via `/bin/sh -c` (kernel still gates the joined command string)
  * - denied / requires_approval → {@link SandboxDelegationError} (fail closed)
  * - allowed + CommandResult → {@link SandboxExecResult}
+ * - host lifecycle → `session.create` via {@link CarinaSandbox.ensureSession}
  *
  * Kernel protocol is maintained in `Nebutra/carina`. This file only maps.
  *
  * @see docs/architecture/2026-08-03-carina-track-b-upstream.md
  */
-export function createCarinaSandbox(options: CarinaSandboxOptions): ExternalSandbox {
+export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbox {
   const {
     baseUrl,
     token,
@@ -220,9 +261,12 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): ExternalSand
     minProtocolVersion = CARINA_MIN_PROTOCOL_VERSION,
     skipHello = false,
     executedOn = "carina",
-    resolveSessionId = (r) => r.threadId,
+    resolveSessionId,
     clientId = "nebutra-sailor",
   } = options;
+
+  /** Sailor threadId → Carina session_id */
+  const sessionByThread = new Map<string, string>();
 
   const endpoint = `${baseUrl.replace(/\/$/, "")}${
     !rpcPath ? "" : rpcPath.startsWith("/") ? rpcPath : `/${rpcPath}`
@@ -292,13 +336,47 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): ExternalSand
     await helloDone;
   }
 
+  const defaultResolveSessionId = (r: SandboxExecRequest): string =>
+    sessionByThread.get(r.threadId) ?? r.threadId;
+  const mapSessionId = resolveSessionId ?? defaultResolveSessionId;
+
   return {
+    resolveMappedSessionId(threadId: string): string | undefined {
+      return sessionByThread.get(threadId);
+    },
+
+    async ensureSession(request: CarinaEnsureSessionRequest): Promise<string> {
+      const cached = sessionByThread.get(request.threadId);
+      if (cached) return cached;
+
+      const root = request.workspaceRoot.trim();
+      if (!root) {
+        throw new CarinaProtocolError(
+          "Carina session.create requires a non-empty workspaceRoot",
+        );
+      }
+
+      await ensureHello();
+
+      const params: Record<string, unknown> = { workspace_root: root };
+      if (request.profile) params.profile = request.profile;
+      if (request.approvalMode) params.approval_mode = request.approvalMode;
+      // Audit hint only — not a privilege grant (cloud boundary).
+      if (request.tenantId) params.tenant_id = request.tenantId;
+      params.correlation_id = request.threadId;
+
+      const session = await rpcCall<unknown>("session.create", params);
+      const sessionId = extractCarinaSessionId(session);
+      sessionByThread.set(request.threadId, sessionId);
+      return sessionId;
+    },
+
     async exec(request: SandboxExecRequest): Promise<SandboxExecResult> {
       assertSafePosture(request.capabilityPolicy);
 
       await ensureHello();
 
-      const sessionId = resolveSessionId(request);
+      const sessionId = mapSessionId(request);
       const argv = ["/bin/sh", "-c", request.command];
       const wire = await rpcCall<CarinaExecWire>("command.exec", {
         session_id: sessionId,
@@ -361,3 +439,44 @@ export function assertSafePosture(policy: CapabilityPolicy, allowDanger = false)
     );
   }
 }
+
+
+// ── Env resolution + command-exec tool (Phase 2 host helpers) ────────────────
+
+export type CarinaEnv = {
+  readonly CARINA_JSONRPC_URL?: string;
+  readonly CARINA_JSONRPC_TOKEN?: string;
+  readonly CARINA_JSONRPC_PATH?: string;
+  readonly CARINA_WORKSPACE_ROOT?: string;
+  readonly CARINA_CLIENT_ID?: string;
+};
+
+/**
+ * Resolve Track-B sandbox from environment.
+ * - `CARINA_JSONRPC_URL` set → {@link createCarinaSandbox}
+ * - unset / empty → {@link REFUSING_SANDBOX} (fail closed)
+ */
+export function resolveCarinaSandboxFromEnv(
+  env: CarinaEnv = process.env as CarinaEnv,
+  overrides: Partial<CarinaSandboxOptions> = {},
+): ExternalSandbox {
+  const baseUrl = env.CARINA_JSONRPC_URL?.trim();
+  if (!baseUrl) return REFUSING_SANDBOX;
+
+  const options: CarinaSandboxOptions = {
+    baseUrl,
+    ...(env.CARINA_JSONRPC_TOKEN ? { token: env.CARINA_JSONRPC_TOKEN } : {}),
+    ...(env.CARINA_JSONRPC_PATH ? { rpcPath: env.CARINA_JSONRPC_PATH } : {}),
+    ...(env.CARINA_CLIENT_ID ? { clientId: env.CARINA_CLIENT_ID } : {}),
+    ...overrides,
+  };
+  return createCarinaSandbox(options);
+}
+
+export function isCarinaSandbox(sandbox: ExternalSandbox): sandbox is CarinaSandbox {
+  return (
+    typeof (sandbox as CarinaSandbox).ensureSession === "function" &&
+    typeof (sandbox as CarinaSandbox).resolveMappedSessionId === "function"
+  );
+}
+

--- a/packages/ai/agent-runtime/tsup.config.ts
+++ b/packages/ai/agent-runtime/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "adapters/dispatcher-sse": "src/adapters/dispatcher-sse.ts",
     "adapters/mcp-catalog": "src/adapters/mcp-catalog.ts",
     "adapters/prisma-rollout": "src/adapters/prisma-rollout.ts",
+    "command-exec": "src/command-exec.ts",
     commands: "src/commands.ts",
     cli: "src/cli.ts",
     definitions: "src/definitions.ts",


### PR DESCRIPTION
## Summary

Continues Carina Track-B **收口** after #382 / #385: host-side wire so a self-deployed daemon can actually run commands when env is set.

### Package (`@nebutra/agent-runtime`)
- `CarinaSandbox.ensureSession` → catalog `session.create`, caches Sailor `threadId` → Carina `session_id`
- `resolveCarinaSandboxFromEnv` / `isCarinaSandbox` — fail-closed without `CARINA_JSONRPC_URL`
- `registerCommandExecTool` / `command_exec` — ensure session then `sandbox.exec`
- Tests for env, session cache, and tool path

### Gateway
- `createGatewayCarinaBundle()` — when URL set, registers `command_exec`; otherwise empty tools + refuse sandbox
- Agent-runtime SSE turn route uses the bundle

### Ops env
| Var | Role |
|-----|------|
| `CARINA_JSONRPC_URL` | Enable Track B |
| `CARINA_JSONRPC_TOKEN` | Product/gateway Bearer (not owner unlock) |
| `CARINA_JSONRPC_PATH` | Optional RPC path |
| `CARINA_WORKSPACE_ROOT` | Absolute path on Carina host for `session.create` |

### Still open (#384 Phase 2b)
- Approval UI + `task.action.approve` / `deny`
- Per-tenant workspace routing beyond a single `CARINA_WORKSPACE_ROOT`

## Test plan
- [x] `vitest` agent-runtime (21) green
- [x] gateway `carina-sandbox.test.ts` (2) green
- [ ] Operator smoke: self-deploy Carina + set env + call `/api/v1/agent-runtime/turns` with a model that requests `command_exec`

Closes inject/session/tool portion of #384.