### PR TITLE
feat(carina): same-host co-deploy via unix socket NDJSON

### DIFF
--- a/backends/gateway/.env.example
+++ b/backends/gateway/.env.example
@@ -134,21 +134,26 @@ FEATURE_FLAG_BILLING=true
 AGENT_ROLLOUT_DURABLE=false
 
 # ──────────────────────────────────────────────────────────────────────────
-# Carina Track B (self-deployed daemon — optional)
+# Carina Track B — same-host co-deploy (default)
 # ──────────────────────────────────────────────────────────────────────────
-# Enable agent-runtime turns:
-#   FEATURE_FLAG_AGENT_RUNTIME_DEMO=true
-#   (or KILL_SWITCH_AGENT_RUNTIME_DEMO=true)
-CARINA_JSONRPC_URL=
-CARINA_JSONRPC_TOKEN=
-CARINA_JSONRPC_PATH=
-CARINA_WORKSPACE_ROOT=
+# On ECS: bash infra/ops/scripts/carina-codeploy.sh
+#   installs carina-daemon, starts PM2, writes these defaults.
+#
+# CARINA_CODEPLOY=1 (default) → unix socket /var/carina/run/daemon.sock
+# CARINA_CODEPLOY=0           → fail closed unless CARINA_JSONRPC_URL set
+CARINA_CODEPLOY=1
+CARINA_DAEMON_SOCK=/var/carina/run/daemon.sock
+CARINA_WORKSPACE_ROOT=/var/carina/ws
+# Optional HTTP instead of socket:
+# CARINA_JSONRPC_URL=
+# CARINA_JSONRPC_TOKEN=
+# CARINA_JSONRPC_PATH=
 # CARINA_WORKSPACE_TEMPLATE=/var/carina/ws/{tenantId}
 # CARINA_WORKSPACE_MAP={"org_demo":"/var/carina/ws/demo"}
-CARINA_SESSION_APPROVAL_MODE=
+CARINA_SESSION_APPROVAL_MODE=always-approve
 # CARINA_AUTO_APPROVE=1
 CARINA_CLIENT_ID=nebutra-sailor
-FEATURE_FLAG_AGENT_RUNTIME_DEMO=false
+FEATURE_FLAG_AGENT_RUNTIME_DEMO=true
 
 # ──────────────────────────────────────────────────────────────────────────
 # China SMS providers

--- a/backends/gateway/src/lib/carina-sandbox.test.ts
+++ b/backends/gateway/src/lib/carina-sandbox.test.ts
@@ -1,13 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { REFUSING_SANDBOX, isCarinaSandbox } from "@nebutra/agent-runtime";
+import {
+  CODEPLOY_CARINA_SOCKET_PATH,
+  CODEPLOY_CARINA_WORKSPACE_ROOT,
+  REFUSING_SANDBOX,
+  isCarinaSandbox,
+} from "@nebutra/agent-runtime";
 import { createGatewayCarinaBundle, getCarinaSandbox } from "./carina-sandbox.js";
 
 describe("createGatewayCarinaBundle", () => {
-  it("fails closed with empty tools when Carina URL is unset", () => {
-    const bundle = createGatewayCarinaBundle({});
+  it("fails closed when co-deploy is explicitly disabled", () => {
+    const bundle = createGatewayCarinaBundle({ CARINA_CODEPLOY: "0" });
     expect(bundle.carinaEnabled).toBe(false);
     expect(bundle.sandbox).toBe(REFUSING_SANDBOX);
     expect(bundle.tools.list()).toHaveLength(0);
+  });
+
+  it("defaults to same-host co-deploy (socket + workspace)", () => {
+    const bundle = createGatewayCarinaBundle({}, { tenantId: "org_a", threadId: "th1" });
+    expect(bundle.carinaEnabled).toBe(true);
+    expect(isCarinaSandbox(bundle.sandbox)).toBe(true);
+    expect(bundle.workspaceRoot).toBe(CODEPLOY_CARINA_WORKSPACE_ROOT);
+    expect(bundle.tools.list().map((t) => t.definition.name)).toEqual(["command_exec"]);
   });
 
   it("registers command_exec when CARINA_JSONRPC_URL is set", () => {
@@ -19,7 +32,6 @@ describe("createGatewayCarinaBundle", () => {
       { tenantId: "org_a", threadId: "th1" },
     );
     expect(bundle.carinaEnabled).toBe(true);
-    expect(isCarinaSandbox(bundle.sandbox)).toBe(true);
     expect(bundle.workspaceRoot).toBe("/var/carina/ws");
     expect(bundle.tools.list().map((t) => t.definition.name)).toEqual(["command_exec"]);
   });
@@ -27,7 +39,7 @@ describe("createGatewayCarinaBundle", () => {
   it("resolves per-tenant workspace from map and template", () => {
     const mapped = createGatewayCarinaBundle(
       {
-        CARINA_JSONRPC_URL: "http://c",
+        CARINA_CODEPLOY: "1",
         CARINA_WORKSPACE_MAP: JSON.stringify({ org_a: "/tenants/a" }),
         CARINA_WORKSPACE_ROOT: "/fallback",
       },
@@ -45,7 +57,7 @@ describe("createGatewayCarinaBundle", () => {
     expect(templated.workspaceRoot).toBe("/ws/org_b/t9");
   });
 
-  it("getCarinaSandbox returns null when disabled", () => {
-    expect(getCarinaSandbox({})).toBeNull();
+  it("getCarinaSandbox returns null when co-deploy disabled", () => {
+    expect(getCarinaSandbox({ CARINA_CODEPLOY: "0" })).toBeNull();
   });
 });

--- a/backends/gateway/src/lib/carina-sandbox.ts
+++ b/backends/gateway/src/lib/carina-sandbox.ts
@@ -12,7 +12,10 @@
  *   CARINA_AUTO_APPROVE           1|true → auto resolve requires_approval once
  *   CARINA_CLIENT_ID              optional hello client_id
  *
- * Fail-closed: without CARINA_JSONRPC_URL → REFUSING_SANDBOX + empty tools.
+ * Co-deploy (default): unix socket /var/carina/run/daemon.sock + workspace
+ * /var/carina/ws — same host as api-gateway. Opt out: CARINA_CODEPLOY=0.
+ *
+ * Fail-closed only when co-deploy is disabled and no URL/socket is set.
  */
 
 import {
@@ -20,7 +23,7 @@ import {
   isCarinaSandbox,
   registerCommandExecTool,
   resolveCarinaSandboxFromEnv,
-  resolveCarinaWorkspaceRoot,
+  resolveCarinaWorkspaceRootWithCodeploy,
   type CarinaEnv,
   type CarinaSandbox,
   type ExternalSandbox,
@@ -48,7 +51,7 @@ export function createGatewayCarinaBundle(
 
   let workspaceRoot: string | undefined;
   if (carinaEnabled) {
-    workspaceRoot = resolveCarinaWorkspaceRoot(
+    workspaceRoot = resolveCarinaWorkspaceRootWithCodeploy(
       opts.tenantId ?? "_default",
       env,
       opts.threadId ?? "",

--- a/docs/architecture/2026-08-03-carina-track-b-upstream.md
+++ b/docs/architecture/2026-08-03-carina-track-b-upstream.md
@@ -104,6 +104,22 @@ non-Carina isolators. Production Track B **prefers** `createCarinaSandbox`.
 Do **not** vendor Carina source into this monorepo. Follow
 `protocol/jsonrpc/methods.json` and Carina release notes.
 
+
+## Same-host co-deploy (default)
+
+Sailor + Carina on **one machine** is the product default:
+
+```text
+api-gateway  ──unix NDJSON──►  carina-daemon
+  CARINA_DAEMON_SOCK=/var/carina/run/daemon.sock
+  CARINA_WORKSPACE_ROOT=/var/carina/ws
+```
+
+- Install/start: `infra/ops/scripts/carina-codeploy.sh`
+- PM2: `carina-daemon` in `infra/iac/ecs/ecosystem.config.cjs`
+- Opt out: `CARINA_CODEPLOY=0` (fail closed without URL)
+- Optional HTTP `CARINA_JSONRPC_URL` remains for non-socket bridges
+
 ## Consequences
 
 - Phase 1: adapter + tests on main; without endpoint, exec **fail-closed**.

--- a/infra/iac/ecs/ecosystem.config.cjs
+++ b/infra/iac/ecs/ecosystem.config.cjs
@@ -145,11 +145,33 @@ module.exports = {
       listen_timeout: 10000,
     },
     {
+      // Carina Track-B kernel — same host as api-gateway (local-first co-deploy).
+      // Install binary: infra/ops/scripts/install-carina-daemon.sh
+      // Socket: /var/carina/run/daemon.sock → CARINA_DAEMON_SOCK on api-gateway.
+      name: "carina-daemon",
+      cwd: "/var/carina",
+      script: "/var/carina/bin/carina-daemon",
+      args: "-socket /var/carina/run/daemon.sock -state /var/carina/state -approval-mode always-approve",
+      interpreter: "none",
+      env: {
+        HOME: "/var/carina",
+        CARINA_HOME: "/var/carina",
+      },
+      max_memory_restart: "512M",
+      instances: 1,
+      exec_mode: "fork",
+      autorestart: true,
+      max_restarts: 20,
+      kill_timeout: 8000,
+      listen_timeout: 15000,
+    },
+    {
       name: "api-gateway",
       // start.sh sources /var/www/nebutra/api/.env then `exec node dist/node.js`.
       // Plain `node dist/node.js` from PM2 does not load that env file, so DB/cache
       // probes fail (DATABASE_URL missing or mis-parsed). Packaging still strips
       // the tsx emergency loader — start.sh must stay on node, never tsx.
+      // Carina co-deploy defaults (override via /var/www/nebutra/api/.env).
       cwd: "/var/www/nebutra/api",
       script: "start.sh",
       interpreter: "bash",
@@ -157,6 +179,9 @@ module.exports = {
         NODE_ENV: "production",
         PORT: 3002,
         HOSTNAME: "127.0.0.1",
+        CARINA_CODEPLOY: "1",
+        CARINA_DAEMON_SOCK: "/var/carina/run/daemon.sock",
+        CARINA_WORKSPACE_ROOT: "/var/carina/ws",
       },
       // Gateway imports Prisma, provider SDKs, workers, and Hono route graphs
       // at startup. The real VM process settles near the old 300M limit,

--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Same-host Carina co-deploy with Sailor api-gateway.
+#
+# 1) Ensures binary + dirs under /var/carina
+# 2) Starts/reloads PM2 process `carina-daemon`
+# 3) Injects default api-gateway env (socket + workspace + demo flag)
+#
+# Usage (on the VM as deploy user with sudo for /var/carina if needed):
+#   bash infra/ops/scripts/carina-codeploy.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+CARINA_ROOT="${CARINA_ROOT:-/var/carina}"
+API_ENV_FILE="${API_ENV_FILE:-/var/www/nebutra/api/.env}"
+SOCKET_PATH="${CARINA_DAEMON_SOCK:-$CARINA_ROOT/run/daemon.sock}"
+STATE_DIR="${CARINA_STATE_DIR:-$CARINA_ROOT/state}"
+WS_ROOT="${CARINA_WORKSPACE_ROOT:-$CARINA_ROOT/ws}"
+APPROVAL_MODE="${CARINA_SESSION_APPROVAL_MODE:-always-approve}"
+
+if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ]; then
+  echo "Installing carina-daemon…"
+  bash "$ROOT_DIR/infra/ops/scripts/install-carina-daemon.sh"
+fi
+
+mkdir -p "$CARINA_ROOT/run" "$WS_ROOT" "$STATE_DIR"
+
+# Remove stale socket if present and no live process
+if [ -S "$SOCKET_PATH" ] && ! pgrep -f "carina-daemon.*$SOCKET_PATH" >/dev/null 2>&1; then
+  rm -f "$SOCKET_PATH" || true
+fi
+
+# Start via PM2 when available
+if command -v pm2 >/dev/null 2>&1; then
+  if pm2 describe carina-daemon >/dev/null 2>&1; then
+    pm2 restart carina-daemon --update-env || pm2 reload carina-daemon
+  else
+    # Prefer ecosystem entry when present
+    ECO="${PM2_CONFIG:-/var/www/nebutra/ecosystem.config.cjs}"
+    if [ -f "$ECO" ] && grep -q 'carina-daemon' "$ECO" 2>/dev/null; then
+      pm2 start "$ECO" --only carina-daemon
+    else
+      pm2 start "$CARINA_ROOT/bin/carina-daemon" --name carina-daemon -- \
+        -socket "$SOCKET_PATH" \
+        -state "$STATE_DIR" \
+        -approval-mode "$APPROVAL_MODE"
+    fi
+  fi
+  pm2 save || true
+else
+  echo "pm2 not found — starting carina-daemon in background"
+  nohup "$CARINA_ROOT/bin/carina-daemon" \
+    -socket "$SOCKET_PATH" \
+    -state "$STATE_DIR" \
+    -approval-mode "$APPROVAL_MODE" \
+    >"$CARINA_ROOT/run/daemon.log" 2>&1 &
+fi
+
+# Wait for socket
+for i in $(seq 1 30); do
+  if [ -S "$SOCKET_PATH" ]; then
+    echo "carina socket ready: $SOCKET_PATH"
+    break
+  fi
+  sleep 0.5
+done
+if [ ! -S "$SOCKET_PATH" ]; then
+  echo "warning: socket not ready yet at $SOCKET_PATH" >&2
+fi
+
+# Inject api-gateway env (defaults for co-deploy)
+bash "$ROOT_DIR/infra/ops/scripts/configure-api-carina-env.sh"
+
+echo "Carina co-deploy complete."
+echo "  socket:    $SOCKET_PATH"
+echo "  workspace: $WS_ROOT"
+echo "  api env:   $API_ENV_FILE"

--- a/infra/ops/scripts/configure-api-carina-env.sh
+++ b/infra/ops/scripts/configure-api-carina-env.sh
@@ -1,25 +1,17 @@
 #!/usr/bin/env bash
-# Merge Carina Track-B env into ECS api-gateway env file and restart PM2.
+# Inject Carina Track-B co-deploy defaults into api-gateway env + restart PM2.
 #
-# Run on the VM (or via SSH from CI):
-#   CARINA_JSONRPC_URL=http://127.0.0.1:7420/jsonrpc \
-#   CARINA_WORKSPACE_ROOT=/var/carina/ws \
-#   bash configure-api-carina-env.sh
+# Same-host defaults (no remote URL needed):
+#   CARINA_CODEPLOY=1
+#   CARINA_DAEMON_SOCK=/var/carina/run/daemon.sock
+#   CARINA_WORKSPACE_ROOT=/var/carina/ws
+#   FEATURE_FLAG_AGENT_RUNTIME_DEMO=true
 #
-# Optional:
-#   CARINA_JSONRPC_TOKEN, CARINA_JSONRPC_PATH, CARINA_WORKSPACE_TEMPLATE,
-#   CARINA_WORKSPACE_MAP, CARINA_SESSION_APPROVAL_MODE, CARINA_AUTO_APPROVE,
-#   CARINA_CLIENT_ID, ENABLE_AGENT_RUNTIME_DEMO=true
-#
-# Env file default: /var/www/nebutra/api/.env
+# Optional overrides via env before running.
 set -euo pipefail
 
 ENV_FILE="${API_ENV_FILE:-/var/www/nebutra/api/.env}"
-
-if [ -z "${CARINA_JSONRPC_URL:-}" ]; then
-  echo "CARINA_JSONRPC_URL is required" >&2
-  exit 1
-fi
+CARINA_ROOT="${CARINA_ROOT:-/var/carina}"
 
 mkdir -p "$(dirname "$ENV_FILE")"
 touch "$ENV_FILE"
@@ -37,10 +29,15 @@ upsert() {
   fi
 }
 
-upsert "CARINA_JSONRPC_URL" "$CARINA_JSONRPC_URL"
+# Co-deploy defaults
+upsert "CARINA_CODEPLOY" "${CARINA_CODEPLOY:-1}"
+upsert "CARINA_DAEMON_SOCK" "${CARINA_DAEMON_SOCK:-$CARINA_ROOT/run/daemon.sock}"
+upsert "CARINA_WORKSPACE_ROOT" "${CARINA_WORKSPACE_ROOT:-$CARINA_ROOT/ws}"
+
+# Optional HTTP still supported
+[ -n "${CARINA_JSONRPC_URL:-}" ] && upsert "CARINA_JSONRPC_URL" "$CARINA_JSONRPC_URL"
 [ -n "${CARINA_JSONRPC_TOKEN:-}" ] && upsert "CARINA_JSONRPC_TOKEN" "$CARINA_JSONRPC_TOKEN"
 [ -n "${CARINA_JSONRPC_PATH:-}" ] && upsert "CARINA_JSONRPC_PATH" "$CARINA_JSONRPC_PATH"
-[ -n "${CARINA_WORKSPACE_ROOT:-}" ] && upsert "CARINA_WORKSPACE_ROOT" "$CARINA_WORKSPACE_ROOT"
 [ -n "${CARINA_WORKSPACE_TEMPLATE:-}" ] && upsert "CARINA_WORKSPACE_TEMPLATE" "$CARINA_WORKSPACE_TEMPLATE"
 [ -n "${CARINA_WORKSPACE_MAP:-}" ] && upsert "CARINA_WORKSPACE_MAP" "$CARINA_WORKSPACE_MAP"
 [ -n "${CARINA_SESSION_APPROVAL_MODE:-}" ] && upsert "CARINA_SESSION_APPROVAL_MODE" "$CARINA_SESSION_APPROVAL_MODE"
@@ -52,7 +49,7 @@ if [ "${ENABLE_AGENT_RUNTIME_DEMO:-true}" = "true" ]; then
 fi
 
 chmod 600 "$ENV_FILE"
-echo "Updated $ENV_FILE (Carina Track B)"
+echo "Updated $ENV_FILE (Carina co-deploy)"
 
 if command -v pm2 >/dev/null 2>&1; then
   pm2 restart api-gateway --update-env || pm2 restart api-gateway

--- a/infra/ops/scripts/install-carina-daemon.sh
+++ b/infra/ops/scripts/install-carina-daemon.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Install carina-daemon binary for same-host Track-B co-deploy with api-gateway.
+#
+# Default layout:
+#   /var/carina/bin/carina-daemon
+#   /var/carina/run/daemon.sock   (created at runtime)
+#   /var/carina/ws               (workspace root)
+#   /var/carina/state            (session/event storage)
+#
+# Usage (on the VM):
+#   sudo bash install-carina-daemon.sh
+#   CARINA_VERSION=0.8.1 bash install-carina-daemon.sh
+set -euo pipefail
+
+CARINA_VERSION="${CARINA_VERSION:-0.8.1}"
+CARINA_ROOT="${CARINA_ROOT:-/var/carina}"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH_TAG="linux_amd64" ;;
+  aarch64|arm64) ARCH_TAG="linux_arm64" ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+ASSET="carina_${CARINA_VERSION}_${ARCH_TAG}.tar.gz"
+URL="${CARINA_RELEASE_URL:-https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSION}/${ASSET}}"
+
+mkdir -p "$CARINA_ROOT/bin" "$CARINA_ROOT/run" "$CARINA_ROOT/ws" "$CARINA_ROOT/state" "$CARINA_ROOT/tmp"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading $URL"
+curl -fsSL "$URL" -o "$TMP/$ASSET"
+tar -xzf "$TMP/$ASSET" -C "$TMP"
+
+# tarball layout may nest binaries; find carina-daemon
+BIN="$(find "$TMP" -type f -name 'carina-daemon' | head -1)"
+if [ -z "$BIN" ]; then
+  echo "carina-daemon not found in archive" >&2
+  ls -laR "$TMP" >&2 || true
+  exit 1
+fi
+install -m 0755 "$BIN" "$CARINA_ROOT/bin/carina-daemon"
+
+# optional CLI helpers
+for name in carina carina-cli; do
+  C="$(find "$TMP" -type f -name "$name" | head -1 || true)"
+  if [ -n "$C" ]; then
+    install -m 0755 "$C" "$CARINA_ROOT/bin/$name"
+  fi
+done
+
+echo "Installed $CARINA_ROOT/bin/carina-daemon (v${CARINA_VERSION})"
+"$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | head -5 || true

--- a/packages/ai/agent-runtime/README.md
+++ b/packages/ai/agent-runtime/README.md
@@ -43,12 +43,10 @@ import {
 } from "@nebutra/agent-runtime";
 
 // Production: only when a reachable Carina JSON-RPC base URL is configured.
-const sandbox: ExternalSandbox = process.env.CARINA_JSONRPC_URL
-  ? createCarinaSandbox({
-      baseUrl: process.env.CARINA_JSONRPC_URL,
-      token: process.env.CARINA_JSONRPC_TOKEN, // product/gateway cred — never owner unlock
-    })
-  : REFUSING_SANDBOX;
+// Same-host co-deploy (default): unix socket /var/carina/run/daemon.sock
+import { resolveCarinaSandboxFromEnv } from "@nebutra/agent-runtime";
+const sandbox = resolveCarinaSandboxFromEnv();
+// Opt out: CARINA_CODEPLOY=0  |  optional HTTP: CARINA_JSONRPC_URL=…
 ```
 
 See `docs/architecture/2026-08-03-carina-track-b-upstream.md`.

--- a/packages/ai/agent-runtime/src/agent-runtime.test.ts
+++ b/packages/ai/agent-runtime/src/agent-runtime.test.ts
@@ -298,9 +298,12 @@ describe("tools", () => {
 
 
 describe("Carina Phase 2 host helpers", () => {
-  it("resolveCarinaSandboxFromEnv fails closed without URL", () => {
-    expect(resolveCarinaSandboxFromEnv({})).toBe(REFUSING_SANDBOX);
-    expect(resolveCarinaSandboxFromEnv({ CARINA_JSONRPC_URL: "   " })).toBe(REFUSING_SANDBOX);
+  it("resolveCarinaSandboxFromEnv fails closed when co-deploy is off", () => {
+    expect(resolveCarinaSandboxFromEnv({ CARINA_CODEPLOY: "0" })).toBe(REFUSING_SANDBOX);
+  });
+
+  it("resolveCarinaSandboxFromEnv co-deploys by default (socket sandbox)", () => {
+    expect(isCarinaSandbox(resolveCarinaSandboxFromEnv({}))).toBe(true);
   });
 
   it("resolveCarinaSandboxFromEnv builds a Carina sandbox when URL is set", () => {

--- a/packages/ai/agent-runtime/src/carina-ndjson.test.ts
+++ b/packages/ai/agent-runtime/src/carina-ndjson.test.ts
@@ -1,0 +1,113 @@
+import { createServer, type Server } from "node:net";
+import { mkdtempSync, rmSync, unlinkSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_CAPABILITY_POLICY } from "./policy";
+import {
+  createCarinaSandbox,
+  resolveCarinaSandboxFromEnv,
+  REFUSING_SANDBOX,
+  isCarinaSandbox,
+} from "./sandbox";
+
+describe("carina ndjson + co-deploy resolve", () => {
+  const dirs: string[] = [];
+  let server: Server | null = null;
+
+  afterEach(() => {
+    if (server) {
+      // Do not await close — open NDJSON clients keep the server from draining.
+      try {
+        server.close();
+      } catch {
+        /* ignore */
+      }
+      server = null;
+    }
+    for (const d of dirs) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("resolveCarinaSandboxFromEnv refuses when CARINA_CODEPLOY=0", () => {
+    expect(resolveCarinaSandboxFromEnv({ CARINA_CODEPLOY: "0" })).toBe(REFUSING_SANDBOX);
+  });
+
+  it("resolveCarinaSandboxFromEnv defaults to co-deploy socket", () => {
+    expect(isCarinaSandbox(resolveCarinaSandboxFromEnv({}))).toBe(true);
+  });
+
+  it(
+    "createCarinaSandbox over unix NDJSON does hello + session + exec",
+    { timeout: 15_000 },
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "carina-sock-"));
+      dirs.push(dir);
+      const sockPath = join(dir, "daemon.sock");
+      if (existsSync(sockPath)) unlinkSync(sockPath);
+
+      server = createServer((conn) => {
+        let buf = "";
+        conn.setEncoding("utf8");
+        conn.on("data", (chunk: string) => {
+          buf += chunk;
+          for (;;) {
+            const nl = buf.indexOf("\n");
+            if (nl < 0) break;
+            const line = buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            if (!line.trim()) continue;
+            const req = JSON.parse(line) as {
+              id: number;
+              method: string;
+              params?: Record<string, unknown>;
+            };
+            let result: unknown = {};
+            if (req.method === "gateway.hello") {
+              result = { protocol_version: 1 };
+            } else if (req.method === "session.create") {
+              result = { session_id: "sess_sock", status: "active" };
+            } else if (req.method === "command.exec") {
+              expect(req.params?.session_id).toBe("sess_sock");
+              result = {
+                decision: { decision: "allowed", decision_id: "d1" },
+                result: { exit_code: 0, stdout: ["ok\n"], stderr: [] },
+              };
+            } else {
+              conn.write(
+                JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: req.id,
+                  error: { code: -32601, message: `unknown ${req.method}` },
+                }) + "\n",
+              );
+              continue;
+            }
+            conn.write(JSON.stringify({ jsonrpc: "2.0", id: req.id, result }) + "\n");
+          }
+        });
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server!.listen(sockPath, () => resolve());
+        server!.once("error", reject);
+      });
+
+      const sandbox = createCarinaSandbox({ socketPath: sockPath });
+      await sandbox.ensureSession({ threadId: "th", workspaceRoot: "/tmp/ws" });
+      const result = await sandbox.exec({
+        tenantId: "org",
+        threadId: "th",
+        command: "echo ok",
+        capabilityPolicy: DEFAULT_CAPABILITY_POLICY,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.aggregatedOutput).toBe("ok\n");
+    },
+  );
+});

--- a/packages/ai/agent-runtime/src/carina-ndjson.ts
+++ b/packages/ai/agent-runtime/src/carina-ndjson.ts
@@ -1,0 +1,194 @@
+/**
+ * Carina native transport: newline-delimited JSON-RPC 2.0 over a Unix socket
+ * (same wire as @carina/sdk and `carina-daemon -socket`).
+ *
+ * Node-only — not for edge runtimes without `node:net`.
+ */
+
+import { createConnection, type Socket } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const defaultCarinaSocketPath = (): string =>
+  join(homedir(), ".carina", "daemon.sock");
+
+/** Production co-deploy layout on the Sailor ECS api host. */
+export const CODEPLOY_CARINA_SOCKET_PATH = "/var/carina/run/daemon.sock";
+export const CODEPLOY_CARINA_WORKSPACE_ROOT = "/var/carina/ws";
+export const CODEPLOY_CARINA_STATE_DIR = "/var/carina/state";
+export const CODEPLOY_CARINA_BIN_DIR = "/var/carina/bin";
+
+export class CarinaNdjsonError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "CarinaNdjsonError";
+  }
+}
+
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type NdjsonRpcClient = {
+  call: <T>(method: string, params: Record<string, unknown>) => Promise<T>;
+  close: () => void;
+};
+
+/**
+ * Create a reusable NDJSON JSON-RPC client for a Carina unix socket.
+ */
+export function createCarinaNdjsonClient(
+  socketPath: string,
+  callTimeoutMs = 30_000,
+): NdjsonRpcClient {
+  let socket: Socket | null = null;
+  let connecting: Promise<void> | null = null;
+  let nextId = 0;
+  let buffer = "";
+  const pending = new Map<number, Pending>();
+
+  const failAll = (err: Error): void => {
+    for (const [id, p] of pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+      pending.delete(id);
+    }
+  };
+
+  const onData = (chunk: string): void => {
+    buffer += chunk;
+    for (;;) {
+      const nl = buffer.indexOf("\n");
+      if (nl < 0) break;
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (!line) continue;
+      let msg: {
+        id?: number | string;
+        result?: unknown;
+        error?: { code: number; message: string };
+      };
+      try {
+        msg = JSON.parse(line) as typeof msg;
+      } catch {
+        continue;
+      }
+      if (msg.id === undefined || msg.id === null) continue;
+      const id = typeof msg.id === "number" ? msg.id : Number(msg.id);
+      const p = pending.get(id);
+      if (!p) continue;
+      pending.delete(id);
+      clearTimeout(p.timer);
+      if (msg.error) {
+        p.reject(
+          new CarinaNdjsonError(
+            `Carina RPC failed (${msg.error.code}): ${msg.error.message}`,
+            502,
+            String(msg.error.code),
+          ),
+        );
+        continue;
+      }
+      p.resolve(msg.result);
+    }
+  };
+
+  const connect = async (): Promise<void> => {
+    if (socket && !socket.destroyed) return;
+    if (connecting) return connecting;
+    connecting = new Promise<void>((resolve, reject) => {
+      const s = createConnection(socketPath);
+      const onFail = (error: Error): void => {
+        s.destroy();
+        reject(
+          new CarinaNdjsonError(
+            `cannot reach carina-daemon at ${socketPath}: ${error.message}`,
+            503,
+            "transport_error",
+          ),
+        );
+      };
+      s.once("error", onFail);
+      s.once("connect", () => {
+        s.off("error", onFail);
+        socket = s;
+        s.setEncoding("utf8");
+        s.on("data", (chunk: string | Buffer) => onData(String(chunk)));
+        s.on("error", (error) => {
+          failAll(
+            new CarinaNdjsonError(
+              `carina-daemon socket error: ${error.message}`,
+              503,
+              "transport_error",
+            ),
+          );
+          socket = null;
+        });
+        s.on("close", () => {
+          failAll(
+            new CarinaNdjsonError("carina-daemon connection closed", 503, "transport_error"),
+          );
+          socket = null;
+        });
+        resolve();
+      });
+    }).finally(() => {
+      connecting = null;
+    });
+    return connecting;
+  };
+
+  return {
+    async call<T>(method: string, params: Record<string, unknown>): Promise<T> {
+      await connect();
+      const s = socket;
+      if (!s || s.destroyed) {
+        throw new CarinaNdjsonError("carina-daemon is disconnected", 503, "transport_error");
+      }
+      const id = ++nextId;
+      const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n";
+      return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(
+            new CarinaNdjsonError(
+              `Carina RPC ${method} timed out after ${callTimeoutMs}ms`,
+              504,
+              "timeout",
+            ),
+          );
+        }, callTimeoutMs);
+        pending.set(id, {
+          timer,
+          resolve: (v) => resolve(v as T),
+          reject,
+        });
+        s.write(payload, (error) => {
+          if (!error) return;
+          const p = pending.get(id);
+          if (!p) return;
+          pending.delete(id);
+          clearTimeout(p.timer);
+          p.reject(
+            new CarinaNdjsonError(
+              `Carina RPC ${method} write failed: ${error.message}`,
+              503,
+              "transport_error",
+            ),
+          );
+        });
+      });
+    },
+    close(): void {
+      failAll(new CarinaNdjsonError("carina ndjson client closed", 503, "closed"));
+      socket?.destroy();
+      socket = null;
+    },
+  };
+}

--- a/packages/ai/agent-runtime/src/index.ts
+++ b/packages/ai/agent-runtime/src/index.ts
@@ -41,6 +41,7 @@ export * from "./protocol";
 export * from "./pulsar";
 export * from "./rollout";
 export * from "./rollout-store-persistent";
+export * from "./carina-ndjson";
 export * from "./sandbox";
 export * from "./session-share";
 export * from "./skill-distillation";

--- a/packages/ai/agent-runtime/src/sandbox.ts
+++ b/packages/ai/agent-runtime/src/sandbox.ts
@@ -17,6 +17,14 @@
  */
 
 import type { CapabilityPolicy } from "./policy";
+import {
+  CODEPLOY_CARINA_SOCKET_PATH,
+  CODEPLOY_CARINA_WORKSPACE_ROOT,
+  CarinaNdjsonError,
+  createCarinaNdjsonClient,
+  defaultCarinaSocketPath,
+  type NdjsonRpcClient,
+} from "./carina-ndjson";
 
 export interface SandboxExecRequest {
   /** Mandatory tenant scope — every delegated exec is tenant-bound. */
@@ -168,20 +176,22 @@ type CarinaHello = {
 
 export type CarinaSandboxOptions = {
   /**
-   * Base URL of a Carina JSON-RPC endpoint reachable over HTTP POST.
-   * Typically a local daemon bridge or product connector that forwards to
-   * `~/.carina/daemon.sock` / Gateway WS — not a public multi-tenant API.
+   * HTTP JSON-RPC base URL (optional if {@link socketPath} is set).
+   * Prefer unix socket co-deploy on the same host as the gateway.
    */
-  readonly baseUrl: string;
+  readonly baseUrl?: string;
   /**
-   * Gateway token (`gw1`, transport-bound) or product connector credential.
-   * Never a local owner/admin unlock token.
+   * Native Carina unix socket path (NDJSON JSON-RPC). Preferred for same-host
+   * co-deploy — full command.exec authority (TCP diagnostic is read-limited).
+   */
+  readonly socketPath?: string;
+  /**
+   * Gateway token for HTTP transport only. Never a local owner unlock token.
    */
   readonly token?: string;
   readonly fetchImpl?: typeof fetch;
   /**
    * Path under baseUrl for JSON-RPC POST. Default `""` posts to baseUrl itself.
-   * Connectors often use `/jsonrpc` or `/rpc`.
    */
   readonly rpcPath?: string;
   /** Fail closed if hello reports a lower protocol_version. Default {@link CARINA_MIN_PROTOCOL_VERSION}. */
@@ -274,6 +284,7 @@ function extractCarinaSessionId(session: unknown): string {
 export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbox {
   const {
     baseUrl,
+    socketPath,
     token,
     fetchImpl = fetch,
     rpcPath = "",
@@ -285,17 +296,36 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
     autoApproveOnRequire = false,
   } = options;
 
+  const httpBase = baseUrl?.trim();
+  const sock = socketPath?.trim();
+  if (!httpBase && !sock) {
+    throw new CarinaProtocolError(
+      "createCarinaSandbox requires baseUrl (HTTP) or socketPath (unix NDJSON)",
+    );
+  }
+
   /** Sailor threadId → Carina session_id */
   const sessionByThread = new Map<string, string>();
 
-  const endpoint = `${baseUrl.replace(/\/$/, "")}${
-    !rpcPath ? "" : rpcPath.startsWith("/") ? rpcPath : `/${rpcPath}`
-  }`;
+  const endpoint = httpBase
+    ? `${httpBase.replace(/\/$/, "")}${
+        !rpcPath ? "" : rpcPath.startsWith("/") ? rpcPath : `/${rpcPath}`
+      }`
+    : "";
 
   let helloDone: Promise<void> | null = null;
   let rpcId = 0;
+  let ndjson: NdjsonRpcClient | null = null;
 
-  async function rpcCall<T>(method: string, params: Record<string, unknown>): Promise<T> {
+  function getNdjson(): NdjsonRpcClient {
+    if (!sock) {
+      throw new CarinaProtocolError("socket transport requested without socketPath");
+    }
+    if (!ndjson) ndjson = createCarinaNdjsonClient(sock);
+    return ndjson;
+  }
+
+  async function rpcCallHttp<T>(method: string, params: Record<string, unknown>): Promise<T> {
     const id = ++rpcId;
     const headers = new Headers({ "content-type": "application/json" });
     if (token) {
@@ -331,6 +361,20 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
       throw new CarinaProtocolError(`Carina RPC ${method} returned no result`);
     }
     return body.result;
+  }
+
+  async function rpcCall<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    if (sock && !httpBase) {
+      try {
+        return await getNdjson().call<T>(method, params);
+      } catch (err) {
+        if (err instanceof CarinaNdjsonError) {
+          throw new SandboxDelegationError(err.message, err.status, err.code);
+        }
+        throw err;
+      }
+    }
+    return rpcCallHttp<T>(method, params);
   }
 
   async function ensureHello(): Promise<void> {
@@ -558,29 +602,78 @@ export function resolveCarinaWorkspaceRoot(
 }
 
 /**
+ * Co-deploy is on unless explicitly disabled (`CARINA_CODEPLOY=0|false`).
+ * Same-host default: unix socket {@link CODEPLOY_CARINA_SOCKET_PATH}.
+ */
+export function isCarinaCodeployEnabled(env: CarinaEnv = process.env): boolean {
+  const v = env.CARINA_CODEPLOY?.trim().toLowerCase();
+  if (v === "0" || v === "false" || v === "off") return false;
+  // Explicit enable, or any socket/url/path hint, or default co-deploy on Node hosts.
+  if (v === "1" || v === "true" || v === "on") return true;
+  if (env.CARINA_JSONRPC_URL?.trim()) return true;
+  if (env.CARINA_DAEMON_SOCK?.trim()) return true;
+  // Default: co-deploy mode for production Node gateway (opt-out with CARINA_CODEPLOY=0).
+  return v === undefined || v === "";
+}
+
+/**
  * Resolve Track-B sandbox from environment.
- * - `CARINA_JSONRPC_URL` set → {@link createCarinaSandbox}
- * - unset / empty → {@link REFUSING_SANDBOX} (fail closed)
+ *
+ * Priority:
+ * 1. `CARINA_JSONRPC_URL` → HTTP JSON-RPC
+ * 2. `CARINA_DAEMON_SOCK` → unix NDJSON
+ * 3. co-deploy default → {@link CODEPLOY_CARINA_SOCKET_PATH}
+ * 4. developer home socket → `~/.carina/daemon.sock` when co-deploy and no prod path intent
+ * 5. otherwise {@link REFUSING_SANDBOX}
  */
 export function resolveCarinaSandboxFromEnv(
   env: CarinaEnv = process.env,
   overrides: Partial<CarinaSandboxOptions> = {},
 ): ExternalSandbox {
-  const baseUrl = env.CARINA_JSONRPC_URL?.trim();
-  if (!baseUrl) return REFUSING_SANDBOX;
-
   const auto =
     env.CARINA_AUTO_APPROVE === "1" || env.CARINA_AUTO_APPROVE === "true";
-
-  const options: CarinaSandboxOptions = {
-    baseUrl,
-    ...(env.CARINA_JSONRPC_TOKEN ? { token: env.CARINA_JSONRPC_TOKEN } : {}),
-    ...(env.CARINA_JSONRPC_PATH ? { rpcPath: env.CARINA_JSONRPC_PATH } : {}),
+  const common: Partial<CarinaSandboxOptions> = {
     ...(env.CARINA_CLIENT_ID ? { clientId: env.CARINA_CLIENT_ID } : {}),
     ...(auto ? { autoApproveOnRequire: true } : {}),
     ...overrides,
   };
-  return createCarinaSandbox(options);
+
+  const baseUrl = env.CARINA_JSONRPC_URL?.trim();
+  if (baseUrl) {
+    return createCarinaSandbox({
+      baseUrl,
+      ...(env.CARINA_JSONRPC_TOKEN ? { token: env.CARINA_JSONRPC_TOKEN } : {}),
+      ...(env.CARINA_JSONRPC_PATH ? { rpcPath: env.CARINA_JSONRPC_PATH } : {}),
+      ...common,
+    });
+  }
+
+  if (!isCarinaCodeployEnabled(env) && !env.CARINA_DAEMON_SOCK?.trim()) {
+    return REFUSING_SANDBOX;
+  }
+
+  const sock =
+    env.CARINA_DAEMON_SOCK?.trim() ||
+    (env.CARINA_CODEPLOY_HOME === "1" || env.CARINA_CODEPLOY_HOME === "true"
+      ? defaultCarinaSocketPath()
+      : CODEPLOY_CARINA_SOCKET_PATH);
+
+  return createCarinaSandbox({
+    socketPath: sock,
+    ...common,
+  });
+}
+
+/** Default workspace when co-deploy is enabled and no override is set. */
+export function resolveCarinaWorkspaceRootWithCodeploy(
+  tenantId: string,
+  env: CarinaEnv = process.env,
+  threadId = "",
+): string | undefined {
+  return (
+    resolveCarinaWorkspaceRoot(tenantId, env, threadId) ??
+    (isCarinaCodeployEnabled(env) ? CODEPLOY_CARINA_WORKSPACE_ROOT : undefined)
+  );
 }
 
 export function isCarinaSandbox(sandbox: ExternalSandbox): sandbox is CarinaSandbox {
@@ -590,3 +683,8 @@ export function isCarinaSandbox(sandbox: ExternalSandbox): sandbox is CarinaSand
   );
 }
 
+export {
+  CODEPLOY_CARINA_SOCKET_PATH,
+  CODEPLOY_CARINA_WORKSPACE_ROOT,
+  defaultCarinaSocketPath,
+} from "./carina-ndjson";


### PR DESCRIPTION
## Summary

**Same-host co-deploy is now the default** — no remote Daemon URL required.

```text
api-gateway  ── unix NDJSON ──►  carina-daemon
  /var/carina/run/daemon.sock
  /var/carina/ws
```

### Runtime
- `createCarinaSandbox({ socketPath })` — NDJSON over unix (Carina native)
- `resolveCarinaSandboxFromEnv()` defaults to co-deploy socket
- `CARINA_CODEPLOY=0` → fail closed (unless `CARINA_JSONRPC_URL`)
- HTTP URL still works for optional bridges

### Ops
- `install-carina-daemon.sh` — download release binary to `/var/carina/bin`
- `carina-codeploy.sh` — install + PM2 start + inject api `.env`
- `configure-api-carina-env.sh` — co-deploy defaults (no URL required)
- PM2 `carina-daemon` in `ecosystem.config.cjs`
- api-gateway env defaults for socket + workspace

### On ECS
```bash
bash infra/ops/scripts/carina-codeploy.sh
```

## Test plan
- [x] 28 agent-runtime tests + 5 gateway bundle tests
- [ ] Run `carina-codeploy.sh` on VM after merge