### PR TITLE
fix(ops): run carina-daemon in Docker when host glibc is too old

### DIFF
--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -36,30 +36,79 @@ if [ -S "$SOCKET_PATH" ] && ! pgrep -f "carina-daemon.*$SOCKET_PATH" >/dev/null 
   rm -f "$SOCKET_PATH" || true
 fi
 
-# Start via PM2 when available
-if command -v pm2 >/dev/null 2>&1; then
-  if pm2 describe carina-daemon >/dev/null 2>&1; then
-    pm2 restart carina-daemon --update-env || pm2 reload carina-daemon
+# Detect whether the binary can run on the host (GLIBC). Official linux_amd64
+# builds need GLIBC_2.34+; older ECS images fall back to Docker (ubuntu:22.04).
+needs_docker=0
+if ! "$CARINA_ROOT/bin/carina-daemon" -h >/dev/null 2>&1; then
+  if "$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | grep -qi 'GLIBC'; then
+    echo "Host glibc too old for carina-daemon — using Docker (ubuntu:22.04)"
+    needs_docker=1
   else
-    # Prefer ecosystem entry when present
-    ECO="${PM2_CONFIG:-/var/www/nebutra/ecosystem.config.cjs}"
-    if [ -f "$ECO" ] && grep -q 'carina-daemon' "$ECO" 2>/dev/null; then
-      pm2 start "$ECO" --only carina-daemon
-    else
-      pm2 start "$CARINA_ROOT/bin/carina-daemon" --name carina-daemon -- \
-        -socket "$SOCKET_PATH" \
-        -state "$STATE_DIR" \
-        -approval-mode "$APPROVAL_MODE"
+    # Binary may print help to stderr and exit non-zero; only force docker on GLIBC.
+    if ldd "$CARINA_ROOT/bin/carina-daemon" 2>&1 | grep -qi 'not found\|GLIBC'; then
+      echo "Shared library mismatch for carina-daemon — using Docker"
+      needs_docker=1
     fi
   fi
-  pm2 save || true
+fi
+
+start_native() {
+  if command -v pm2 >/dev/null 2>&1; then
+    # Stop docker variant if any
+    docker rm -f carina-daemon >/dev/null 2>&1 || true
+    if pm2 describe carina-daemon >/dev/null 2>&1; then
+      pm2 restart carina-daemon --update-env || pm2 reload carina-daemon
+    else
+      ECO="${PM2_CONFIG:-/var/www/nebutra/ecosystem.config.cjs}"
+      if [ -f "$ECO" ] && grep -q 'carina-daemon' "$ECO" 2>/dev/null; then
+        pm2 start "$ECO" --only carina-daemon
+      else
+        pm2 start "$CARINA_ROOT/bin/carina-daemon" --name carina-daemon -- \
+          -socket "$SOCKET_PATH" \
+          -state "$STATE_DIR" \
+          -approval-mode "$APPROVAL_MODE"
+      fi
+    fi
+    pm2 save || true
+  else
+    nohup "$CARINA_ROOT/bin/carina-daemon" \
+      -socket "$SOCKET_PATH" \
+      -state "$STATE_DIR" \
+      -approval-mode "$APPROVAL_MODE" \
+      >"$CARINA_ROOT/run/daemon.log" 2>&1 &
+  fi
+}
+
+start_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker required to run carina-daemon on this host (glibc too old)" >&2
+    return 1
+  fi
+  # Prefer not to crash-loop a broken native pm2 app
+  if command -v pm2 >/dev/null 2>&1; then
+    pm2 delete carina-daemon >/dev/null 2>&1 || true
+    pm2 save || true
+  fi
+  docker rm -f carina-daemon >/dev/null 2>&1 || true
+  # Pull once (cached thereafter). ubuntu:22.04 has GLIBC_2.35.
+  docker pull ubuntu:22.04 >/dev/null
+  docker run -d --name carina-daemon --restart unless-stopped \
+    -v "$CARINA_ROOT/run:$CARINA_ROOT/run" \
+    -v "$STATE_DIR:$STATE_DIR" \
+    -v "$WS_ROOT:$WS_ROOT" \
+    -v "$CARINA_ROOT/bin/carina-daemon:/usr/local/bin/carina-daemon:ro" \
+    ubuntu:22.04 \
+    /usr/local/bin/carina-daemon \
+      -socket "$SOCKET_PATH" \
+      -state "$STATE_DIR" \
+      -approval-mode "$APPROVAL_MODE"
+  echo "carina-daemon running in docker (ubuntu:22.04)"
+}
+
+if [ "$needs_docker" = "1" ]; then
+  start_docker
 else
-  echo "pm2 not found — starting carina-daemon in background"
-  nohup "$CARINA_ROOT/bin/carina-daemon" \
-    -socket "$SOCKET_PATH" \
-    -state "$STATE_DIR" \
-    -approval-mode "$APPROVAL_MODE" \
-    >"$CARINA_ROOT/run/daemon.log" 2>&1 &
+  start_native
 fi
 
 # Wait for socket


### PR DESCRIPTION
Production ECS lacks GLIBC_2.34 required by carina-daemon. Auto-fallback to docker ubuntu:22.04 with shared socket volume.