### PR TITLE
fix(ops): bound Carina install timeouts so ECS deploy cannot hang

### DIFF
--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -19,7 +19,10 @@ APPROVAL_MODE="${CARINA_SESSION_APPROVAL_MODE:-always-approve}"
 
 if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ]; then
   echo "Installing carina-daemon…"
-  bash "$SCRIPTS_DIR/install-carina-daemon.sh"
+  if ! bash "$SCRIPTS_DIR/install-carina-daemon.sh"; then
+    echo "ERROR: install-carina-daemon.sh failed" >&2
+    exit 1
+  fi
 fi
 
 mkdir -p "$CARINA_ROOT/run" "$WS_ROOT" "$STATE_DIR"

--- a/infra/ops/scripts/ecs-deploy-remote.sh
+++ b/infra/ops/scripts/ecs-deploy-remote.sh
@@ -1360,9 +1360,15 @@ ensure_carina_codeploy() {
   fi
 
   log "Carina same-host co-deploy via $scripts/carina-codeploy.sh"
+  # Soft-fail + hard wall clock: never hang the ECS SSH deploy session.
   # Soft-fail: gateway health already passed; daemon install should not roll back API.
-  if ! bash "$scripts/carina-codeploy.sh"; then
-    log "WARNING: carina-codeploy.sh failed — api-gateway is up; Track-B exec will fail closed until fixed"
+  if command -v timeout >/dev/null 2>&1; then
+    if ! timeout 240 bash "$scripts/carina-codeploy.sh"; then
+      log "WARNING: carina-codeploy.sh failed/timed out — api-gateway is up; Track-B fail-closed until fixed"
+      return 0
+    fi
+  elif ! bash "$scripts/carina-codeploy.sh"; then
+    log "WARNING: carina-codeploy.sh failed — api-gateway is up; Track-B fail-closed until fixed"
     return 0
   fi
   log "Carina co-deploy finished (socket + api env)"

--- a/infra/ops/scripts/install-carina-daemon.sh
+++ b/infra/ops/scripts/install-carina-daemon.sh
@@ -29,7 +29,11 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 echo "Downloading $URL"
-curl -fsSL "$URL" -o "$TMP/$ASSET"
+# Hard timeouts — GH Actions SSH session must not hang forever on a bad release CDN.
+if ! curl -fsSL --connect-timeout 20 --max-time 180 --retry 2 --retry-delay 3     "$URL" -o "$TMP/$ASSET"; then
+  echo "ERROR: failed to download $URL" >&2
+  exit 1
+fi
 tar -xzf "$TMP/$ASSET" -C "$TMP"
 
 # tarball layout may nest binaries; find carina-daemon


### PR DESCRIPTION
Unblocks production co-deploy: previous api deploy hung during remote step (likely unbounded curl for carina release). Adds hard timeouts; keeps soft-fail for Track-B.