### PR TITLE
fix(web): VI color BrandLogo instead of solid blue mono

### DIFF
--- a/apps/web/src/components/brand/__tests__/brand-logo.test.tsx
+++ b/apps/web/src/components/brand/__tests__/brand-logo.test.tsx
@@ -23,23 +23,30 @@ describe("BrandLogo", () => {
     expect(img.getAttribute("src")).toBe("https://cdn.example.com/org-logos/org_1/logo.png");
   });
 
-  it("falls back to static mark when tenantLogoUrl is null", () => {
+  it("falls back to VI color mark when tenantLogoUrl is null", () => {
     const { container } = render(<BrandLogo variant="mark" tenantLogoUrl={null} />);
     const imgs = container.querySelectorAll("img");
     expect(imgs.length).toBeGreaterThan(0);
     for (const img of Array.from(imgs)) {
-      expect(img.getAttribute("src")).not.toBe("https://cdn.example.com/org-logos/org_1/logo.png");
+      const src = img.getAttribute("src") ?? "";
+      expect(src).not.toBe("https://cdn.example.com/org-logos/org_1/logo.png");
+      // Multi-path color asset (or webpack/next hashed path containing logo-color)
+      expect(src.includes("logo-color") || src.startsWith("data:") || src.startsWith("/")).toBe(
+        true,
+      );
     }
   });
 
-  it("falls back to static horizontal logo when tenantLogoUrl is undefined", () => {
+  it("falls back to color mark + wordmark when tenantLogoUrl is undefined", () => {
     const { container } = render(<BrandLogo variant="horizontal" />);
     const imgs = container.querySelectorAll("img");
     expect(imgs.length).toBeGreaterThan(0);
-    // All images should be static brand assets (not tenant CDN URLs)
+    // Color mark image present; not tenant CDN
     for (const img of Array.from(imgs)) {
       const src = img.getAttribute("src") ?? "";
       expect(src.includes("cdn.example.com")).toBe(false);
     }
+    // Independent wordmark SVG (not mono LogoEn composite)
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 });

--- a/apps/web/src/components/brand/brand-assets.tsx
+++ b/apps/web/src/components/brand/brand-assets.tsx
@@ -1,23 +1,30 @@
 /**
  * Web product chrome brand assets.
- * Default mark/wordmark: inline SVG from `@nebutra/brand` (no public/brand sync).
- * Tenant logos still use remote Image URLs.
+ *
+ * VI rule (productChromeLogoRule):
+ * - Light mark: multi-path color asset (`logo-color.svg`) — never mono + solid brand-mark blue
+ * - Dark mark: mono LogomarkSVG white
+ * - Wordmark: independent WordmarkEnSVG (currentColor), decoupled from mark fills
  */
 
-import { LogoEnSVG, LogomarkSVG } from "@nebutra/brand";
+import { LogomarkSVG, WordmarkEnSVG } from "@nebutra/brand";
+import logoColorMark from "@nebutra/brand/assets/logo/logo-color.svg";
 import { cn } from "@nebutra/ui/utils";
 import Image from "next/image";
 
-/** @deprecated Prefer inline SVG BrandLogo; kept for callers reading asset metadata. */
+const logoColorMarkSrc =
+  typeof logoColorMark === "string" ? logoColorMark : (logoColorMark as { src: string }).src;
+
+/** @deprecated Prefer BrandLogo; kept for callers reading asset metadata. */
 export const webBrandAssets = {
-  source: "@nebutra/brand/LogoSVG",
+  source: "@nebutra/brand",
   mark: {
-    src: "inline:LogomarkSVG",
+    src: "logo-color.svg + LogomarkSVG",
     width: 550,
     height: 513,
   },
   horizontal: {
-    src: "inline:LogoEnSVG",
+    src: "logo-color + WordmarkEnSVG",
     width: 1062,
     height: 208,
   },
@@ -32,6 +39,7 @@ export const webBrandLabels = {
 
 interface BrandLogoProps {
   className?: string;
+  /** Force light (color mark). Default auto uses theme (data-theme / .dark). */
   colorScheme?: "auto" | "light";
   imgClassName?: string;
   variant?: "horizontal" | "mark";
@@ -44,8 +52,7 @@ interface BrandLogoProps {
 
 export function BrandLogo({
   className,
-  // Retained for API stability; tone is token-driven and auto-flips via data-theme.
-  colorScheme: _colorScheme = "auto",
+  colorScheme = "auto",
   imgClassName,
   variant = "horizontal",
   tenantLogoUrl,
@@ -70,21 +77,78 @@ export function BrandLogo({
     );
   }
 
-  // Inline SVG: fill=currentColor + text-brand-mark (auto-flips under [data-theme="dark"]).
-  // Never reintroduce a manual dark-mode white text override — the token already flips.
-  const tone = "text-brand-mark";
+  const forceLight = colorScheme === "light";
 
+  // Mark: multi-path VI color on light; mono white on dark
+  const colorMarkClass = cn(
+    "h-full w-auto shrink-0 object-contain",
+    !forceLight && "dark:hidden",
+    imgClassName,
+  );
+  const monoMarkClass = cn(
+    "h-full w-auto shrink-0 !text-white",
+    forceLight ? "hidden" : "hidden dark:block",
+    imgClassName,
+  );
+
+  if (variant === "mark") {
+    return (
+      <span
+        className={cn("inline-flex shrink-0 items-center justify-center", className)}
+        data-brand-asset="mark"
+        data-brand-source={webBrandAssets.source}
+      >
+        <Image
+          src={logoColorMarkSrc}
+          alt=""
+          width={28}
+          height={26}
+          unoptimized
+          aria-hidden
+          draggable={false}
+          className={colorMarkClass}
+        />
+        <LogomarkSVG width={28} height={26} className={monoMarkClass} aria-label="Nebutra" />
+      </span>
+    );
+  }
+
+  // Horizontal: color mark + independent wordmark (not mono solid blue composite)
   return (
     <span
-      className={cn("inline-flex shrink-0 items-center", tone, className)}
-      data-brand-asset={variant}
+      className={cn("inline-flex h-full min-h-[1.25rem] shrink-0 items-center gap-2", className)}
+      data-brand-asset="horizontal"
       data-brand-source={webBrandAssets.source}
     >
-      {variant === "mark" ? (
-        <LogomarkSVG className={cn("block h-full w-full", imgClassName)} width={32} height={32} />
-      ) : (
-        <LogoEnSVG className={cn("block h-full w-auto max-w-full", imgClassName)} width={140} />
-      )}
+      <Image
+        src={logoColorMarkSrc}
+        alt=""
+        width={26}
+        height={24}
+        unoptimized
+        aria-hidden
+        draggable={false}
+        className={cn("h-[1.35em] w-auto", !forceLight && "dark:hidden", imgClassName)}
+      />
+      <LogomarkSVG
+        width={24}
+        height={24}
+        className={cn(
+          "h-[1.35em] w-auto shrink-0 !text-white",
+          forceLight ? "hidden" : "hidden dark:block",
+          imgClassName,
+        )}
+        aria-label="Nebutra"
+      />
+      <WordmarkEnSVG
+        width={100}
+        height={18}
+        className={cn(
+          "h-[0.95em] w-auto !text-[var(--neutral-12)]",
+          !forceLight && "dark:!text-white",
+          imgClassName,
+        )}
+      />
     </span>
   );
 }

--- a/apps/web/src/lib/__tests__/audit-remediation.test.ts
+++ b/apps/web/src/lib/__tests__/audit-remediation.test.ts
@@ -147,11 +147,13 @@ describe("UI/UX audit remediation invariants", () => {
     );
 
     expect(brandAssets).toContain('from "@nebutra/brand"');
-    expect(brandAssets).toContain("LogoEnSVG");
     expect(brandAssets).toContain("LogomarkSVG");
+    expect(brandAssets).toContain("WordmarkEnSVG");
+    expect(brandAssets).toContain("logo-color.svg");
     expect(brandAssets).toContain("data-brand-source={webBrandAssets.source}");
-    expect(brandAssets).toContain("text-brand-mark");
-    expect(brandAssets).not.toContain('src: "/brand/logo-color.svg"');
+    // Must not paint nav logo as mono solid brand-mark blue
+    expect(brandAssets).not.toContain("LogoEnSVG");
+    expect(brandAssets).not.toContain("text-brand-mark");
     expect(brandAssets).not.toContain('src: "/brand/logo-horizontal-en.svg"');
     expect(shell).toContain("BrandLogo");
     expect(shell).toContain("webBrandLabels.homeLink");


### PR DESCRIPTION
## Summary
- Replace mono `LogoEnSVG` + `text-brand-mark` (flat primary blue) with multi-path `logo-color.svg` mark + independent `WordmarkEnSVG`.
- Dark mode: mono white mark + white wordmark.
- Aligns with `productChromeLogoRule` and sailor-docs nav.

## Test plan
- [x] BrandLogo unit tests
- [ ] Visual check on https://app.nebutra.com public demo header