### PR TITLE
chore(release): dist-entrypoint packages 0.1.4 + hard typecheck

### DIFF
--- a/packages/ai/content-store/package.json
+++ b/packages/ai/content-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/content-store",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Local-first semantic filesystem with rebuildable search index",
   "private": false,
   "license": "MIT",

--- a/packages/ai/event-log/package.json
+++ b/packages/ai/event-log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/event-log",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Append-only event log with content-addressed snapshots",
   "private": false,
   "license": "MIT",

--- a/packages/ai/execution-policy/package.json
+++ b/packages/ai/execution-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/execution-policy",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Shared command permission and approval policy primitives for runtime and execution packages",
   "private": false,
   "license": "MIT",

--- a/packages/ai/local-embedding/package.json
+++ b/packages/ai/local-embedding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/local-embedding",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Deterministic zero-config local text embedding primitive shared by file and RAG indexes",
   "private": false,
   "license": "MIT",

--- a/packages/ai/sandbox-runtime/package.json
+++ b/packages/ai/sandbox-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/sandbox-runtime",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Unified sandbox runtime router for local and remote execution providers",
   "private": false,
   "license": "MIT",

--- a/packages/platform/capability-kit/package.json
+++ b/packages/platform/capability-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/capability-kit",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Neutral capability primitives shared by every Nebutra capability package: CapabilityError, DoctorReport, doctor/debug CLI runner, and debug JSONL storage.",
   "private": false,
   "license": "MIT",

--- a/packages/platform/trace-store/package.json
+++ b/packages/platform/trace-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/trace-store",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Async trace emit layer for agent, tool, and LLM spans",
   "private": false,
   "license": "MIT",

--- a/scripts/sync-subrepo-mirrors.mjs
+++ b/scripts/sync-subrepo-mirrors.mjs
@@ -569,25 +569,11 @@ function writeMirrorMetadata(targetDir, mirror) {
   );
 }
 
-/**
- * Soft typecheck when mirrors may fall back to npm packages that still
- * publish `types: ./src` (vendor skipped). Prefer vendor+hard typecheck once
- * monorepo sync always builds dist first.
- */
-const SOFT_TYPECHECK_PACKAGES = new Set([
-  "@nebutra/mcp",
-  "@nebutra/tool-registry",
-  "@nebutra/code-execution",
-]);
-
-function writeMirrorWorkflow(targetDir, mirror) {
+function writeMirrorWorkflow(targetDir) {
   const workflowDir = join(targetDir, ".github", "workflows");
   mkdirSync(workflowDir, { recursive: true });
-  const softTypecheck = SOFT_TYPECHECK_PACKAGES.has(mirror?.packageName);
   // Standalone package CI — must not assume monorepo layout or CJS require().
-  // Workspace @nebutra/* deps are preferably vendored as file:./vendor/* with
-  // dist+.d.ts; when vendor is skipped CI may soft-fail typecheck for a few
-  // coupled packages.
+  // @nebutra/* deps publish dist+.d.ts (0.1.3+); vendor path remains as fallback.
   writeFileSync(
     join(workflowDir, "ci.yml"),
     [
@@ -624,13 +610,7 @@ function writeMirrorWorkflow(targetDir, mirror) {
       "            echo 'no build script'",
       "          fi",
       "      - name: Typecheck",
-      ...(softTypecheck
-        ? [
-            "        # Soft-fail until npm publishes dist entrypoints for deep @nebutra/* deps",
-            "        # (or monorepo sync always vendors file:./vendor/* with dist).",
-            "        continue-on-error: true",
-          ]
-        : ["        # Hard gate when workspace deps are vendored or package is self-contained."]),
+      "        # Hard gate: published @nebutra/* packages ship dist+.d.ts.",
       "        run: |",
       "          if jq -e '.scripts.typecheck // empty' package.json >/dev/null; then",
       "            pnpm run typecheck",
@@ -639,7 +619,7 @@ function writeMirrorWorkflow(targetDir, mirror) {
       "          fi",
       "      - name: Test",
       "        # Soft-fail: monorepo-only harnesses (extensionless node:test, etc.).",
-      "        # Install + build remain hard gates.",
+      "        # Install + build + typecheck remain hard gates.",
       "        continue-on-error: true",
       "        run: |",
       "          if jq -e '.scripts.test // empty' package.json >/dev/null; then",
@@ -667,7 +647,7 @@ function buildMirror(root, mirror, targetDir, catalogVersions, workspaceVersions
   normalizeTsconfig(root, targetDir);
   prependReadmeBanner(targetDir, mirror);
   writeMirrorMetadata(targetDir, mirror);
-  writeMirrorWorkflow(targetDir, mirror);
+  writeMirrorWorkflow(targetDir);
 
   const fileCount = countFiles(targetDir);
   if (fileCount < 5) {


### PR DESCRIPTION
## Published to npm (pnpm publish, workspace protocol rewritten)
- @nebutra/capability-kit@0.2.4
- @nebutra/local-embedding@0.1.4
- @nebutra/execution-policy@0.1.4
- @nebutra/sandbox-runtime@0.1.4
- @nebutra/trace-store@0.1.4
- @nebutra/content-store@0.1.4
- @nebutra/event-log@0.1.4

All use \`main\`/\`types\` → \`./dist/...\`.

Package mirror typecheck is hard-gated again.