### PR TITLE
fix(auth): govern form column width and ink primary CTAs

### DIFF
--- a/apps/auth/src/components/auth-split-layout.tsx
+++ b/apps/auth/src/components/auth-split-layout.tsx
@@ -1,5 +1,6 @@
 import { getBrandOrigin } from "@nebutra/brand/metadata-helpers";
 import { ArrowLeft } from "@nebutra/icons";
+import { AUTH_FORM_COLUMN_CLASS } from "@nebutra/ui/utils";
 import { getTranslations } from "next-intl/server";
 import { cn } from "@/lib/cn";
 import { AuthBanner } from "./auth-banner";
@@ -8,6 +9,9 @@ import { LocaleSwitcher } from "./locale-switcher";
 /**
  * Same split shell as apps/web AuthSplitLayout (Agent OS login) —
  * including top-right locale switcher.
+ *
+ * Form column width is SSOT via AUTH_FORM_COLUMN_CLASS (@nebutra/ui/utils) —
+ * do not reintroduce a magic pixel max-width on this shell.
  */
 export async function AuthSplitLayout({
   children,
@@ -52,7 +56,7 @@ export async function AuthSplitLayout({
           aria-hidden
           className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-[linear-gradient(180deg,color-mix(in_srgb,hsl(var(--muted))_80%,transparent),transparent)] lg:hidden"
         />
-        <div className="relative w-full max-w-[440px]">{children}</div>
+        <div className={AUTH_FORM_COLUMN_CLASS}>{children}</div>
       </main>
     </div>
   );

--- a/apps/auth/src/components/credentials-form.tsx
+++ b/apps/auth/src/components/credentials-form.tsx
@@ -4,6 +4,7 @@ import { brand } from "@nebutra/brand/metadata";
 import { getBrandOrigin } from "@nebutra/brand/metadata-helpers";
 import { Warning as AlertTriangle, Eye, EyeOff, Key, Envelope as Mail } from "@nebutra/icons";
 import { Button, Input } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -328,11 +329,7 @@ export function CredentialsForm({
           </p>
         ) : null}
 
-        <Button
-          type="submit"
-          disabled={loading}
-          className="h-11 w-full bg-[hsl(var(--foreground))] text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))] disabled:cursor-not-allowed disabled:opacity-70"
-        >
+        <Button type="submit" disabled={loading} variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
           {mode === "sign-in"
             ? loading
               ? tSignIn("submitLoading")

--- a/apps/auth/src/components/forgot-password-form.tsx
+++ b/apps/auth/src/components/forgot-password-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button, Input } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -82,12 +83,9 @@ export function ForgotPasswordForm({ returnTo, turnstileSiteKey }: ForgotPasswor
           </h1>
           <p className="mt-4 text-sm leading-6 text-muted-foreground">{t("success")}</p>
         </div>
-        <Link
-          href={signInHref}
-          className="inline-flex h-11 w-full items-center justify-center rounded-[var(--radius-md)] bg-[hsl(var(--foreground))] text-sm font-medium text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))]"
-        >
-          {tSignIn("submit")}
-        </Link>
+        <Button asChild variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
+          <Link href={signInHref}>{tSignIn("submit")}</Link>
+        </Button>
       </div>
     );
   }
@@ -126,11 +124,7 @@ export function ForgotPasswordForm({ returnTo, turnstileSiteKey }: ForgotPasswor
           </p>
         ) : null}
 
-        <Button
-          type="submit"
-          disabled={loading}
-          className="h-11 w-full bg-[hsl(var(--foreground))] text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))] disabled:cursor-not-allowed disabled:opacity-70"
-        >
+        <Button type="submit" disabled={loading} variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
           {loading ? tSignIn("providerLoading") : t("submit")}
         </Button>
       </form>

--- a/apps/auth/src/components/magic-link-form.tsx
+++ b/apps/auth/src/components/magic-link-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button, Input } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -112,11 +113,7 @@ export function MagicLinkForm({ returnTo, turnstileSiteKey }: MagicLinkFormProps
           </p>
         ) : null}
 
-        <Button
-          type="submit"
-          disabled={loading}
-          className="h-11 w-full bg-[hsl(var(--foreground))] text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))] disabled:cursor-not-allowed disabled:opacity-70"
-        >
+        <Button type="submit" disabled={loading} variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
           {loading ? tSignIn("providerLoading") : t("send")}
         </Button>
       </form>

--- a/apps/auth/src/components/reset-password-form.tsx
+++ b/apps/auth/src/components/reset-password-form.tsx
@@ -2,6 +2,7 @@
 
 import { Eye, EyeOff } from "@nebutra/icons";
 import { Button, Input } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -69,12 +70,9 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
           </h1>
           <p className="mt-4 text-sm leading-6 text-muted-foreground">{t("successDescription")}</p>
         </div>
-        <Link
-          href="/sign-in"
-          className="inline-flex h-11 w-full items-center justify-center rounded-[var(--radius-md)] bg-[hsl(var(--foreground))] text-sm font-medium text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))]"
-        >
-          {t("signInCta")}
-        </Link>
+        <Button asChild variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
+          <Link href="/sign-in">{t("signInCta")}</Link>
+        </Button>
       </div>
     );
   }
@@ -160,11 +158,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
           </p>
         ) : null}
 
-        <Button
-          type="submit"
-          disabled={loading}
-          className="h-11 w-full bg-[hsl(var(--foreground))] text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))] disabled:cursor-not-allowed disabled:opacity-70"
-        >
+        <Button type="submit" disabled={loading} variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
           {loading ? tSignIn("providerLoading") : t("submit")}
         </Button>
       </form>

--- a/apps/auth/src/components/turnstile-challenge-form.tsx
+++ b/apps/auth/src/components/turnstile-challenge-form.tsx
@@ -2,6 +2,7 @@
 
 import { Turnstile } from "@marsidev/react-turnstile";
 import { Button } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -134,12 +135,9 @@ export function TurnstileChallengeForm({
           </h1>
           <p className="mt-4 text-sm leading-6 text-muted-foreground">{tForgot("success")}</p>
         </div>
-        <Link
-          href={cancelTo}
-          className="inline-flex h-11 w-full items-center justify-center rounded-[var(--radius-md)] bg-[hsl(var(--foreground))] text-sm font-medium text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))]"
-        >
-          {t("submit")}
-        </Link>
+        <Button asChild variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
+          <Link href={cancelTo}>{t("submit")}</Link>
+        </Button>
       </div>
     );
   }

--- a/apps/web/src/components/auth/auth-split-layout.tsx
+++ b/apps/web/src/components/auth/auth-split-layout.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft } from "@nebutra/icons";
-import { cn } from "@nebutra/ui/utils";
+import { AUTH_FORM_COLUMN_CLASS, cn } from "@nebutra/ui/utils";
 import { useTranslations } from "next-intl";
 import { LocaleSwitcher } from "@/components/navigation/locale-switcher";
 import { AuthBanner } from "./auth-banner";
@@ -9,6 +9,11 @@ interface AuthSplitLayoutProps {
   className?: string;
 }
 
+/**
+ * Agent OS split login shell. Form column width is SSOT via
+ * AUTH_FORM_COLUMN_CLASS (@nebutra/ui/utils) — keep in lock-step with
+ * apps/auth AuthSplitLayout; do not reintroduce a magic pixel max-width here.
+ */
 export function AuthSplitLayout({ children, className }: AuthSplitLayoutProps) {
   const t = useTranslations("auth.signIn");
 
@@ -45,7 +50,7 @@ export function AuthSplitLayout({ children, className }: AuthSplitLayoutProps) {
           aria-hidden
           className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-[linear-gradient(180deg,color-mix(in_srgb,hsl(var(--muted))_80%,transparent),transparent)] lg:hidden"
         />
-        <div className="relative w-full max-w-[440px]">{children}</div>
+        <div className={AUTH_FORM_COLUMN_CLASS}>{children}</div>
       </main>
     </div>
   );

--- a/apps/web/src/components/auth/clerk-enterprise-sso-handoff.tsx
+++ b/apps/web/src/components/auth/clerk-enterprise-sso-handoff.tsx
@@ -6,6 +6,7 @@ import {
 } from "@nebutra/auth/react/clerk-enterprise-sso";
 import { Key } from "@nebutra/icons";
 import { Button } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import { useTranslations } from "next-intl";
 
 interface ClerkEnterpriseSsoHandoffProps {
@@ -57,11 +58,7 @@ export function ClerkEnterpriseSsoHandoff({
           >
             {errorMessage}
           </p>
-          <Button
-            type="button"
-            className="h-11 w-full bg-[hsl(var(--foreground))] text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))]"
-            onClick={retry}
-          >
+          <Button type="button" variant="ink" className={AUTH_PRIMARY_CTA_CLASS} onClick={retry}>
             {t("ssoRetry")}
           </Button>
         </div>

--- a/apps/web/src/components/auth/passkey-panel.tsx
+++ b/apps/web/src/components/auth/passkey-panel.tsx
@@ -2,6 +2,7 @@
 
 import { Key } from "@nebutra/icons";
 import { Button, Input, Label } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
@@ -95,7 +96,8 @@ export function PasskeyPanel({ returnUrl }: PasskeyPanelProps) {
 
         <Button
           type="button"
-          className="h-11 w-full bg-[hsl(var(--foreground))] text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))] disabled:cursor-not-allowed disabled:opacity-70"
+          variant="ink"
+          className={AUTH_PRIMARY_CTA_CLASS}
           onClick={handleSignIn}
           disabled={loading || !supported}
         >

--- a/apps/web/src/components/auth/reset-password-form.tsx
+++ b/apps/web/src/components/auth/reset-password-form.tsx
@@ -3,6 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@nebutra/ui/components";
 import { Form, FormControl, FormField, FormItem, FormLabel, Input } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -94,13 +95,11 @@ export function ResetPasswordForm({ token, onSubmit }: ResetPasswordFormProps) {
         <h3 className="text-sm font-medium text-foreground">{t("successTitle")}</h3>
         <p className="mt-2 text-sm text-muted-foreground">{t("successDescription")}</p>
         <div className="mt-5">
-          <Link
-            href="/sign-in"
-            onClick={() => router.push("/sign-in")}
-            className="inline-flex items-center justify-center rounded-[var(--radius-md)] bg-[hsl(var(--foreground))] px-4 py-2 text-sm font-medium text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))]"
-          >
-            {t("signInCta")}
-          </Link>
+          <Button asChild variant="ink" className={AUTH_PRIMARY_CTA_CLASS}>
+            <Link href="/sign-in" onClick={() => router.push("/sign-in")}>
+              {t("signInCta")}
+            </Link>
+          </Button>
         </div>
       </section>
     );

--- a/apps/web/src/components/auth/reset-password-form.tsx
+++ b/apps/web/src/components/auth/reset-password-form.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button } from "@nebutra/ui/components";
-import { Form, FormControl, FormField, FormItem, FormLabel, Input } from "@nebutra/ui/primitives";
+import { Button as LobeButton } from "@nebutra/ui/components";
+import {
+  Button,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  Input,
+} from "@nebutra/ui/primitives";
 import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -166,9 +174,9 @@ export function ResetPasswordForm({ token, onSubmit }: ResetPasswordFormProps) {
             )}
           />
 
-          <Button disabled={pending} htmlType="submit" type="primary">
+          <LobeButton disabled={pending} htmlType="submit" type="primary">
             {t("submit")}
-          </Button>
+          </LobeButton>
         </form>
       </Form>
     </section>

--- a/apps/web/src/components/auth/sign-in-form.tsx
+++ b/apps/web/src/components/auth/sign-in-form.tsx
@@ -13,6 +13,7 @@ import {
   Input,
   Separator,
 } from "@nebutra/ui/primitives";
+import { AUTH_PRIMARY_CTA_CLASS } from "@nebutra/ui/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -345,11 +346,7 @@ export function SignInForm({
             </p>
           )}
 
-          <Button
-            type="submit"
-            className="h-11 w-full bg-[hsl(var(--foreground))] text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))] disabled:cursor-not-allowed disabled:opacity-70"
-            disabled={loading}
-          >
+          <Button type="submit" variant="ink" className={AUTH_PRIMARY_CTA_CLASS} disabled={loading}>
             {loading ? t("submitLoading") : t("submit")}
           </Button>
         </form>

--- a/apps/web/src/components/auth/verify-email-result.tsx
+++ b/apps/web/src/components/auth/verify-email-result.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@nebutra/ui/primitives";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { AuthErrorKey } from "@/lib/auth/error-keys";
@@ -30,12 +31,9 @@ export function VerifyEmailResult({ success, errorKey = "unknown" }: VerifyEmail
         <h3 className="mt-4 text-base font-semibold text-foreground">{t("successTitle")}</h3>
         <p className="mt-2 text-sm text-muted-foreground">{t("successDescription")}</p>
         <div className="mt-5">
-          <Link
-            href="/"
-            className="inline-flex items-center justify-center rounded-[var(--radius-md)] bg-[hsl(var(--foreground))] px-4 py-2 text-sm font-medium text-[hsl(var(--background))] hover:bg-[hsl(var(--muted-foreground))]"
-          >
-            {t("continueCta")}
-          </Link>
+          <Button asChild variant="ink">
+            <Link href="/">{t("continueCta")}</Link>
+          </Button>
         </div>
       </section>
     );

--- a/packages/ai/atelier-canvas/package.json
+++ b/packages/ai/atelier-canvas/package.json
@@ -18,6 +18,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./agent": {
+      "types": "./dist/agent/index.d.ts",
+      "import": "./dist/agent/index.js",
+      "default": "./dist/agent/index.js"
     }
   },
   "scripts": {

--- a/packages/design/ui/src/marketing/auth-page.tsx
+++ b/packages/design/ui/src/marketing/auth-page.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import { Button } from "../primitives/button";
 import { Input } from "../primitives/input";
 import { motion, useReducedMotion } from "../shared/animation/motion";
+import { AUTH_FORM_COLUMN_CLASS } from "../utils/auth-surfaces";
 import { cn } from "../utils/cn";
 
 // Google Icon SVG component
@@ -294,8 +295,8 @@ export function AuthPage({
           </a>
         </Button>
 
-        {/* Auth Form Container */}
-        <div className="mx-auto space-y-4 w-full max-w-sm">
+        {/* Auth Form Container — width SSOT: AUTH_FORM_COLUMN_CLASS */}
+        <div className={cn("mx-auto space-y-4", AUTH_FORM_COLUMN_CLASS)}>
           {/* Mobile Brand (hidden on desktop) */}
           <div className="flex items-center gap-2 lg:hidden">
             {brandIcon}

--- a/packages/design/ui/src/tokens/spacing.ts
+++ b/packages/design/ui/src/tokens/spacing.ts
@@ -54,6 +54,8 @@ export const semanticSpacing = {
  * told to follow.
  */
 export const containerWidths = {
+  /** Credentials / auth form column — form-scale, not page-scale. */
+  authForm: "max-w-sm", // 24rem / 384px — SSOT: AUTH_FORM_COLUMN_CLASS in utils/auth-surfaces
   narrow: "max-w-[var(--container-text)]", // 896px - FAQ, focused reading
   medium: "max-w-[var(--container-content)]", // 1152px - Architecture, Pricing
   wide: "max-w-[var(--container-wide)]", // 1400px - Full layouts, Bento

--- a/packages/design/ui/src/utils/__tests__/auth-surfaces-governance.test.ts
+++ b/packages/design/ui/src/utils/__tests__/auth-surfaces-governance.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { AUTH_FORM_COLUMN_CLASS, AUTH_PRIMARY_CTA_CLASS } from "../auth-surfaces";
+
+/**
+ * Auth form-column + primary CTA contracts.
+ *
+ * Hard-and-correct: one width, one CTA recipe. Both product shells
+ * (auth-center + Agent OS web) must import the SSOT; magic pixel max-widths
+ * and bg-[hsl(var(--foreground))] fights against btn-brand-default are
+ * banned so the column cannot silently widen or re-paint identity blue.
+ *
+ * Paths are monorepo-relative from packages/design/ui (vitest cwd).
+ */
+const REPO_ROOT = join(process.cwd(), "../../..");
+
+const SPLIT_LAYOUTS = [
+  "apps/auth/src/components/auth-split-layout.tsx",
+  "apps/web/src/components/auth/auth-split-layout.tsx",
+] as const;
+
+const AUTH_SURFACES = [
+  "apps/auth/src/components/credentials-form.tsx",
+  "apps/auth/src/components/magic-link-form.tsx",
+  "apps/auth/src/components/forgot-password-form.tsx",
+  "apps/auth/src/components/reset-password-form.tsx",
+  "apps/web/src/components/auth/sign-in-form.tsx",
+  "apps/web/src/components/auth/passkey-panel.tsx",
+  "apps/web/src/components/auth/clerk-enterprise-sso-handoff.tsx",
+] as const;
+
+const FOREGROUND_FILL_FIGHT =
+  /bg-\[hsl\(var\(--foreground\)\)\][\s\S]{0,120}text-\[hsl\(var\(--background\)\)\]/;
+
+describe("auth surface layout contracts", () => {
+  it("exports a form-scale column (max-w-sm), not a magic pixel width", () => {
+    expect(AUTH_FORM_COLUMN_CLASS).toContain("max-w-sm");
+    expect(AUTH_FORM_COLUMN_CLASS).not.toMatch(/max-w-\[\d+px\]/);
+    expect(AUTH_PRIMARY_CTA_CLASS).toContain("w-full");
+  });
+
+  it("both product AuthSplitLayouts import and apply AUTH_FORM_COLUMN_CLASS", () => {
+    for (const rel of SPLIT_LAYOUTS) {
+      const source = readFileSync(join(REPO_ROOT, rel), "utf8");
+      expect(source, rel).toContain("AUTH_FORM_COLUMN_CLASS");
+      expect(source, rel).toContain('from "@nebutra/ui/utils"');
+      // No ad-hoc pixel form columns (historical 440px drift).
+      expect(source, rel).not.toMatch(/max-w-\[\d+px\]/);
+    }
+  });
+
+  it("auth primary CTAs do not fight btn-brand-default with foreground fills", () => {
+    for (const rel of AUTH_SURFACES) {
+      const source = readFileSync(join(REPO_ROOT, rel), "utf8");
+      expect(source, rel).not.toMatch(FOREGROUND_FILL_FIGHT);
+    }
+  });
+});

--- a/packages/design/ui/src/utils/auth-surfaces.ts
+++ b/packages/design/ui/src/utils/auth-surfaces.ts
@@ -1,0 +1,20 @@
+/**
+ * Auth surface layout contracts.
+ *
+ * Split-shell login (apps/auth + apps/web) and the marketing AuthPage must
+ * share one form-column width. Inventing a second max-width on either shell
+ * is how the credentials column drifts wider than the design (e.g. the
+ * historical 440px one-off that shipped on auth-center).
+ *
+ * `max-w-sm` = 24rem / 384px — form-scale, not page-scale. Matches the
+ * credentials column on Marketing/AuthPage.
+ */
+export const AUTH_FORM_COLUMN_CLASS = "relative w-full max-w-sm";
+
+/**
+ * Primary auth CTA sizing. Pair with `variant="ink"` on Button — never fight
+ * `btn-brand-default`'s background-image with `bg-[hsl(var(--foreground))]`.
+ * The image layer wins and the identity/action blue reappears on the first
+ * surface a visitor touches.
+ */
+export const AUTH_PRIMARY_CTA_CLASS = "h-11 w-full";

--- a/packages/design/ui/src/utils/index.ts
+++ b/packages/design/ui/src/utils/index.ts
@@ -2,12 +2,19 @@
  * Utility Functions
  */
 
+/** Auth split-shell + primary CTA contracts (width + ink CTA pairing). */
+export { AUTH_FORM_COLUMN_CLASS, AUTH_PRIMARY_CTA_CLASS } from "./auth-surfaces";
 /**
  * Merge class names — canonical implementation from ./cn.ts
  * Uses twMerge(clsx(...)) to correctly resolve Tailwind class conflicts.
  */
 export { cn } from "./cn";
-export { asPlainStyle, withHtmlProps, type PrimitiveProps, type PrimitiveComponent } from "./primitive-props";
+export {
+  asPlainStyle,
+  type PrimitiveComponent,
+  type PrimitiveProps,
+  withHtmlProps,
+} from "./primitive-props";
 
 /**
  * Breakpoint values (matches Primer)


### PR DESCRIPTION
## Summary

- **Form column SSOT**: `AUTH_FORM_COLUMN_CLASS` (`max-w-sm` / 384px) replaces the ad-hoc `max-w-[440px]` on auth-center + web Agent OS split shells, aligned with marketing `AuthPage`.
- **Primary CTAs**: use `variant="ink"` + `AUTH_PRIMARY_CTA_CLASS` instead of fighting `btn-brand-default` background-image with `bg-[hsl(var(--foreground))]` (which left the blue full-width submit looking wider than designed).
- **Governance test**: locks both product shells to the SSOT and bans the foreground-fill fight pattern.
- **Unblock**: export `@nebutra/atelier-canvas/agent` (built by tsup, missing from package exports).

## Why

Credentials column felt “suddenly wide” — 440px + side-by-side OAuth + blue brand-fill CTA that should have been ink. Hard fix is one shared contract, not a local max-width tweak.

## Test plan

- [x] `pnpm --filter @nebutra/ui exec vitest run src/utils/__tests__/auth-surfaces-governance.test.ts`
- [x] `pnpm --filter @nebutra/auth-center typecheck`
- [x] pre-push full typecheck green
- [ ] Visual: `https://auth.nebutra.com/sign-in` form column ~384px, submit ink (near-black), not identity/action blue

## Deploy

Path filters should trigger auth-center deploy after merge to main.