### PR TITLE
fix(ci): track vendored dist artifacts in package mirrors

### DIFF
--- a/scripts/sync-subrepo-mirrors.mjs
+++ b/scripts/sync-subrepo-mirrors.mjs
@@ -553,9 +553,19 @@ function writeMirrorMetadata(targetDir, mirror) {
       "",
     ].join("\n"),
   );
+  // Root `/dist` only — vendor/*/dist must remain tracked for file: deps.
   writeFileSync(
     join(targetDir, ".gitignore"),
-    ["node_modules", "dist", "coverage", ".turbo", ".DS_Store", ""].join("\n"),
+    [
+      "node_modules",
+      "/dist",
+      "!vendor/**/dist",
+      "!vendor/**/dist/**",
+      "coverage",
+      ".turbo",
+      ".DS_Store",
+      "",
+    ].join("\n"),
   );
 }
 


### PR DESCRIPTION
Root .gitignore used bare `dist` which ignored vendor/*/dist. Use /dist + un-ignore vendor paths so file: deps ship types.