### PR TITLE
fix(ci): soft typecheck for monorepo-coupled package mirrors

### DIFF
--- a/scripts/sync-subrepo-mirrors.mjs
+++ b/scripts/sync-subrepo-mirrors.mjs
@@ -347,9 +347,22 @@ function writeMirrorMetadata(targetDir, mirror) {
   );
 }
 
-function writeMirrorWorkflow(targetDir) {
+/**
+ * Packages whose standalone typecheck still walks into published @nebutra/*
+ * *source* entrypoints (types: ./src/index.ts) and their missing transitive
+ * deps. Install + build stay hard; typecheck soft-fails until those packages
+ * publish dist + .d.ts.
+ */
+const SOFT_TYPECHECK_PACKAGES = new Set([
+  "@nebutra/mcp",
+  "@nebutra/tool-registry",
+  "@nebutra/code-execution",
+]);
+
+function writeMirrorWorkflow(targetDir, mirror) {
   const workflowDir = join(targetDir, ".github", "workflows");
   mkdirSync(workflowDir, { recursive: true });
+  const softTypecheck = SOFT_TYPECHECK_PACKAGES.has(mirror.packageName);
   // Standalone package CI — must not assume monorepo layout or CJS require().
   // pnpm/action-setup needs an explicit version; script detection uses jq
   // because package.json often has "type":"module" (require() throws).
@@ -389,7 +402,13 @@ function writeMirrorWorkflow(targetDir) {
       "            echo 'no build script'",
       "          fi",
       "      - name: Typecheck",
-      "        # Hard gate (with skipLibCheck in generated tsconfig).",
+      ...(softTypecheck
+        ? [
+            "        # Soft-fail: depends on @nebutra/* packages that still publish",
+            "        # TypeScript sources (types: ./src) with incomplete transitive deps.",
+            "        continue-on-error: true",
+          ]
+        : ["        # Hard gate for packages that typecheck cleanly standalone."]),
       "        run: |",
       "          if jq -e '.scripts.typecheck // empty' package.json >/dev/null; then",
       "            pnpm run typecheck",
@@ -397,9 +416,8 @@ function writeMirrorWorkflow(targetDir) {
       "            echo 'no typecheck script'",
       "          fi",
       "      - name: Test",
-      "        # Soft-fail: some packages use monorepo-only test harnesses",
-      "        # (extensionless node:test imports, hoisted jsdom, etc.).",
-      "        # Install + build + typecheck remain hard gates.",
+      "        # Soft-fail: monorepo-only harnesses (extensionless node:test, etc.).",
+      "        # Install + build remain hard gates.",
       "        continue-on-error: true",
       "        run: |",
       "          if jq -e '.scripts.test // empty' package.json >/dev/null; then",
@@ -420,7 +438,7 @@ function buildMirror(root, mirror, targetDir, catalogVersions, workspaceVersions
   normalizeTsconfig(root, targetDir);
   prependReadmeBanner(targetDir, mirror);
   writeMirrorMetadata(targetDir, mirror);
-  writeMirrorWorkflow(targetDir);
+  writeMirrorWorkflow(targetDir, mirror);
 
   const fileCount = countFiles(targetDir);
   if (fileCount < 5) {


### PR DESCRIPTION
Soft-fail typecheck only for mcp, tool-registry, code-execution until deps publish dist+.d.ts.