### PR TITLE
fix(ci): package-mirror toolchain + ui DTS + CLA token

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -65,10 +65,12 @@ jobs:
         uses: cla-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # If/when we want signatures stored in a different repo (e.g. a
-          # private legal repo), define PERSONAL_ACCESS_TOKEN as an org
-          # secret. Until then, GITHUB_TOKEN is sufficient.
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          # cla-assistant crashes with "Cannot read properties of undefined
+          # (reading 'some')" when PERSONAL_ACCESS_TOKEN is an empty string
+          # (secret defined but blank). Fall back to GITHUB_TOKEN for
+          # same-repo signature storage on the cla-signatures branch.
+          # For a remote legal repo, set org secret PERSONAL_ACCESS_TOKEN.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           # Required by the action — points at the canonical CLA text.
           path-to-document: "https://github.com/Nebutra/Nebutra-Sailor/blob/main/docs/legal/CLA.md"

--- a/packages/ai/mcp/package.json
+++ b/packages/ai/mcp/package.json
@@ -49,7 +49,9 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "homepage": "https://github.com/Nebutra/Nebutra-Sailor/tree/main/packages/ai/mcp#readme",
   "repository": {

--- a/packages/design/ui/src/components/index.ts
+++ b/packages/design/ui/src/components/index.ts
@@ -67,7 +67,7 @@ export {
 } from "@lobehub/ui/chat";
 // Import Spotlight directly. The @lobehub/ui/awesome barrel also imports Spline,
 // whose runtime uses Function() and violates the app's production CSP.
-// @ts-expect-error Upstream .d.mts declares a named export, but the runtime .mjs only ships default.
+// (Upstream types now match the default export — do not reintroduce @ts-expect-error.)
 export { default as Spotlight } from "@lobehub/ui/es/awesome/Spotlight/Spotlight";
 export * from "../shared/animation/motion";
 export * from "./ai-prompt-box";

--- a/packages/platform/logger/package.json
+++ b/packages/platform/logger/package.json
@@ -54,7 +54,8 @@
     "@types/node": "^22.19.15",
     "pino-pretty": "^13.1.3",
     "tsup": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "homepage": "https://github.com/Nebutra/Nebutra-Sailor/tree/main/packages/platform/logger#readme",
   "repository": {

--- a/scripts/sync-subrepo-mirrors.mjs
+++ b/scripts/sync-subrepo-mirrors.mjs
@@ -205,6 +205,11 @@ function normalizePackageJson(root, mirror, targetDir, catalogVersions, workspac
     manifest.packageManager = "pnpm@10.32.1";
   }
 
+  // Monorepo packages often rely on root-hoisted toolchain (tsup/vitest/tsx).
+  // Standalone mirrors must declare anything their scripts invoke, or Build
+  // hard-fails with "command not found".
+  ensureStandaloneToolchain(manifest, catalogVersions);
+
   // Typecheck scripts often need Node types that monorepo hoists at the root.
   if (manifest.scripts?.typecheck) {
     manifest.devDependencies = {
@@ -214,6 +219,46 @@ function normalizePackageJson(root, mirror, targetDir, catalogVersions, workspac
   }
 
   writeJson(manifestPath, manifest);
+}
+
+/** Default ranges when the workspace catalog does not pin a tool. */
+const STANDALONE_TOOLCHAIN_FALLBACKS = {
+  tsup: "^8.5.1",
+  vitest: "^4.1.4",
+  tsx: "^4.21.0",
+  typescript: "^5.9.3",
+};
+
+/**
+ * If package scripts reference a CLI tool but neither dependencies nor
+ * devDependencies declare it, inject it into devDependencies so standalone
+ * `pnpm install` + `pnpm run build|test` works outside the monorepo.
+ */
+function ensureStandaloneToolchain(manifest, catalogVersions) {
+  const scriptsText = Object.values(manifest.scripts ?? {}).join("\n");
+  if (!scriptsText) return;
+
+  const declared = {
+    ...(manifest.dependencies ?? {}),
+    ...(manifest.devDependencies ?? {}),
+  };
+  const dev = { ...(manifest.devDependencies ?? {}) };
+  let changed = false;
+
+  for (const [tool, fallback] of Object.entries(STANDALONE_TOOLCHAIN_FALLBACKS)) {
+    const used =
+      tool === "typescript"
+        ? /\btsc\b/.test(scriptsText) || /\btypescript\b/.test(scriptsText)
+        : new RegExp(`\\b${tool}\\b`).test(scriptsText);
+    if (!used || declared[tool]) continue;
+    const catalog = catalogVersions?.get?.(tool);
+    dev[tool] = catalog ?? fallback;
+    changed = true;
+  }
+
+  if (changed) {
+    manifest.devDependencies = dev;
+  }
 }
 
 function normalizeTsconfig(root, targetDir) {


### PR DESCRIPTION
## Summary
- Standalone package mirrors were hard-failing when scripts called root-hoisted tools (`tsup: command not found` on `@nebutra/mcp`).
- `@nebutra/ui` DTS build failed on an unused `@ts-expect-error`.
- CLA Assistant crashed when `PERSONAL_ACCESS_TOKEN` was an empty string.

## Changes
1. `scripts/sync-subrepo-mirrors.mjs` injects missing tsup/vitest/tsx/typescript into mirror `devDependencies`.
2. Source packages declare their own toolchain honestly (`mcp`, `logger`).
3. Drop unused `@ts-expect-error` on Spotlight re-export.
4. CLA workflow: `PERSONAL_ACCESS_TOKEN || GITHUB_TOKEN` (signatures ledger already fixed to `{ signedContributors: [] }`).

## Test plan
- [x] Local mcp mirror install+build after generator inject
- [ ] First-wave package CI green (esp. mcp, ui)
- [ ] CLA check no longer throws on empty PAT