### PR TITLE
fix(ops): allow longer Carina download on China ECS

### DIFF
--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -17,6 +17,10 @@ STATE_DIR="${CARINA_STATE_DIR:-$CARINA_ROOT/state}"
 WS_ROOT="${CARINA_WORKSPACE_ROOT:-$CARINA_ROOT/ws}"
 APPROVAL_MODE="${CARINA_SESSION_APPROVAL_MODE:-always-approve}"
 
+# Env first — gateway can fail-closed cleanly while daemon installs.
+echo "Injecting api-gateway Carina env (co-deploy defaults)…"
+bash "$SCRIPTS_DIR/configure-api-carina-env.sh" || true
+
 if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ]; then
   echo "Installing carina-daemon…"
   if ! bash "$SCRIPTS_DIR/install-carina-daemon.sh"; then
@@ -70,8 +74,8 @@ if [ ! -S "$SOCKET_PATH" ]; then
   echo "warning: socket not ready yet at $SOCKET_PATH" >&2
 fi
 
-# Inject api-gateway env (defaults for co-deploy)
-bash "$SCRIPTS_DIR/configure-api-carina-env.sh"
+# Re-inject after daemon start (idempotent)
+bash "$SCRIPTS_DIR/configure-api-carina-env.sh" || true
 
 echo "Carina co-deploy complete."
 echo "  socket:    $SOCKET_PATH"

--- a/infra/ops/scripts/ecs-deploy-remote.sh
+++ b/infra/ops/scripts/ecs-deploy-remote.sh
@@ -1363,7 +1363,7 @@ ensure_carina_codeploy() {
   # Soft-fail + hard wall clock: never hang the ECS SSH deploy session.
   # Soft-fail: gateway health already passed; daemon install should not roll back API.
   if command -v timeout >/dev/null 2>&1; then
-    if ! timeout 240 bash "$scripts/carina-codeploy.sh"; then
+    if ! timeout 600 bash "$scripts/carina-codeploy.sh"; then
       log "WARNING: carina-codeploy.sh failed/timed out — api-gateway is up; Track-B fail-closed until fixed"
       return 0
     fi

--- a/infra/ops/scripts/install-carina-daemon.sh
+++ b/infra/ops/scripts/install-carina-daemon.sh
@@ -30,7 +30,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 echo "Downloading $URL"
 # Hard timeouts — GH Actions SSH session must not hang forever on a bad release CDN.
-if ! curl -fsSL --connect-timeout 20 --max-time 180 --retry 2 --retry-delay 3     "$URL" -o "$TMP/$ASSET"; then
+if ! curl -fsSL --connect-timeout 30 --max-time 480 --retry 3 --retry-delay 5     "$URL" -o "$TMP/$ASSET"; then
   echo "ERROR: failed to download $URL" >&2
   exit 1
 fi


### PR DESCRIPTION
Production co-deploy timed out downloading carina_0.8.1_linux_amd64.tar.gz (240s wall). Bump timeouts; inject gateway env before binary install.