### PR TITLE
feat(agent-runtime): ship Carina Phase 2b (approval, workspace, ops)

### DIFF
--- a/backends/gateway/.env.example
+++ b/backends/gateway/.env.example
@@ -134,6 +134,23 @@ FEATURE_FLAG_BILLING=true
 AGENT_ROLLOUT_DURABLE=false
 
 # ──────────────────────────────────────────────────────────────────────────
+# Carina Track B (self-deployed daemon — optional)
+# ──────────────────────────────────────────────────────────────────────────
+# Enable agent-runtime turns:
+#   FEATURE_FLAG_AGENT_RUNTIME_DEMO=true
+#   (or KILL_SWITCH_AGENT_RUNTIME_DEMO=true)
+CARINA_JSONRPC_URL=
+CARINA_JSONRPC_TOKEN=
+CARINA_JSONRPC_PATH=
+CARINA_WORKSPACE_ROOT=
+# CARINA_WORKSPACE_TEMPLATE=/var/carina/ws/{tenantId}
+# CARINA_WORKSPACE_MAP={"org_demo":"/var/carina/ws/demo"}
+CARINA_SESSION_APPROVAL_MODE=
+# CARINA_AUTO_APPROVE=1
+CARINA_CLIENT_ID=nebutra-sailor
+FEATURE_FLAG_AGENT_RUNTIME_DEMO=false
+
+# ──────────────────────────────────────────────────────────────────────────
 # China SMS providers
 # ──────────────────────────────────────────────────────────────────────────
 ALIYUN_SMS_ACCESS_KEY_ID=

--- a/backends/gateway/src/lib/agent-run.ts
+++ b/backends/gateway/src/lib/agent-run.ts
@@ -10,7 +10,6 @@ import {
   PersistentRolloutStore,
   type RolloutStore,
   runTurn,
-  ToolRegistry,
   type TurnConfig,
 } from "@nebutra/agent-runtime";
 import {
@@ -22,6 +21,7 @@ import { createAgentContext } from "@nebutra/agents";
 import { getTenantDb } from "@nebutra/db";
 import { logger } from "@nebutra/logger";
 import { getGatewayOrchestrator } from "../agents/orchestrator-singleton.js";
+import { createGatewayCarinaBundle } from "./carina-sandbox.js";
 
 /** Automation runs are durable: rollout lines persist for replay/debugging. */
 function durableRolloutStore(): RolloutStore {
@@ -48,9 +48,9 @@ export interface AgentTurnResult {
 }
 
 /**
- * Run a single agent turn to completion. Tools are an empty registry (text-only
- * research/synthesis on tenant-scoped data); any approval request auto-denies so
- * an automated run never stalls waiting for a human.
+ * Run a single agent turn to completion. Tools include `command_exec` when
+ * Carina is configured; Sailor ApprovalGate auto-denies so automation never
+ * stalls on product HITL (use CARINA_AUTO_APPROVE or /carina/approvals for kernel).
  */
 export async function runAgentTurn(opts: AgentTurnInput): Promise<AgentTurnResult> {
   const orch = getGatewayOrchestrator();
@@ -96,7 +96,10 @@ export async function runAgentTurn(opts: AgentTurnInput): Promise<AgentTurnResul
       config,
       approvalPolicy: { kind: "on_request" },
       model,
-      tools: new ToolRegistry(),
+      tools: createGatewayCarinaBundle(process.env, {
+        tenantId: opts.tenantId,
+        threadId: opts.threadId,
+      }).tools,
       store: durableRolloutStore(),
       approvalGate: {
         async request() {

--- a/backends/gateway/src/lib/carina-sandbox.test.ts
+++ b/backends/gateway/src/lib/carina-sandbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { REFUSING_SANDBOX, isCarinaSandbox } from "@nebutra/agent-runtime";
-import { createGatewayCarinaBundle } from "./carina-sandbox.js";
+import { createGatewayCarinaBundle, getCarinaSandbox } from "./carina-sandbox.js";
 
 describe("createGatewayCarinaBundle", () => {
   it("fails closed with empty tools when Carina URL is unset", () => {
@@ -11,12 +11,41 @@ describe("createGatewayCarinaBundle", () => {
   });
 
   it("registers command_exec when CARINA_JSONRPC_URL is set", () => {
-    const bundle = createGatewayCarinaBundle({
-      CARINA_JSONRPC_URL: "http://127.0.0.1:7420/jsonrpc",
-      CARINA_WORKSPACE_ROOT: "/var/carina/ws",
-    });
+    const bundle = createGatewayCarinaBundle(
+      {
+        CARINA_JSONRPC_URL: "http://127.0.0.1:7420/jsonrpc",
+        CARINA_WORKSPACE_ROOT: "/var/carina/ws",
+      },
+      { tenantId: "org_a", threadId: "th1" },
+    );
     expect(bundle.carinaEnabled).toBe(true);
     expect(isCarinaSandbox(bundle.sandbox)).toBe(true);
+    expect(bundle.workspaceRoot).toBe("/var/carina/ws");
     expect(bundle.tools.list().map((t) => t.definition.name)).toEqual(["command_exec"]);
+  });
+
+  it("resolves per-tenant workspace from map and template", () => {
+    const mapped = createGatewayCarinaBundle(
+      {
+        CARINA_JSONRPC_URL: "http://c",
+        CARINA_WORKSPACE_MAP: JSON.stringify({ org_a: "/tenants/a" }),
+        CARINA_WORKSPACE_ROOT: "/fallback",
+      },
+      { tenantId: "org_a" },
+    );
+    expect(mapped.workspaceRoot).toBe("/tenants/a");
+
+    const templated = createGatewayCarinaBundle(
+      {
+        CARINA_JSONRPC_URL: "http://c",
+        CARINA_WORKSPACE_TEMPLATE: "/ws/{tenantId}/{threadId}",
+      },
+      { tenantId: "org_b", threadId: "t9" },
+    );
+    expect(templated.workspaceRoot).toBe("/ws/org_b/t9");
+  });
+
+  it("getCarinaSandbox returns null when disabled", () => {
+    expect(getCarinaSandbox({})).toBeNull();
   });
 });

--- a/backends/gateway/src/lib/carina-sandbox.ts
+++ b/backends/gateway/src/lib/carina-sandbox.ts
@@ -2,14 +2,17 @@
  * Gateway Track-B wiring — resolve Carina from env and attach command_exec.
  *
  * Env (operator / self-deployed daemon):
- *   CARINA_JSONRPC_URL       HTTP JSON-RPC base (required to enable)
- *   CARINA_JSONRPC_TOKEN     product/gateway Bearer (never local owner unlock)
- *   CARINA_JSONRPC_PATH      optional path under base (e.g. /jsonrpc)
- *   CARINA_WORKSPACE_ROOT    absolute path on Carina host for session.create
- *   CARINA_CLIENT_ID         optional hello client_id
+ *   CARINA_JSONRPC_URL            HTTP JSON-RPC base (required to enable)
+ *   CARINA_JSONRPC_TOKEN          product/gateway Bearer (never local owner unlock)
+ *   CARINA_JSONRPC_PATH           optional path under base (e.g. /jsonrpc)
+ *   CARINA_WORKSPACE_ROOT         default absolute path on Carina host
+ *   CARINA_WORKSPACE_TEMPLATE     e.g. /var/carina/ws/{tenantId}
+ *   CARINA_WORKSPACE_MAP          JSON {"org_x":"/path"}
+ *   CARINA_SESSION_APPROVAL_MODE  passed to session.create (e.g. always-approve)
+ *   CARINA_AUTO_APPROVE           1|true → auto resolve requires_approval once
+ *   CARINA_CLIENT_ID              optional hello client_id
  *
- * Fail-closed: without CARINA_JSONRPC_URL, returns REFUSING_SANDBOX and an
- * empty tool registry (no command_exec surface).
+ * Fail-closed: without CARINA_JSONRPC_URL → REFUSING_SANDBOX + empty tools.
  */
 
 import {
@@ -17,6 +20,8 @@ import {
   isCarinaSandbox,
   registerCommandExecTool,
   resolveCarinaSandboxFromEnv,
+  resolveCarinaWorkspaceRoot,
+  type CarinaSandbox,
   type ExternalSandbox,
 } from "@nebutra/agent-runtime";
 
@@ -25,32 +30,54 @@ export type GatewayCarinaBundle = {
   readonly tools: RuntimeToolRegistry;
   /** True when CARINA_JSONRPC_URL is set (sandbox is Carina, not refuse stub). */
   readonly carinaEnabled: boolean;
+  readonly workspaceRoot?: string;
 };
 
 /**
  * Build sandbox + tools for an agent-runtime turn.
- * Pure enough to unit-test with a synthetic env map.
+ * Workspace is resolved per tenant (map → template → root).
  */
 export function createGatewayCarinaBundle(
   env: NodeJS.ProcessEnv = process.env,
+  opts: { readonly tenantId?: string; readonly threadId?: string } = {},
 ): GatewayCarinaBundle {
   const sandbox = resolveCarinaSandboxFromEnv(env);
   const tools = new RuntimeToolRegistry();
   const carinaEnabled = isCarinaSandbox(sandbox);
 
+  let workspaceRoot: string | undefined;
   if (carinaEnabled) {
-    const workspaceRoot = env.CARINA_WORKSPACE_ROOT?.trim();
+    workspaceRoot = resolveCarinaWorkspaceRoot(
+      opts.tenantId ?? "_default",
+      env,
+      opts.threadId ?? "",
+    );
+    const approvalMode = env.CARINA_SESSION_APPROVAL_MODE?.trim();
     registerCommandExecTool(tools, {
       sandbox,
       ...(workspaceRoot ? { workspaceRoot } : {}),
+      ...(approvalMode ? { approvalMode } : {}),
     });
   }
 
-  return { sandbox, tools, carinaEnabled };
+  return {
+    sandbox,
+    tools,
+    carinaEnabled,
+    ...(workspaceRoot ? { workspaceRoot } : {}),
+  };
 }
 
 export function gatewaySandboxOrRefuse(
   env: NodeJS.ProcessEnv = process.env,
 ): ExternalSandbox {
   return resolveCarinaSandboxFromEnv(env);
+}
+
+/** Narrow helper for routes that need Carina-only methods. */
+export function getCarinaSandbox(
+  env: NodeJS.ProcessEnv = process.env,
+): CarinaSandbox | null {
+  const sandbox = resolveCarinaSandboxFromEnv(env);
+  return isCarinaSandbox(sandbox) ? sandbox : null;
 }

--- a/backends/gateway/src/routes/agent-runtime/index.ts
+++ b/backends/gateway/src/routes/agent-runtime/index.ts
@@ -3,18 +3,13 @@
  *
  * Connects the absorbed runtime grammar into the gateway: a tenant-scoped
  * turn driven by `runTurn`, streamed to the client over SSE. Gated by the
- * off-by-default `agent-runtime-demo` feature flag and `requireAuth`.
+ * off-by-default `agent-runtime-demo` feature flag and `requireAuth`
+ * (enable with FEATURE_FLAG_AGENT_RUNTIME_DEMO=true or KILL_SWITCH_…).
  *
- * Honest scope:
- *  - ModelInvoker is a thin bridge over `@nebutra/agents` (real model stack;
- *    no provider re-port).
- *  - ApprovalGate is fail-closed (auto-denies prompts) — human-in-the-loop
- *    transport is future work; unapproved tools are never dispatched.
- *  - Track B (Carina): `createGatewayCarinaBundle()` reads CARINA_JSONRPC_URL.
- *    When set, registers `command_exec` → createCarinaSandbox + session.create
- *    (needs CARINA_WORKSPACE_ROOT). When unset, empty tools + fail-closed.
- *    Approval bridge (task.action.approve) still open — see #384.
- *  - RolloutStore: in-memory by default; AGENT_ROLLOUT_DURABLE=1 → Postgres.
+ * Track B (Carina):
+ *  - `createGatewayCarinaBundle({ tenantId, threadId })` when CARINA_JSONRPC_URL
+ *  - `GET  /carina/status`     connectivity probe (auth; no demo flag)
+ *  - `POST /carina/approvals`  governance.approval.resolve bridge (auth)
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
@@ -36,20 +31,21 @@ import { getTenantDb } from "@nebutra/db";
 import { FLAGS, featureFlagMiddleware } from "@nebutra/feature-flags";
 import { streamSSE } from "hono/streaming";
 import { getGatewayOrchestrator } from "../../agents/orchestrator-singleton.js";
-import { createGatewayCarinaBundle } from "../../lib/carina-sandbox.js";
+import {
+  createGatewayCarinaBundle,
+  getCarinaSandbox,
+} from "../../lib/carina-sandbox.js";
 import { requireAuth } from "../../middlewares/tenantContext.js";
 
 export const agentRuntimeRoutes = new OpenAPIHono();
 
 agentRuntimeRoutes.use("*", requireAuth);
-agentRuntimeRoutes.use("*", featureFlagMiddleware(FLAGS.AGENT_RUNTIME_DEMO));
+// Demo flag only for turns — carina/status + approvals stay operator-reachable.
+agentRuntimeRoutes.use("/turns", featureFlagMiddleware(FLAGS.AGENT_RUNTIME_DEMO));
 
 /**
  * Rollout store selector. Default = process-local in-memory. The durable
- * Postgres system-of-record is opt-in via `AGENT_ROLLOUT_DURABLE=1` and
- * requires the migration applied + Prisma client regenerated (see ADR
- * 2026-05-19). The cast bridges the not-yet-regenerated client without
- * faking durability: when off, durability is simply not claimed.
+ * Postgres system-of-record is opt-in via `AGENT_ROLLOUT_DURABLE=1`.
  */
 function rolloutStore(): RolloutStore {
   if (process.env.AGENT_ROLLOUT_DURABLE !== "1") {
@@ -61,6 +57,13 @@ function rolloutStore(): RolloutStore {
       return (db as unknown as { agentRolloutLine: PrismaRolloutDelegate }).agentRolloutLine;
     }),
   );
+}
+
+function tenantFrom(c: { get: (k: string) => unknown }): {
+  organizationId?: string;
+  userId?: string;
+} {
+  return c.get("tenant") as { organizationId?: string; userId?: string };
 }
 
 /** Thin bridge: one round = the orchestrator's reply as a single text item. */
@@ -88,6 +91,135 @@ function modelInvoker(
     },
   };
 }
+
+// ── Carina ops (auth only — no demo flag so operators can probe) ─────────────
+
+const carinaStatusRoute = createRoute({
+  method: "get",
+  path: "/carina/status",
+  tags: ["Agent Runtime"],
+  operationId: "getCarinaStatus",
+  summary: "Probe Carina Track-B connectivity",
+  responses: {
+    200: {
+      description: "Carina configuration + optional hello probe",
+      content: {
+        "application/json": {
+          schema: z.object({
+            enabled: z.boolean(),
+            workspaceConfigured: z.boolean(),
+            autoApprove: z.boolean(),
+            protocolVersion: z.number().optional(),
+            error: z.string().optional(),
+          }),
+        },
+      },
+    },
+    401: { description: "Unauthenticated" },
+  },
+});
+
+agentRuntimeRoutes.openapi(carinaStatusRoute, async (c) => {
+  const env = process.env;
+  const enabled = Boolean(env.CARINA_JSONRPC_URL?.trim());
+  const workspaceConfigured = Boolean(
+    env.CARINA_WORKSPACE_ROOT?.trim() ||
+      env.CARINA_WORKSPACE_TEMPLATE?.trim() ||
+      env.CARINA_WORKSPACE_MAP?.trim(),
+  );
+  const autoApprove = env.CARINA_AUTO_APPROVE === "1" || env.CARINA_AUTO_APPROVE === "true";
+
+  if (!enabled) {
+    return c.json({ enabled: false, workspaceConfigured, autoApprove });
+  }
+
+  const sandbox = getCarinaSandbox(env);
+  if (!sandbox) {
+    return c.json({
+      enabled: false,
+      workspaceConfigured,
+      autoApprove,
+      error: "url set but sandbox resolve failed",
+    });
+  }
+
+  try {
+    const probe = await sandbox.probe();
+    return c.json({
+      enabled: true,
+      workspaceConfigured,
+      autoApprove,
+      protocolVersion: probe.protocolVersion,
+    });
+  } catch (err) {
+    return c.json({
+      enabled: true,
+      workspaceConfigured,
+      autoApprove,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+
+const carinaApprovalRoute = createRoute({
+  method: "post",
+  path: "/carina/approvals",
+  tags: ["Agent Runtime"],
+  operationId: "resolveCarinaApproval",
+  summary: "Approve or deny a Carina governance decision",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            decisionId: z.string().min(1),
+            approve: z.boolean(),
+            scope: z.enum(["once", "session", "project"]).optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Carina resolve result",
+      content: {
+        "application/json": {
+          schema: z.object({
+            ok: z.boolean(),
+            result: z.unknown().optional(),
+            error: z.string().optional(),
+          }),
+        },
+      },
+    },
+    401: { description: "Unauthenticated" },
+    503: { description: "Carina not configured" },
+  },
+});
+
+agentRuntimeRoutes.openapi(carinaApprovalRoute, async (c) => {
+  const sandbox = getCarinaSandbox();
+  if (!sandbox) {
+    return c.json({ ok: false, error: "Carina not configured (CARINA_JSONRPC_URL)" }, 503);
+  }
+  const tenant = tenantFrom(c);
+  const body = c.req.valid("json");
+  try {
+    const result = await sandbox.resolveApproval({
+      decisionId: body.decisionId,
+      approve: body.approve,
+      approver: tenant.userId ?? tenant.organizationId ?? "gateway",
+      ...(body.scope ? { scope: body.scope } : {}),
+    });
+    return c.json({ ok: true, result });
+  } catch (err) {
+    return c.json({
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
 
 // ── Route: start a turn, stream events over SSE ──────────────────────────────
 
@@ -131,11 +263,7 @@ agentRuntimeRoutes.openapi(turnRoute, async (c) => {
   const orch = getGatewayOrchestrator();
   if (!orch) return c.json({ error: "model stack unavailable" }, 503);
 
-  const tenant = c.get("tenant") as {
-    organizationId?: string;
-    userId?: string;
-    plan?: string;
-  };
+  const tenant = tenantFrom(c);
   const tenantId = tenant.organizationId;
   if (!tenantId) return c.json({ error: "organization scope required" }, 401);
 
@@ -148,7 +276,10 @@ agentRuntimeRoutes.openapi(turnRoute, async (c) => {
   };
 
   return streamSSE(c, async (stream) => {
-    const { tools } = createGatewayCarinaBundle();
+    const { tools } = createGatewayCarinaBundle(process.env, {
+      tenantId,
+      threadId: body.threadId,
+    });
     const events = runTurn(body.input, {
       tenantId,
       threadId: body.threadId,
@@ -159,6 +290,8 @@ agentRuntimeRoutes.openapi(turnRoute, async (c) => {
       store: rolloutStore(),
       approvalGate: {
         async request() {
+          // Product HITL UI not shipped; deny Sailor-side prompts. Carina
+          // kernel approvals use POST /carina/approvals or CARINA_AUTO_APPROVE.
           return { kind: "denied" };
         },
       },

--- a/docs/architecture/2026-08-03-carina-track-b-upstream.md
+++ b/docs/architecture/2026-08-03-carina-track-b-upstream.md
@@ -8,8 +8,9 @@ wiring) tracked in [Nebutra-Sailor#384](https://github.com/Nebutra/Nebutra-Sailo
 | Phase | Scope | State |
 |-------|--------|--------|
 | **1 — Dock** | `createCarinaSandbox` JSON-RPC map, fail-closed default, ADR, package tests | **Done** ([#382](https://github.com/Nebutra/Nebutra-Sailor/pull/382)) |
-| **2a — Host wire** | Env resolve, `session.create` / ensureSession, `command_exec` tool, gateway bundle | **Done** (this tree; closes inject+session+tool in #384) |
-| **2b — Product HITL** | Approval UI + `task.action.approve` / `deny`, multi-tenant workspace routing | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
+| **2a — Host wire** | Env resolve, `session.create` / ensureSession, `command_exec` tool, gateway bundle | **Done** (#386) |
+| **2b — Ship** | Workspace map/template, approval resolve API, auto-approve, status probe, ops script | **Done** (this change) |
+| **2c — Product UI** | Full product HITL surface (beyond API bridge) | Optional follow-up |
 
 ## Context
 
@@ -109,8 +110,9 @@ Do **not** vendor Carina source into this monorepo. Follow
 - Phase 2a: gateway `createGatewayCarinaBundle()` injects when
   `CARINA_JSONRPC_URL` is set; `command_exec` calls `ensureSession` then
   `command.exec`. Requires `CARINA_WORKSPACE_ROOT` on the Carina host.
-- Phase 2b (#384 remainder): human approval bridge and per-tenant workspace
-  routing remain open.
+- Phase 2b: `POST /api/v1/agent-runtime/carina/approvals`, workspace map/template,
+  `CARINA_AUTO_APPROVE`, `GET .../carina/status`, `configure-api-carina-env.sh`.
+- Phase 2c (optional): rich product approval UI beyond the API bridge.
 - Protocol breaks require Carina version bump + Sailor adapter pin update.
 - Approval UI bridge remains optional on top of the exec adapter.
 

--- a/docs/capabilities/agent-runtime/CAPABILITY_MAP.md
+++ b/docs/capabilities/agent-runtime/CAPABILITY_MAP.md
@@ -59,8 +59,9 @@
 - **Done (Track B Phase 2a — host wire):** `ensureSession` / `session.create`,
   `resolveCarinaSandboxFromEnv`, `registerCommandExecTool` (`command_exec`),
   gateway `createGatewayCarinaBundle` on agent-runtime turns.
-- **Not yet built (Track B Phase 2b — #384):** optional approval bridge
-  (`task.action.approve` / `deny` + product UI), per-tenant workspace routing.
+- **Done (Track B Phase 2b — ship):** workspace map/template, `resolveApproval`,
+  auto-approve retry, gateway `/carina/status` + `/carina/approvals`, ops env script.
+- **Optional (product UI):** rich HITL surface beyond the API bridge.
 - **Not deeply mapped:** model catalog manager, apply-patch grammar,
   compaction *generation* logic, tool_search discovery *mechanism*, hooks
   pipeline impl, web_search/image-gen handlers.

--- a/infra/ops/scripts/configure-api-carina-env.sh
+++ b/infra/ops/scripts/configure-api-carina-env.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Merge Carina Track-B env into ECS api-gateway env file and restart PM2.
+#
+# Run on the VM (or via SSH from CI):
+#   CARINA_JSONRPC_URL=http://127.0.0.1:7420/jsonrpc \
+#   CARINA_WORKSPACE_ROOT=/var/carina/ws \
+#   bash configure-api-carina-env.sh
+#
+# Optional:
+#   CARINA_JSONRPC_TOKEN, CARINA_JSONRPC_PATH, CARINA_WORKSPACE_TEMPLATE,
+#   CARINA_WORKSPACE_MAP, CARINA_SESSION_APPROVAL_MODE, CARINA_AUTO_APPROVE,
+#   CARINA_CLIENT_ID, ENABLE_AGENT_RUNTIME_DEMO=true
+#
+# Env file default: /var/www/nebutra/api/.env
+set -euo pipefail
+
+ENV_FILE="${API_ENV_FILE:-/var/www/nebutra/api/.env}"
+
+if [ -z "${CARINA_JSONRPC_URL:-}" ]; then
+  echo "CARINA_JSONRPC_URL is required" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$ENV_FILE")"
+touch "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+upsert() {
+  local key="$1" val="$2"
+  if grep -qE "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    local tmp
+    tmp="$(mktemp)"
+    awk -v k="$key" -v v="$val" 'BEGIN{FS=OFS="="} $1==k {$0=k"="v} {print}' "$ENV_FILE" >"$tmp"
+    mv "$tmp" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$val" >>"$ENV_FILE"
+  fi
+}
+
+upsert "CARINA_JSONRPC_URL" "$CARINA_JSONRPC_URL"
+[ -n "${CARINA_JSONRPC_TOKEN:-}" ] && upsert "CARINA_JSONRPC_TOKEN" "$CARINA_JSONRPC_TOKEN"
+[ -n "${CARINA_JSONRPC_PATH:-}" ] && upsert "CARINA_JSONRPC_PATH" "$CARINA_JSONRPC_PATH"
+[ -n "${CARINA_WORKSPACE_ROOT:-}" ] && upsert "CARINA_WORKSPACE_ROOT" "$CARINA_WORKSPACE_ROOT"
+[ -n "${CARINA_WORKSPACE_TEMPLATE:-}" ] && upsert "CARINA_WORKSPACE_TEMPLATE" "$CARINA_WORKSPACE_TEMPLATE"
+[ -n "${CARINA_WORKSPACE_MAP:-}" ] && upsert "CARINA_WORKSPACE_MAP" "$CARINA_WORKSPACE_MAP"
+[ -n "${CARINA_SESSION_APPROVAL_MODE:-}" ] && upsert "CARINA_SESSION_APPROVAL_MODE" "$CARINA_SESSION_APPROVAL_MODE"
+[ -n "${CARINA_AUTO_APPROVE:-}" ] && upsert "CARINA_AUTO_APPROVE" "$CARINA_AUTO_APPROVE"
+[ -n "${CARINA_CLIENT_ID:-}" ] && upsert "CARINA_CLIENT_ID" "$CARINA_CLIENT_ID"
+
+if [ "${ENABLE_AGENT_RUNTIME_DEMO:-true}" = "true" ]; then
+  upsert "FEATURE_FLAG_AGENT_RUNTIME_DEMO" "true"
+fi
+
+chmod 600 "$ENV_FILE"
+echo "Updated $ENV_FILE (Carina Track B)"
+
+if command -v pm2 >/dev/null 2>&1; then
+  pm2 restart api-gateway --update-env || pm2 restart api-gateway
+  pm2 save || true
+  echo "pm2 restarted api-gateway"
+else
+  echo "pm2 not found — restart api-gateway manually"
+fi

--- a/packages/ai/agent-runtime/README.md
+++ b/packages/ai/agent-runtime/README.md
@@ -6,8 +6,9 @@ Status: **Track A live (grammar + gateway demo); Track B Phase 1 docked**
 |-------|--------|
 | Track A grammar (`runTurn`, policy, rollout, tools) | Shipped; gateway demo route behind `agent-runtime-demo` |
 | Track B adapter (`createCarinaSandbox` → Carina JSON-RPC) | **Phase 1 done** ([#382](https://github.com/Nebutra/Nebutra-Sailor/pull/382)) |
-| Track B host wire (env, ensureSession, `command_exec`, gateway bundle) | **Phase 2a done** |
-| Track B HITL / multi-tenant workspace routing | **Open** ([#384](https://github.com/Nebutra/Nebutra-Sailor/issues/384)) |
+| Track B host wire (env, ensureSession, `command_exec`, gateway bundle) | **Phase 2a done** (#386) |
+| Track B ship (workspace map, approval resolve, auto-approve, status) | **Phase 2b done** |
+| Product HITL UI (beyond API) | Optional |
 | Default without Carina endpoint | **Fail-closed** (`REFUSING_SANDBOX`) |
 
 Multi-tenant **agent-runtime grammar**. A faithful re-expression of a terminal

--- a/packages/ai/agent-runtime/src/agent-runtime.test.ts
+++ b/packages/ai/agent-runtime/src/agent-runtime.test.ts
@@ -22,6 +22,7 @@ import {
   NoExecutorConfiguredError,
   REFUSING_SANDBOX,
   resolveCarinaSandboxFromEnv,
+  resolveCarinaWorkspaceRoot,
   SandboxDelegationError,
 } from "./sandbox";
 import { ToolRegistry } from "./tools";
@@ -427,5 +428,115 @@ describe("Carina Phase 2 host helpers", () => {
     expect(out.exitCode).toBe(0);
     expect(out.executedOn).toBe("carina");
     expect(methods).toEqual(["gateway.hello", "session.create", "command.exec"]);
+  });
+});
+
+
+describe("Carina workspace + approval", () => {
+  it("resolveCarinaWorkspaceRoot prefers map then template then root", () => {
+    expect(
+      resolveCarinaWorkspaceRoot("org_a", {
+        CARINA_WORKSPACE_MAP: JSON.stringify({ org_a: "/a" }),
+        CARINA_WORKSPACE_ROOT: "/root",
+      }),
+    ).toBe("/a");
+    expect(
+      resolveCarinaWorkspaceRoot("org_b", {
+        CARINA_WORKSPACE_TEMPLATE: "/ws/{tenantId}",
+        CARINA_WORKSPACE_ROOT: "/root",
+      }),
+    ).toBe("/ws/org_b");
+    expect(resolveCarinaWorkspaceRoot("x", { CARINA_WORKSPACE_ROOT: "/root" })).toBe("/root");
+    expect(resolveCarinaWorkspaceRoot("x", {})).toBeUndefined();
+  });
+
+  it("resolveApproval calls governance.approval.resolve", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const fakeFetch = (async (_i: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      bodies.push(body);
+      if (body.method === "gateway.hello") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocol_version: 1 } }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "governance.approval.resolve") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { resolved: true } }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const sandbox = createCarinaSandbox({ baseUrl: "http://c", fetchImpl: fakeFetch });
+    const result = await sandbox.resolveApproval({
+      decisionId: "dec_1",
+      approve: true,
+      scope: "once",
+      approver: "user_1",
+    });
+    expect(result).toEqual({ resolved: true });
+    expect(bodies.some((b) => b.method === "governance.approval.resolve")).toBe(true);
+  });
+
+  it("autoApproveOnRequire retries command.exec after resolve", async () => {
+    let execCount = 0;
+    const fakeFetch = (async (_i: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string; id?: number };
+      if (body.method === "gateway.hello") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocol_version: 1 } }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "governance.approval.resolve") {
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { ok: true } }),
+          { status: 200 },
+        );
+      }
+      if (body.method === "command.exec") {
+        execCount += 1;
+        if (execCount === 1) {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: body.id,
+              result: { decision: { decision: "requires_approval", decision_id: "d9" } },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              decision: { decision: "allowed", decision_id: "d9" },
+              result: { exit_code: 0, stdout: ["ok"], stderr: [] },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const sandbox = createCarinaSandbox({
+      baseUrl: "http://c",
+      fetchImpl: fakeFetch,
+      autoApproveOnRequire: true,
+      skipHello: false,
+    });
+    const result = await sandbox.exec({
+      tenantId: "t",
+      threadId: "s",
+      command: "echo ok",
+      capabilityPolicy: DEFAULT_CAPABILITY_POLICY,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(execCount).toBe(2);
   });
 });

--- a/packages/ai/agent-runtime/src/sandbox.ts
+++ b/packages/ai/agent-runtime/src/sandbox.ts
@@ -196,6 +196,12 @@ export type CarinaSandboxOptions = {
    * Optional client metadata sent on hello (discovery only — not an auth grant).
    */
   readonly clientId?: string;
+  /**
+   * When true, `command.exec` that returns `requires_approval` will call
+   * `governance.approval.resolve` (approve=true) once and retry. Default false
+   * (fail closed). Operators set via CARINA_AUTO_APPROVE=1 for unattended nodes.
+   */
+  readonly autoApproveOnRequire?: boolean;
 };
 
 export type CarinaEnsureSessionRequest = {
@@ -214,6 +220,13 @@ export type CarinaEnsureSessionRequest = {
  * `command.exec` requires a Carina session; call {@link CarinaSandbox.ensureSession}
  * before the first exec for a thread (or let {@link registerCommandExecTool} do it).
  */
+export type CarinaApprovalResolveRequest = {
+  readonly decisionId: string;
+  readonly approve: boolean;
+  readonly approver?: string;
+  readonly scope?: "once" | "session" | "project";
+};
+
 export interface CarinaSandbox extends ExternalSandbox {
   /**
    * Create (or reuse cached) Carina session for a Sailor thread.
@@ -222,6 +235,12 @@ export interface CarinaSandbox extends ExternalSandbox {
   ensureSession(request: CarinaEnsureSessionRequest): Promise<string>;
   /** Peek cached Carina session id for a Sailor thread, if any. */
   resolveMappedSessionId(threadId: string): string | undefined;
+  /**
+   * Host HITL: map product approve/deny → Carina `governance.approval.resolve`.
+   */
+  resolveApproval(request: CarinaApprovalResolveRequest): Promise<unknown>;
+  /** Lightweight connectivity probe (`gateway.hello`). */
+  probe(): Promise<{ protocolVersion: number; ok: true }>;
 }
 
 function extractCarinaSessionId(session: unknown): string {
@@ -263,6 +282,7 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
     executedOn = "carina",
     resolveSessionId,
     clientId = "nebutra-sailor",
+    autoApproveOnRequire = false,
   } = options;
 
   /** Sailor threadId → Carina session_id */
@@ -345,6 +365,31 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
       return sessionByThread.get(threadId);
     },
 
+    async probe(): Promise<{ protocolVersion: number; ok: true }> {
+      await ensureHello();
+      // hello already validated version; re-call for an explicit probe result
+      const hello = await rpcCall<CarinaHello>("gateway.hello", {
+        protocol_version: minProtocolVersion,
+        client_id: clientId,
+      });
+      return { protocolVersion: hello.protocol_version ?? minProtocolVersion, ok: true };
+    },
+
+    async resolveApproval(request: CarinaApprovalResolveRequest): Promise<unknown> {
+      const decisionId = request.decisionId.trim();
+      if (!decisionId) {
+        throw new CarinaProtocolError("resolveApproval requires decisionId");
+      }
+      await ensureHello();
+      const params: Record<string, unknown> = {
+        decision_id: decisionId,
+        approve: request.approve,
+      };
+      if (request.approver) params.approver = request.approver;
+      if (request.scope) params.scope = request.scope;
+      return rpcCall<unknown>("governance.approval.resolve", params);
+    },
+
     async ensureSession(request: CarinaEnsureSessionRequest): Promise<string> {
       const cached = sessionByThread.get(request.threadId);
       if (cached) return cached;
@@ -378,7 +423,7 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
 
       const sessionId = mapSessionId(request);
       const argv = ["/bin/sh", "-c", request.command];
-      const wire = await rpcCall<CarinaExecWire>("command.exec", {
+      let wire = await rpcCall<CarinaExecWire>("command.exec", {
         session_id: sessionId,
         argv,
         // Host correlation for audit — ignored if kernel drops unknown fields.
@@ -386,8 +431,8 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
         tenant_id: request.tenantId,
       });
 
-      const decision = wire.decision?.decision ?? "denied";
-      const decisionId = wire.decision?.decision_id;
+      let decision = wire.decision?.decision ?? "denied";
+      let decisionId = wire.decision?.decision_id;
 
       if (decision === "denied") {
         throw new SandboxDelegationError(
@@ -397,11 +442,46 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
         );
       }
       if (decision === "requires_approval") {
-        throw new SandboxDelegationError(
-          `Carina requires approval` + (decisionId ? ` (decision_id=${decisionId})` : ""),
-          409,
-          "requires_approval",
-        );
+        if (autoApproveOnRequire && decisionId) {
+          await rpcCall<unknown>("governance.approval.resolve", {
+            decision_id: decisionId,
+            approve: true,
+            scope: "once",
+            approver: clientId,
+          });
+          // Retry once after host auto-approve.
+          wire = await rpcCall<CarinaExecWire>("command.exec", {
+            session_id: sessionId,
+            argv,
+            correlation_id: `${request.tenantId}:${request.threadId}`,
+            tenant_id: request.tenantId,
+          });
+          const retryDecision = wire.decision?.decision ?? "denied";
+          if (retryDecision === "allowed") {
+            decision = "allowed";
+            decisionId = wire.decision?.decision_id ?? decisionId;
+            // fall through to result handling below
+          } else if (retryDecision === "denied") {
+            throw new SandboxDelegationError(
+              `Carina denied command after auto-approve: ${wire.decision?.reason ?? "denied"}`,
+              403,
+              "denied",
+            );
+          } else {
+            throw new SandboxDelegationError(
+              `Carina still requires approval after auto-approve` +
+                (wire.decision?.decision_id ? ` (decision_id=${wire.decision.decision_id})` : ""),
+              409,
+              "requires_approval",
+            );
+          }
+        } else {
+          throw new SandboxDelegationError(
+            `Carina requires approval` + (decisionId ? ` (decision_id=${decisionId})` : ""),
+            409,
+            "requires_approval",
+          );
+        }
       }
 
       const cr = wire.result;
@@ -448,8 +528,46 @@ export type CarinaEnv = {
   readonly CARINA_JSONRPC_TOKEN?: string;
   readonly CARINA_JSONRPC_PATH?: string;
   readonly CARINA_WORKSPACE_ROOT?: string;
+  /** JSON map tenantId → absolute workspace path on the Carina host. */
+  readonly CARINA_WORKSPACE_MAP?: string;
+  /** Template with `{tenantId}` / `{threadId}` placeholders. */
+  readonly CARINA_WORKSPACE_TEMPLATE?: string;
   readonly CARINA_CLIENT_ID?: string;
+  /** session.create approval_mode (e.g. always-approve, on_request). */
+  readonly CARINA_SESSION_APPROVAL_MODE?: string;
+  /** "1" / "true" → auto-approve requires_approval once and retry exec. */
+  readonly CARINA_AUTO_APPROVE?: string;
 };
+
+/**
+ * Resolve workspace path for a tenant/thread.
+ * Order: CARINA_WORKSPACE_MAP[tenant] → TEMPLATE → CARINA_WORKSPACE_ROOT.
+ */
+export function resolveCarinaWorkspaceRoot(
+  tenantId: string,
+  env: CarinaEnv = process.env as CarinaEnv,
+  threadId = "",
+): string | undefined {
+  const mapRaw = env.CARINA_WORKSPACE_MAP?.trim();
+  if (mapRaw) {
+    try {
+      const map = JSON.parse(mapRaw) as Record<string, unknown>;
+      const hit = map[tenantId];
+      if (typeof hit === "string" && hit.trim()) return hit.trim();
+    } catch {
+      // ignore bad JSON — fall through
+    }
+  }
+  const template = env.CARINA_WORKSPACE_TEMPLATE?.trim();
+  if (template) {
+    return template
+      .replaceAll("{tenantId}", tenantId)
+      .replaceAll("{threadId}", threadId)
+      .trim();
+  }
+  const root = env.CARINA_WORKSPACE_ROOT?.trim();
+  return root || undefined;
+}
 
 /**
  * Resolve Track-B sandbox from environment.
@@ -463,11 +581,15 @@ export function resolveCarinaSandboxFromEnv(
   const baseUrl = env.CARINA_JSONRPC_URL?.trim();
   if (!baseUrl) return REFUSING_SANDBOX;
 
+  const auto =
+    env.CARINA_AUTO_APPROVE === "1" || env.CARINA_AUTO_APPROVE === "true";
+
   const options: CarinaSandboxOptions = {
     baseUrl,
     ...(env.CARINA_JSONRPC_TOKEN ? { token: env.CARINA_JSONRPC_TOKEN } : {}),
     ...(env.CARINA_JSONRPC_PATH ? { rpcPath: env.CARINA_JSONRPC_PATH } : {}),
     ...(env.CARINA_CLIENT_ID ? { clientId: env.CARINA_CLIENT_ID } : {}),
+    ...(auto ? { autoApproveOnRequire: true } : {}),
     ...overrides,
   };
   return createCarinaSandbox(options);


### PR DESCRIPTION
## Summary

Phase 2b ship for Carina Track-B after #386 — make self-deployed daemon **operable in production**.

### Runtime
- Per-tenant workspace: `CARINA_WORKSPACE_MAP` → `TEMPLATE` → `ROOT`
- `resolveApproval` → Carina `governance.approval.resolve`
- `CARINA_AUTO_APPROVE=1` retries once after auto-resolve
- `probe()` / hello for connectivity

### Gateway
- `GET /api/v1/agent-runtime/carina/status` (auth, no demo flag)
- `POST /api/v1/agent-runtime/carina/approvals` (auth)
- Turns still gated by `FEATURE_FLAG_AGENT_RUNTIME_DEMO`
- Headless `agent-run` also gets `command_exec` when Carina enabled

### Ops
- `infra/ops/scripts/configure-api-carina-env.sh`
- `backends/gateway/.env.example` Carina block

### Enable on ECS
```bash
CARINA_JSONRPC_URL=http://127.0.0.1:7420/jsonrpc \\
CARINA_WORKSPACE_ROOT=/var/carina/ws \\
CARINA_AUTO_APPROVE=1 \\  # optional unattended
bash infra/ops/scripts/configure-api-carina-env.sh
# sets FEATURE_FLAG_AGENT_RUNTIME_DEMO=true by default
```

## Test plan
- [x] agent-runtime 24 tests
- [x] gateway carina-sandbox 4 tests
- [ ] After merge: deploy api-gateway + configure env against live Carina (if daemon present)

Closes remaining ship checklist on #384 (product UI optional).