### PR TITLE
fix(ci): vendor dist workspace deps; hard typecheck all first-wave

### DIFF
--- a/packages/ai/content-store/package.json
+++ b/packages/ai/content-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/content-store",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Local-first semantic filesystem with rebuildable search index",
   "private": false,
   "license": "MIT",
@@ -11,10 +11,14 @@
     "surface": "persistence",
     "summary": "File-as-truth content store with frontmatter-aware indexing"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -46,5 +50,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/event-log/package.json
+++ b/packages/ai/event-log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/event-log",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Append-only event log with content-addressed snapshots",
   "private": false,
   "license": "MIT",
@@ -11,10 +11,14 @@
     "surface": "persistence",
     "summary": "Immutable event log, rollback dry-runs, and branches"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -44,5 +48,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/execution-policy/package.json
+++ b/packages/ai/execution-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/execution-policy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared command permission and approval policy primitives for runtime and execution packages",
   "private": false,
   "license": "MIT",
@@ -22,10 +22,14 @@
     "category": "ai",
     "summary": "Single shared owner for command permission matching and shell approval defaults"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -50,5 +54,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/local-embedding/package.json
+++ b/packages/ai/local-embedding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/local-embedding",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Deterministic zero-config local text embedding primitive shared by file and RAG indexes",
   "private": false,
   "license": "MIT",
@@ -22,10 +22,14 @@
     "category": "ai",
     "summary": "Single owner for deterministic zero-config local embedding semantics"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -50,5 +54,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/sandbox-runtime/package.json
+++ b/packages/ai/sandbox-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/sandbox-runtime",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Unified sandbox runtime router for local and remote execution providers",
   "private": false,
   "license": "MIT",
@@ -11,10 +11,14 @@
     "surface": "execution-router",
     "summary": "Sandbox trait, provider router, doctor, and debug tools"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -43,5 +47,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/design/tokens/package.json
+++ b/packages/design/tokens/package.json
@@ -27,7 +27,7 @@
     "emit-skins": "node scripts/emit-skins.mjs",
     "compile-brand": "node scripts/compile-brand.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test src/brand-package/__tests__/*.test.ts"
+    "test": "tsx --test src/brand-package/__tests__/*.test.ts"
   },
   "dependencies": {
     "@nebutra/design-tokens": "workspace:*"
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/react": "^19.2.14",
+    "tsx": "catalog:",
     "typescript": "catalog:"
   },
   "homepage": "https://github.com/Nebutra/Nebutra-Sailor/tree/main/packages/design/tokens#readme",

--- a/packages/platform/capability-kit/package.json
+++ b/packages/platform/capability-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/capability-kit",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Neutral capability primitives shared by every Nebutra capability package: CapabilityError, DoctorReport, doctor/debug CLI runner, and debug JSONL storage.",
   "private": false,
   "license": "MIT",
@@ -11,11 +11,19 @@
     "category": "platform",
     "summary": "Shared capability error, doctor-report, cli runner, tenant fallback selection, and debug JSONL storage"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./debug": "./src/debug.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./debug": {
+      "types": "./dist/debug.d.ts",
+      "import": "./dist/debug.js",
+      "default": "./dist/debug.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -40,5 +48,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/platform/trace-store/package.json
+++ b/packages/platform/trace-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/trace-store",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Async trace emit layer for agent, tool, and LLM spans",
   "private": false,
   "license": "MIT",
@@ -10,10 +10,14 @@
     "category": "platform",
     "summary": "Batched trace emitter over the shared telemetry layer"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -42,5 +46,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/scripts/sync-subrepo-mirrors.mjs
+++ b/scripts/sync-subrepo-mirrors.mjs
@@ -169,11 +169,181 @@ function normalizeDependencyBlock(block, workspaceVersions, catalogVersions) {
   );
 }
 
-function normalizePackageJson(root, mirror, targetDir, catalogVersions, workspaceVersions) {
+function packageVendorSlug(packageName) {
+  return packageName.replace(/^@/, "").replace(/\//g, "__");
+}
+
+function copyDirRecursive(src, dst) {
+  mkdirSync(dst, { recursive: true });
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const from = join(src, entry.name);
+    const to = join(dst, entry.name);
+    if (entry.isDirectory()) copyDirRecursive(from, to);
+    else if (entry.isFile()) copyFileSync(from, to);
+  }
+}
+
+/**
+ * Prefer dist-based exports for vendored packages. Monorepo packages may still
+ * point at src for DX; vendored copies always ship built artifacts.
+ */
+function distExportsForManifest(manifest) {
+  if (manifest.exports && typeof manifest.exports === "object" && !Array.isArray(manifest.exports)) {
+    const rewritten = {};
+    for (const [key, value] of Object.entries(manifest.exports)) {
+      if (typeof value === "string") {
+        if (value.startsWith("./dist/")) {
+          rewritten[key] = value;
+          continue;
+        }
+        // ./src/foo.ts -> ./dist/foo.js (+ types)
+        const base = value
+          .replace(/^\.\/src\//, "")
+          .replace(/\.tsx?$/, "")
+          .replace(/\/index$/, "/index");
+        const js = `./dist/${base}.js`;
+        const dts = `./dist/${base}.d.ts`;
+        rewritten[key] = { types: dts, import: js, default: js };
+      } else if (value && typeof value === "object") {
+        rewritten[key] = value;
+      }
+    }
+    if (Object.keys(rewritten).length > 0) return rewritten;
+  }
+
+  return {
+    ".": {
+      types: "./dist/index.d.ts",
+      import: "./dist/index.js",
+      default: "./dist/index.js",
+    },
+  };
+}
+
+/**
+ * Vendor workspace @nebutra/* dependencies as file:./vendor/* packages built
+ * from monorepo dist/. This avoids standalone typecheck walking into npm
+ * packages that still publish types: ./src/index.ts.
+ */
+function vendorWorkspaceDependencies(
+  root,
+  targetDir,
+  manifest,
+  packageByName,
+  catalogVersions,
+  workspaceVersions,
+) {
+  const vendorRoot = join(targetDir, "vendor");
+  const seen = new Set();
+
+  function vendorOne(packageName) {
+    if (seen.has(packageName)) return true;
+    const entry = packageByName.get(packageName);
+    if (!entry) return false;
+
+    const sourceDir = join(root, entry.relativeDir);
+    const distDir = join(sourceDir, "dist");
+    if (!existsSync(distDir)) {
+      console.warn(`[subrepo-sync] cannot vendor ${packageName}: missing dist/ (build first)`);
+      return false;
+    }
+
+    seen.add(packageName);
+    const sourceManifest = readJson(join(sourceDir, "package.json"));
+
+    // Vendor nested workspace deps first so file: links resolve.
+    for (const field of ["dependencies", "optionalDependencies"]) {
+      const block = sourceManifest[field] ?? {};
+      for (const [depName, range] of Object.entries(block)) {
+        if (typeof range === "string" && range.startsWith("workspace:")) {
+          vendorOne(depName);
+        }
+      }
+    }
+
+    const slug = packageVendorSlug(packageName);
+    const outDir = join(vendorRoot, slug);
+    rmSync(outDir, { recursive: true, force: true });
+    mkdirSync(outDir, { recursive: true });
+    copyDirRecursive(distDir, join(outDir, "dist"));
+
+    const deps = {};
+    for (const [depName, range] of Object.entries(sourceManifest.dependencies ?? {})) {
+      if (typeof range !== "string") continue;
+      if (range.startsWith("workspace:") && seen.has(depName)) {
+        deps[depName] = `file:../${packageVendorSlug(depName)}`;
+      } else {
+        deps[depName] = resolveDependencyVersion(
+          depName,
+          range,
+          workspaceVersions,
+          catalogVersions,
+        );
+      }
+    }
+
+    const vendoredManifest = {
+      name: packageName,
+      version: sourceManifest.version,
+      description: sourceManifest.description,
+      license: sourceManifest.license ?? "MIT",
+      type: sourceManifest.type ?? "module",
+      main: "./dist/index.js",
+      types: "./dist/index.d.ts",
+      exports: distExportsForManifest(sourceManifest),
+      files: ["dist"],
+      dependencies: deps,
+      private: false,
+    };
+    writeJson(join(outDir, "package.json"), vendoredManifest);
+    return true;
+  }
+
+  let vendoredAny = false;
+  for (const field of ["dependencies", "optionalDependencies"]) {
+    const block = manifest[field] ?? {};
+    for (const [depName, range] of Object.entries(block)) {
+      if (typeof range !== "string") continue;
+      if (!range.startsWith("workspace:") && !depName.startsWith("@nebutra/")) continue;
+      if (!packageByName.has(depName)) continue;
+      if (vendorOne(depName)) {
+        block[depName] = `file:./vendor/${packageVendorSlug(depName)}`;
+        vendoredAny = true;
+      }
+    }
+    if (Object.keys(block).length > 0) manifest[field] = block;
+  }
+
+  if (vendoredAny) {
+    console.log(
+      `[subrepo-sync] vendored ${seen.size} workspace package(s) into ${toPosix(join(targetDir, "vendor"))}`,
+    );
+  }
+  return seen;
+}
+
+function normalizePackageJson(
+  root,
+  mirror,
+  targetDir,
+  catalogVersions,
+  workspaceVersions,
+  packageByName,
+) {
   const manifestPath = join(targetDir, "package.json");
   const manifest = readJson(manifestPath);
   const repoUrl = `git+https://github.com/${mirror.owner}/${mirror.repoName}.git`;
   const sourceSha = getCurrentGitSha(root);
+
+  // Vendor monorepo workspace deps (built dist) before rewriting ranges to ^x.y.z.
+  vendorWorkspaceDependencies(
+    root,
+    targetDir,
+    manifest,
+    packageByName,
+    catalogVersions,
+    workspaceVersions,
+  );
 
   for (const field of [
     "dependencies",
@@ -181,7 +351,21 @@ function normalizePackageJson(root, mirror, targetDir, catalogVersions, workspac
     "peerDependencies",
     "optionalDependencies",
   ]) {
-    manifest[field] = normalizeDependencyBlock(manifest[field], workspaceVersions, catalogVersions);
+    // Skip file: vendor paths — already finalized.
+    const block = manifest[field];
+    if (!block) continue;
+    const next = {};
+    for (const [name, range] of Object.entries(block)) {
+      if (typeof range === "string" && range.startsWith("file:")) {
+        next[name] = range;
+      } else {
+        next[name] =
+          typeof range === "string"
+            ? resolveDependencyVersion(name, range, workspaceVersions, catalogVersions)
+            : range;
+      }
+    }
+    manifest[field] = next;
   }
 
   manifest.repository = {
@@ -347,25 +531,14 @@ function writeMirrorMetadata(targetDir, mirror) {
   );
 }
 
-/**
- * Packages whose standalone typecheck still walks into published @nebutra/*
- * *source* entrypoints (types: ./src/index.ts) and their missing transitive
- * deps. Install + build stay hard; typecheck soft-fails until those packages
- * publish dist + .d.ts.
- */
-const SOFT_TYPECHECK_PACKAGES = new Set([
-  "@nebutra/mcp",
-  "@nebutra/tool-registry",
-  "@nebutra/code-execution",
-]);
-
-function writeMirrorWorkflow(targetDir, mirror) {
+function writeMirrorWorkflow(targetDir) {
   const workflowDir = join(targetDir, ".github", "workflows");
   mkdirSync(workflowDir, { recursive: true });
-  const softTypecheck = SOFT_TYPECHECK_PACKAGES.has(mirror.packageName);
   // Standalone package CI — must not assume monorepo layout or CJS require().
   // pnpm/action-setup needs an explicit version; script detection uses jq
   // because package.json often has "type":"module" (require() throws).
+  // Workspace @nebutra/* deps are vendored as file:./vendor/* with dist+.d.ts
+  // so typecheck is a hard gate for all first-wave packages.
   writeFileSync(
     join(workflowDir, "ci.yml"),
     [
@@ -402,13 +575,6 @@ function writeMirrorWorkflow(targetDir, mirror) {
       "            echo 'no build script'",
       "          fi",
       "      - name: Typecheck",
-      ...(softTypecheck
-        ? [
-            "        # Soft-fail: depends on @nebutra/* packages that still publish",
-            "        # TypeScript sources (types: ./src) with incomplete transitive deps.",
-            "        continue-on-error: true",
-          ]
-        : ["        # Hard gate for packages that typecheck cleanly standalone."]),
       "        run: |",
       "          if jq -e '.scripts.typecheck // empty' package.json >/dev/null; then",
       "            pnpm run typecheck",
@@ -417,7 +583,7 @@ function writeMirrorWorkflow(targetDir, mirror) {
       "          fi",
       "      - name: Test",
       "        # Soft-fail: monorepo-only harnesses (extensionless node:test, etc.).",
-      "        # Install + build remain hard gates.",
+      "        # Install + build + typecheck remain hard gates.",
       "        continue-on-error: true",
       "        run: |",
       "          if jq -e '.scripts.test // empty' package.json >/dev/null; then",
@@ -430,15 +596,22 @@ function writeMirrorWorkflow(targetDir, mirror) {
   );
 }
 
-function buildMirror(root, mirror, targetDir, catalogVersions, workspaceVersions) {
+function buildMirror(root, mirror, targetDir, catalogVersions, workspaceVersions, packageByName) {
   const sourceDir = join(root, mirror.sourceDir);
   rmSync(targetDir, { recursive: true, force: true });
   copyTree(sourceDir, targetDir);
-  normalizePackageJson(root, mirror, targetDir, catalogVersions, workspaceVersions);
+  normalizePackageJson(
+    root,
+    mirror,
+    targetDir,
+    catalogVersions,
+    workspaceVersions,
+    packageByName,
+  );
   normalizeTsconfig(root, targetDir);
   prependReadmeBanner(targetDir, mirror);
   writeMirrorMetadata(targetDir, mirror);
-  writeMirrorWorkflow(targetDir, mirror);
+  writeMirrorWorkflow(targetDir);
 
   const fileCount = countFiles(targetDir);
   if (fileCount < 5) {
@@ -524,6 +697,9 @@ function main() {
   const workspaceVersions = new Map(
     releaseSurface.publishable.map((entry) => [entry.manifest.name, entry.manifest.version]),
   );
+  const packageByName = new Map(
+    releaseSurface.publishable.map((entry) => [entry.manifest.name, entry]),
+  );
   const sourceSha = getCurrentGitSha(root);
 
   rmSync(outputRoot, { recursive: true, force: true });
@@ -532,7 +708,7 @@ function main() {
   for (const mirror of selectedMirrors) {
     const targetDir =
       selectedMirrors.length === 1 && !args.all ? outputRoot : join(outputRoot, mirror.repoName);
-    buildMirror(root, mirror, targetDir, catalogVersions, workspaceVersions);
+    buildMirror(root, mirror, targetDir, catalogVersions, workspaceVersions, packageByName);
     if (args.push) pushMirror(mirror, targetDir, sourceSha);
   }
 


### PR DESCRIPTION
## Summary
Standalone package CI failed typecheck when npm \`@nebutra/*\` packages still published \`types: ./src\`. This PR:

1. Points 7 dependency packages at \`dist\` (logger-style) after tsup builds
2. Vendors monorepo workspace deps into package mirrors as \`file:./vendor/*\` with dist+.d.ts
3. Hard-gates typecheck for all first-wave packages (including mcp/tool-registry/code-execution)
4. tokens: test via \`tsx --test\` for portable ESM

## Local verification
- mcp / tool-registry / code-execution mirrors: install + typecheck green

## Note
npm publish of the new 0.1.3/0.2.3 versions still needs a valid NPM_TOKEN (env was empty here). Mirrors no longer depend on that for typecheck.