### PR TITLE
fix(ci): sync pnpm-lock for @nebutra/tokens @types/node

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3762,6 +3762,9 @@ importers:
         specifier: 19.2.4
         version: 19.2.4
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14


### PR DESCRIPTION
Unblocks `pnpm install --frozen-lockfile` on deploy-ecs after #389.

## Test plan
- [ ] deploy-ecs api-gateway install succeeds
