### PR TITLE
fix(gateway): type Carina env bag for ProcessEnv and exclude tests from tsc

### DIFF
--- a/backends/gateway/src/lib/carina-sandbox.ts
+++ b/backends/gateway/src/lib/carina-sandbox.ts
@@ -21,6 +21,7 @@ import {
   registerCommandExecTool,
   resolveCarinaSandboxFromEnv,
   resolveCarinaWorkspaceRoot,
+  type CarinaEnv,
   type CarinaSandbox,
   type ExternalSandbox,
 } from "@nebutra/agent-runtime";
@@ -38,7 +39,7 @@ export type GatewayCarinaBundle = {
  * Workspace is resolved per tenant (map → template → root).
  */
 export function createGatewayCarinaBundle(
-  env: NodeJS.ProcessEnv = process.env,
+  env: CarinaEnv = process.env,
   opts: { readonly tenantId?: string; readonly threadId?: string } = {},
 ): GatewayCarinaBundle {
   const sandbox = resolveCarinaSandboxFromEnv(env);
@@ -69,14 +70,14 @@ export function createGatewayCarinaBundle(
 }
 
 export function gatewaySandboxOrRefuse(
-  env: NodeJS.ProcessEnv = process.env,
+  env: CarinaEnv = process.env,
 ): ExternalSandbox {
   return resolveCarinaSandboxFromEnv(env);
 }
 
 /** Narrow helper for routes that need Carina-only methods. */
 export function getCarinaSandbox(
-  env: NodeJS.ProcessEnv = process.env,
+  env: CarinaEnv = process.env,
 ): CarinaSandbox | null {
   const sandbox = resolveCarinaSandboxFromEnv(env);
   return isCarinaSandbox(sandbox) ? sandbox : null;

--- a/backends/gateway/tsconfig.json
+++ b/backends/gateway/tsconfig.json
@@ -14,5 +14,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__tests__/**"]
 }

--- a/packages/ai/agent-runtime/src/sandbox.ts
+++ b/packages/ai/agent-runtime/src/sandbox.ts
@@ -523,21 +523,9 @@ export function assertSafePosture(policy: CapabilityPolicy, allowDanger = false)
 
 // ── Env resolution + command-exec tool (Phase 2 host helpers) ────────────────
 
-export type CarinaEnv = {
-  readonly CARINA_JSONRPC_URL?: string;
-  readonly CARINA_JSONRPC_TOKEN?: string;
-  readonly CARINA_JSONRPC_PATH?: string;
-  readonly CARINA_WORKSPACE_ROOT?: string;
-  /** JSON map tenantId → absolute workspace path on the Carina host. */
-  readonly CARINA_WORKSPACE_MAP?: string;
-  /** Template with `{tenantId}` / `{threadId}` placeholders. */
-  readonly CARINA_WORKSPACE_TEMPLATE?: string;
-  readonly CARINA_CLIENT_ID?: string;
-  /** session.create approval_mode (e.g. always-approve, on_request). */
-  readonly CARINA_SESSION_APPROVAL_MODE?: string;
-  /** "1" / "true" → auto-approve requires_approval once and retry exec. */
-  readonly CARINA_AUTO_APPROVE?: string;
-};
+/** Env bag for Carina host config. Compatible with `process.env`. */
+export type CarinaEnv = Readonly<Record<string, string | undefined>>;
+
 
 /**
  * Resolve workspace path for a tenant/thread.
@@ -545,7 +533,7 @@ export type CarinaEnv = {
  */
 export function resolveCarinaWorkspaceRoot(
   tenantId: string,
-  env: CarinaEnv = process.env as CarinaEnv,
+  env: CarinaEnv = process.env,
   threadId = "",
 ): string | undefined {
   const mapRaw = env.CARINA_WORKSPACE_MAP?.trim();
@@ -575,7 +563,7 @@ export function resolveCarinaWorkspaceRoot(
  * - unset / empty → {@link REFUSING_SANDBOX} (fail closed)
  */
 export function resolveCarinaSandboxFromEnv(
-  env: CarinaEnv = process.env as CarinaEnv,
+  env: CarinaEnv = process.env,
   overrides: Partial<CarinaSandboxOptions> = {},
 ): ExternalSandbox {
   const baseUrl = env.CARINA_JSONRPC_URL?.trim();


### PR DESCRIPTION
Unblocks ECS api-gateway deploy after #387.

## Fix
- `CarinaEnv` = `Readonly<Record<string, string | undefined>>` (accepts `process.env`)
- Gateway bundle helpers use `CarinaEnv`
- Exclude `*.test.ts` / `__tests__` from gateway `tsc` emit

## Test plan
- [x] agent-runtime unit tests
- [ ] CI gateway build + deploy-ecs
