### PR TITLE
fix(ops): run Carina co-deploy after api-gateway ECS health

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -65,6 +65,9 @@ on:
       - "infra/runtime/nginx/conf.d/*.nebutra.com.conf"
       - "infra/runtime/nginx/nginx.conf"
       - "infra/ops/scripts/ecs-deploy-remote.sh"
+      - "infra/ops/scripts/carina-codeploy.sh"
+      - "infra/ops/scripts/install-carina-daemon.sh"
+      - "infra/ops/scripts/configure-api-carina-env.sh"
       - ".github/workflows/deploy-ecs.yml"
 
 permissions:
@@ -913,6 +916,20 @@ jobs:
           # Always re-upload the helper + runtime configs so the box stays in sync.
           scp "${SCP_OPTS[@]}" infra/ops/scripts/ecs-deploy-remote.sh \
             "${ECS_USER}@${ECS_HOST}:/tmp/ecs-deploy-remote.sh"
+          # Carina same-host co-deploy helpers (api-gateway post-start)
+          ssh -i ~/.ssh/id_deploy -p "${ECS_SSH_PORT}" \
+              -o StrictHostKeyChecking=yes -o ConnectTimeout=20 \
+              "${ECS_USER}@${ECS_HOST}" \
+              'mkdir -p /tmp/carina-ops'
+          scp "${SCP_OPTS[@]}" \
+            infra/ops/scripts/carina-codeploy.sh \
+            infra/ops/scripts/install-carina-daemon.sh \
+            infra/ops/scripts/configure-api-carina-env.sh \
+            "${ECS_USER}@${ECS_HOST}:/tmp/carina-ops/"
+          ssh -i ~/.ssh/id_deploy -p "${ECS_SSH_PORT}" \
+              -o StrictHostKeyChecking=yes -o ConnectTimeout=20 \
+              "${ECS_USER}@${ECS_HOST}" \
+              'chmod +x /tmp/carina-ops/*.sh'
           scp "${SCP_OPTS[@]}" infra/iac/ecs/ecosystem.config.cjs \
             "${ECS_USER}@${ECS_HOST}:${ECS_DEPLOY_ROOT}/ecosystem.config.cjs"
           scp "${SCP_OPTS[@]}" infra/runtime/nginx/nginx.conf \

--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -9,7 +9,7 @@
 #   bash infra/ops/scripts/carina-codeploy.sh
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 CARINA_ROOT="${CARINA_ROOT:-/var/carina}"
 API_ENV_FILE="${API_ENV_FILE:-/var/www/nebutra/api/.env}"
 SOCKET_PATH="${CARINA_DAEMON_SOCK:-$CARINA_ROOT/run/daemon.sock}"
@@ -19,7 +19,7 @@ APPROVAL_MODE="${CARINA_SESSION_APPROVAL_MODE:-always-approve}"
 
 if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ]; then
   echo "Installing carina-daemon…"
-  bash "$ROOT_DIR/infra/ops/scripts/install-carina-daemon.sh"
+  bash "$SCRIPTS_DIR/install-carina-daemon.sh"
 fi
 
 mkdir -p "$CARINA_ROOT/run" "$WS_ROOT" "$STATE_DIR"
@@ -68,7 +68,7 @@ if [ ! -S "$SOCKET_PATH" ]; then
 fi
 
 # Inject api-gateway env (defaults for co-deploy)
-bash "$ROOT_DIR/infra/ops/scripts/configure-api-carina-env.sh"
+bash "$SCRIPTS_DIR/configure-api-carina-env.sh"
 
 echo "Carina co-deploy complete."
 echo "  socket:    $SOCKET_PATH"

--- a/infra/ops/scripts/ecs-deploy-remote.sh
+++ b/infra/ops/scripts/ecs-deploy-remote.sh
@@ -1343,6 +1343,31 @@ for p in procs:
     pm2 start "$PM2_CONFIG" --only "$pm2_name"
   fi
 
+
+# Same-host Carina Track-B co-deploy (install daemon + socket env for api-gateway).
+# Scripts are uploaded by deploy-ecs.yml to /tmp/carina-ops/.
+# Opt out: CARINA_CODEPLOY=0 on the remote env.
+ensure_carina_codeploy() {
+  local mode="${CARINA_CODEPLOY:-1}"
+  case "$mode" in
+    0|false|off|no) log "CARINA_CODEPLOY=$mode — skip carina-daemon co-deploy"; return 0 ;;
+  esac
+
+  local scripts="${CARINA_OPS_SCRIPTS:-/tmp/carina-ops}"
+  if [ ! -f "$scripts/carina-codeploy.sh" ]; then
+    log "WARNING: $scripts/carina-codeploy.sh missing — skip Carina co-deploy (gateway remains fail-closed without daemon)"
+    return 0
+  fi
+
+  log "Carina same-host co-deploy via $scripts/carina-codeploy.sh"
+  # Soft-fail: gateway health already passed; daemon install should not roll back API.
+  if ! bash "$scripts/carina-codeploy.sh"; then
+    log "WARNING: carina-codeploy.sh failed — api-gateway is up; Track-B exec will fail closed until fixed"
+    return 0
+  fi
+  log "Carina co-deploy finished (socket + api env)"
+}
+
   # Surface PM2 status + recent logs so CI can see crash reasons. Without
   # this, deploys that succeed at the SSH level but crash at startup return
   # exit 0 here and only fail later in the workflow's HTTP smoke test —
@@ -1355,6 +1380,7 @@ for p in procs:
   case "$pm2_name" in
     api-gateway)
       wait_for_local_http "api-gateway" "$pm2_name" "http://127.0.0.1:3002/api/misc/health" "^200$"
+      ensure_carina_codeploy
       ;;
     landing)
       wait_for_local_http "landing" "$pm2_name" "http://127.0.0.1:3001/get-license"


### PR DESCRIPTION
## Summary

Closes the production gap: **#408 code was merged but daemon never auto-installed**.

- `deploy-ecs.yml` scp's `carina-codeploy.sh` + install/configure into `/tmp/carina-ops/`
- After `api-gateway` local health 200, `ecs-deploy-remote.sh` runs `ensure_carina_codeploy`
- Soft-fail if install fails (gateway stays up; Track-B fail-closed)
- Opt out: `CARINA_CODEPLOY=0`

## Test plan
- [ ] Merge + deploy `apps=api`
- [ ] VM has `pm2 describe carina-daemon` online
- [ ] Socket `/var/carina/run/daemon.sock` exists
- [ ] api `.env` has `CARINA_DAEMON_SOCK` / `CARINA_CODEPLOY=1`