### PR TITLE
fix(ui): avatar style + Spotlight DTS for package mirror CI

### DIFF
--- a/packages/design/ui/src/components/index.ts
+++ b/packages/design/ui/src/components/index.ts
@@ -67,8 +67,9 @@ export {
 } from "@lobehub/ui/chat";
 // Import Spotlight directly. The @lobehub/ui/awesome barrel also imports Spline,
 // whose runtime uses Function() and violates the app's production CSP.
-// (Upstream types now match the default export — do not reintroduce @ts-expect-error.)
-export { Spotlight } from "@lobehub/ui/es/awesome/Spotlight/Spotlight";
+// @ts-ignore — lobehub Spotlight typings flip between default-only and named across
+// versions; @ts-expect-error fails the unused case on standalone mirrors.
+export { default as Spotlight } from "@lobehub/ui/es/awesome/Spotlight/Spotlight";
 export * from "../shared/animation/motion";
 export * from "./ai-prompt-box";
 // Animation

--- a/packages/design/ui/src/primitives/avatar.tsx
+++ b/packages/design/ui/src/primitives/avatar.tsx
@@ -41,15 +41,30 @@ function getAvatarFallbackClass(size: AvatarSize): string {
   return isPresetSize(size) ? sizeClasses[size].fallback : "text-[var(--avatar-font-size)]";
 }
 
-function getAvatarStyle(
-  size: AvatarSize,
-  style?: React.CSSProperties,
-): React.CSSProperties | undefined {
+/**
+ * Merge numeric avatar CSS vars with Base UI's `style` prop.
+ * Base UI types `style` as a CSSProperties / state-function intersection that
+ * is awkward to express; keep the helper loosely typed and let call sites
+ * pass through whatever Root/Fallback accept.
+ */
+function getAvatarStyle(size: AvatarSize, style?: unknown): unknown {
   if (typeof size !== "number") return style;
-  return {
+
+  const numericVars = {
     "--avatar-size": `${size}px`,
     "--avatar-font-size": `${Math.max(10, Math.round(size * 0.375))}px`,
-    ...style,
+  } as React.CSSProperties;
+
+  if (typeof style === "function") {
+    return (state: unknown) => ({
+      ...numericVars,
+      ...(style as (s: unknown) => React.CSSProperties | undefined)(state),
+    });
+  }
+
+  return {
+    ...numericVars,
+    ...(style as React.CSSProperties | undefined),
   } as React.CSSProperties;
 }
 
@@ -140,7 +155,7 @@ const Avatar = ({
           getAvatarRootClass(size),
           className,
         )}
-        style={getAvatarStyle(size, style)}
+        style={getAvatarStyle(size, style) as React.CSSProperties | undefined}
         {...props}
       >
         {shouldRenderConvenienceContent ? (
@@ -209,7 +224,7 @@ const AvatarFallback = ({
         getAvatarFallbackClass(resolvedSize),
         className,
       )}
-      style={getAvatarStyle(resolvedSize, style)}
+      style={getAvatarStyle(resolvedSize, style) as React.CSSProperties | undefined}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
Standalone `@nebutra/ui` package CI failed on DTS build:
1. Base UI `style` can be a function — `getAvatarStyle` only accepted plain CSSProperties
2. Spotlight re-export: monorepo vs published `@lobehub/ui` typings disagree on default export; `@ts-expect-error` fails when unused

## Test plan
- [x] Local `tsup` DTS build green for packages/design/ui
- [ ] Nebutra/ui package CI green after mirror sync