### PR TITLE
fix(ci): package mirror CI without lockfile cache

### DIFF
--- a/scripts/sync-subrepo-mirrors.mjs
+++ b/scripts/sync-subrepo-mirrors.mjs
@@ -313,7 +313,7 @@ function writeMirrorWorkflow(targetDir) {
       "      - uses: actions/setup-node@v4",
       "        with:",
       "          node-version: 22",
-      "          cache: pnpm",
+      "          # No pnpm-lock.yaml in standalone mirrors — caching requires a lockfile.",
       "      - name: Install",
       "        run: pnpm install --no-frozen-lockfile --ignore-scripts",
       "      - name: Build",


### PR DESCRIPTION
Standalone package mirrors have no `pnpm-lock.yaml`; `cache: pnpm` fails setup-node. Remove cache from generated subrepo CI and re-sync mirrors after merge.