### PR TITLE
chore(release): wave-2 dist packages + hard typecheck convergence

### DIFF
--- a/packages/ai/3d-pipeline/package.json
+++ b/packages/ai/3d-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/3d-pipeline",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "BrandContext-first mesh generation, export manifests, and previews",
   "private": false,
   "license": "MIT",
@@ -23,10 +23,14 @@
     "category": "ai",
     "summary": "BrandContext-first mesh, preview, and export surface"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -57,5 +61,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/ai-primitives/package.json
+++ b/packages/ai/ai-primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/ai-primitives",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Zero-dependency AI primitive owner for deterministic hashing, numeric math, scoped keys, and token estimates",
   "private": false,
   "license": "MIT",
@@ -23,10 +23,14 @@
     "category": "ai",
     "summary": "Single owner for pure AI support primitives that otherwise drift across semantic-index and agent-runtime packages"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -51,5 +55,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/atelier-canvas/package.json
+++ b/packages/ai/atelier-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/atelier-canvas",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Server-authoritative creative-canvas engine: scene model, non-overlap placement, write-then-broadcast consistency, tenant-scoped locking",
   "private": false,
   "license": "MIT",
@@ -11,13 +11,14 @@
     "surface": "creative-surface",
     "summary": "Server-authoritative creative-canvas engine"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./store/memory": "./src/store/memory.ts",
-    "./store/prisma": "./src/store/prisma.ts",
-    "./agent": "./src/agent/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -54,5 +55,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/audio-pipeline/package.json
+++ b/packages/ai/audio-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/audio-pipeline",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "BrandContext-first audio generation, license metadata, and loudness utilities",
   "private": false,
   "license": "MIT",
@@ -22,10 +22,14 @@
     "category": "ai",
     "summary": "License-aware BGM, SFX, and song generation surface"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -55,5 +59,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/browser-control/package.json
+++ b/packages/ai/browser-control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/browser-control",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Browser task execution, recording, and deterministic replay ports",
   "private": false,
   "license": "MIT",
@@ -22,10 +22,14 @@
     "category": "ai",
     "summary": "Browser session trait, first-run recording, replay cache, doctor, and debug tools"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -54,5 +58,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/cinema/package.json
+++ b/packages/ai/cinema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/cinema",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Agentic film-production IP: acyclic camera-continuity tree, consistency-ranked best-frame selection, novel→scene/event segmentation, film-director composition. Pure + dependency-injected; sits on reel/agents/graph-model.",
   "private": false,
   "license": "MIT",
@@ -11,10 +11,14 @@
     "surface": "product-orchestration",
     "summary": "Multi-agent film-production orchestration over the reel media graph"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -42,5 +46,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/code-execution/package.json
+++ b/packages/ai/code-execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/code-execution",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Action and observation execution layer backed by sandbox-runtime",
   "private": false,
   "license": "MIT",
@@ -22,10 +22,14 @@
     "category": "ai",
     "summary": "Shell, read, edit-by-diff, policy, replay, doctor, and debug tools"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -56,5 +60,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/code-index/package.json
+++ b/packages/ai/code-index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/code-index",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "license": "MIT",
   "type": "module",
@@ -21,14 +21,14 @@
     "surface": "semantic-index",
     "summary": "Multi-tenant codebase semantic-index grammar: deterministic content-hash chunking (structural / line / markdown), incremental scan, embedding-profile drift recreate, cosine retrieval — all behind provider-agnostic Embedder/VectorStore ports"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./interfaces": "./src/interfaces.ts",
-    "./chunker": "./src/chunker.ts",
-    "./index-engine": "./src/index-engine.ts",
-    "./provider": "./src/provider.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -57,5 +57,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/document-pipeline/package.json
+++ b/packages/ai/document-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/document-pipeline",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Document parse, chunk, embed-port, and content-store ingestion pipeline",
   "private": false,
   "license": "MIT",
@@ -22,10 +22,14 @@
     "category": "ai",
     "summary": "Parser router, metadata-preserving chunks, content-store ingest, doctor, and debug tools"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -55,5 +59,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/ecosystem-safety/package.json
+++ b/packages/ai/ecosystem-safety/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/ecosystem-safety",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared public-disclosure safety primitives for ecosystem publishing surfaces",
   "private": false,
   "license": "MIT",
@@ -21,10 +21,14 @@
     "category": "ai",
     "summary": "Single shared owner for public-disclosure sensitive-field scanning"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -51,5 +55,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/generation-context/package.json
+++ b/packages/ai/generation-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/generation-context",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared BrandContext and generated-asset metadata contracts for multimodal pipelines",
   "private": false,
   "license": "MIT",
@@ -21,10 +21,14 @@
     "category": "ai",
     "summary": "Single shared BrandContext contract for Layer 4 multimodal generation"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -51,5 +55,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/image-pipeline/package.json
+++ b/packages/ai/image-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/image-pipeline",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "BrandContext-first image generation and workflow routing surface",
   "private": false,
   "license": "MIT",
@@ -22,10 +22,14 @@
     "category": "ai",
     "summary": "BrandContext-first image/logo/poster/icon generation surface"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -55,5 +59,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/knowledge-graph/package.json
+++ b/packages/ai/knowledge-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/knowledge-graph",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "license": "MIT",
   "type": "module",
@@ -21,16 +21,14 @@
     "category": "ai",
     "summary": "Multi-tenant self-wiring knowledge-graph substrate: zero-LLM typed entity-edge extraction, markdown-canonical bitemporal typed-fact model with supersession + trajectory, idempotent consolidation, and graph/backlink-boosted hybrid fusion — all behind injected GraphStore/VectorRetriever ports"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./interfaces": "./src/interfaces.ts",
-    "./link-extraction": "./src/link-extraction.ts",
-    "./temporal-facts": "./src/temporal-facts.ts",
-    "./consolidate": "./src/consolidate.ts",
-    "./hybrid-fusion": "./src/hybrid-fusion.ts",
-    "./provider": "./src/provider.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -59,5 +57,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/mcp/package.json
+++ b/packages/ai/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "license": "MIT",
   "type": "module",
@@ -20,13 +20,14 @@
     "surface": "tool-protocol",
     "summary": "MCP server primitives (Model Context Protocol)"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./client": "./src/client/index.ts",
-    "./server": "./src/server/index.ts",
-    "./middleware": "./src/middleware/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "bin": {
     "nebutra-mcp": "./dist/server/contextServer.js",
@@ -64,5 +65,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/play-loader/package.json
+++ b/packages/ai/play-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/play-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Declarative SKILL.md play loader and dependency planner",
   "private": false,
   "license": "MIT",
@@ -21,10 +21,14 @@
     "surface": "product-orchestration",
     "summary": "SKILL.md play parser, dependency-chain planner, and agent-runtime runner seam"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -53,5 +57,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/reel/package.json
+++ b/packages/ai/reel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/reel",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Typed node-graph dataflow for generative-media production: versioned IO envelope, multi-transport execution, storyboard pipeline",
   "private": false,
   "license": "MIT",
@@ -11,15 +11,34 @@
     "surface": "media-graph",
     "summary": "Node-graph dataflow + storyboard pipeline for generative media"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./transport": "./src/transport/index.ts",
-    "./storyboard": "./src/storyboard/index.ts",
-    "./store/memory": "./src/store/memory.ts",
-    "./canvas": "./src/canvas/index.ts",
-    "./canvas/binding": "./src/canvas/binding.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./canvas": {
+      "types": "./dist/canvas/index.d.ts",
+      "import": "./dist/canvas/index.js",
+      "default": "./dist/canvas/index.js"
+    },
+    "./store": {
+      "types": "./dist/store/index.d.ts",
+      "import": "./dist/store/index.js",
+      "default": "./dist/store/index.js"
+    },
+    "./storyboard": {
+      "types": "./dist/storyboard/index.d.ts",
+      "import": "./dist/storyboard/index.js",
+      "default": "./dist/storyboard/index.js"
+    },
+    "./transport": {
+      "types": "./dist/transport/index.d.ts",
+      "import": "./dist/transport/index.js",
+      "default": "./dist/transport/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -78,5 +97,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/tool-registry/package.json
+++ b/packages/ai/tool-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/tool-registry",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "SKILL.md registry with progressive disclosure and content-store backing",
   "private": false,
   "license": "MIT",
@@ -11,10 +11,14 @@
     "surface": "tool-registry",
     "summary": "Procedure knowledge registry for SKILL.md files"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -44,5 +48,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/video-pipeline/package.json
+++ b/packages/ai/video-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/video-pipeline",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Storyboard-first video planning, rendering manifests, and cost previews",
   "private": false,
   "license": "MIT",
@@ -23,10 +23,14 @@
     "category": "ai",
     "summary": "Storyboard-first brand video planning, cost, preview, and composition surface"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -58,5 +62,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/ai/voice-realtime/package.json
+++ b/packages/ai/voice-realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/voice-realtime",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Voice session lifecycle, narration synthesis, and enrollment surface",
   "private": false,
   "license": "MIT",
@@ -23,10 +23,14 @@
     "category": "ai",
     "summary": "Realtime voice session and narration synthesis surface"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -57,5 +61,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/integrations/collab/package.json
+++ b/packages/integrations/collab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/collab",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Multi-tenant, transport-agnostic real-time collaborative sync layer: tenant-partitioned CRDT rooms (Yjs) with pluggable snapshot store + transport seams",
   "private": false,
   "license": "MIT",
@@ -10,12 +10,14 @@
     "category": "integrations",
     "summary": "Tenant-partitioned CRDT room manager (Yjs) with pluggable store + transport seams"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./store/memory": "./src/store/memory.ts",
-    "./transport/loopback": "./src/transport/loopback.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -46,5 +48,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/integrations/integration-vault/package.json
+++ b/packages/integrations/integration-vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/integration-vault",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Tenant-scoped SaaS OAuth and credential vault for tool calling",
   "private": false,
   "license": "MIT",
@@ -10,10 +10,14 @@
     "category": "integrations",
     "summary": "OAuth, secret storage, and SaaS action invocation boundary"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -42,5 +46,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/integrations/tts/package.json
+++ b/packages/integrations/tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/tts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Provider-agnostic text-to-speech / narration synthesis. Zero-config deterministic mock default; ElevenLabs/OpenAI/Volces adapters wired via the shared provider-factory pattern.",
   "private": false,
   "license": "MIT",
@@ -10,10 +10,14 @@
     "category": "integrations",
     "summary": "Multi-tenant text-to-speech provider abstraction"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -41,5 +45,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/integrations/video-compose/package.json
+++ b/packages/integrations/video-compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nebutra/video-compose",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pure timeline / edit-decision-list builder + provider-agnostic video compositor (concat, crossfade transitions, mux). Zero-config deterministic mock default; ffmpeg adapter documented.",
   "private": false,
   "license": "MIT",
@@ -10,10 +10,14 @@
     "category": "integrations",
     "summary": "Timeline builder + multi-tenant video compositor abstraction"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -41,5 +45,11 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION
## Published (dist main/types, workspace: rewritten)
- First-wave AI: mcp@0.1.4, tool-registry@0.1.3, code-execution@0.1.3
- Pipelines / tools: ai-primitives, generation-context, ecosystem-safety, knowledge-graph, code-index, browser-control, audio/image/3d/document/video/voice pipelines, play-loader, cinema, atelier-canvas, reel@1.0.4
- Integrations: collab@0.2.3, tts@0.2.3, video-compose@0.2.3, integration-vault@0.1.3

## Also
- Deprecated broken 0.1.2/0.1.3 (and capability-kit 0.2.2/0.2.3) that shipped src or workspace:*
- Package mirror typecheck remains hard-gated

## Remaining src-entry packages
Still open for a later wave (ui, tokens, fonts, knowledge-base, brand-genesis, product surfaces, etc.)