### PR TITLE
fix(ops): CN mirrors for Carina release + Docker image pulls

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -934,8 +934,27 @@ jobs:
           URL="https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSION}/${ASSET}"
           echo "Pre-staging carina-daemon from $URL"
           mkdir -p /tmp/carina-stage
-          curl -fsSL --connect-timeout 30 --max-time 300 --retry 3 \
-            "$URL" -o "/tmp/carina-stage/$ASSET"
+          # Prefer origin on GH runners; fall back to CN proxies if origin flakes.
+          ok=0
+          for try_url in \
+            "$URL" \
+            "https://ghfast.top/$URL" \
+            "https://ghproxy.net/$URL" \
+            "https://mirror.ghproxy.com/$URL"
+          do
+            echo "  try $try_url"
+            if curl -fsSL --connect-timeout 20 --max-time 180 --retry 1 \
+                "$try_url" -o "/tmp/carina-stage/$ASSET" \
+              && tar -tzf "/tmp/carina-stage/$ASSET" >/dev/null 2>&1; then
+              ok=1
+              break
+            fi
+            rm -f "/tmp/carina-stage/$ASSET"
+          done
+          if [ "$ok" != "1" ]; then
+            echo "::error::failed to download carina release (origin + mirrors)"
+            exit 1
+          fi
           tar -xzf "/tmp/carina-stage/$ASSET" -C /tmp/carina-stage
           BIN="$(find /tmp/carina-stage -type f -name carina-daemon | head -1)"
           if [ -z "$BIN" ]; then

--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -91,13 +91,41 @@ start_docker() {
   fi
   docker rm -f carina-daemon >/dev/null 2>&1 || true
   # Pull once (cached thereafter). ubuntu:22.04 has GLIBC_2.35.
-  docker pull ubuntu:22.04 >/dev/null
+  # Prefer CN registry mirrors when Docker Hub is slow.
+  pull_ubuntu() {
+    local refs=(
+      "${CARINA_DOCKER_IMAGE:-}"
+      "docker.m.daocloud.io/library/ubuntu:22.04"
+      "dockerproxy.net/library/ubuntu:22.04"
+      "ubuntu:22.04"
+    )
+    local r
+    for r in "${refs[@]}"; do
+      [ -n "$r" ] || continue
+      echo "docker pull $r"
+      if docker pull "$r"; then
+        # Retag so run uses a stable local name
+        docker tag "$r" carina-runtime-ubuntu:22.04 2>/dev/null || true
+        echo "$r"
+        return 0
+      fi
+    done
+    return 1
+  }
+  IMAGE_REF="$(pull_ubuntu)" || {
+    echo "ERROR: failed to pull ubuntu:22.04 (try CARINA_DOCKER_IMAGE=...)" >&2
+    return 1
+  }
+  # Prefer retagged name when available
+  if docker image inspect carina-runtime-ubuntu:22.04 >/dev/null 2>&1; then
+    IMAGE_REF="carina-runtime-ubuntu:22.04"
+  fi
   docker run -d --name carina-daemon --restart unless-stopped \
     -v "$CARINA_ROOT/run:$CARINA_ROOT/run" \
     -v "$STATE_DIR:$STATE_DIR" \
     -v "$WS_ROOT:$WS_ROOT" \
     -v "$CARINA_ROOT/bin/carina-daemon:/usr/local/bin/carina-daemon:ro" \
-    ubuntu:22.04 \
+    "$IMAGE_REF" \
     /usr/local/bin/carina-daemon \
       -socket "$SOCKET_PATH" \
       -state "$STATE_DIR" \

--- a/infra/ops/scripts/install-carina-daemon.sh
+++ b/infra/ops/scripts/install-carina-daemon.sh
@@ -7,9 +7,15 @@
 #   /var/carina/ws               (workspace root)
 #   /var/carina/state            (session/event storage)
 #
+# Download order (fastest path first for CN ECS):
+#   1) CI-staged binary at /tmp/carina-ops/carina-daemon
+#   2) CARINA_RELEASE_URL (explicit override)
+#   3) GitHub release via CN-friendly mirrors, then origin
+#
 # Usage (on the VM):
 #   sudo bash install-carina-daemon.sh
 #   CARINA_VERSION=0.8.1 bash install-carina-daemon.sh
+#   CARINA_RELEASE_MIRRORS="https://ghfast.top/ https://ghproxy.net/" bash install-carina-daemon.sh
 set -euo pipefail
 
 CARINA_VERSION="${CARINA_VERSION:-0.8.1}"
@@ -22,11 +28,11 @@ case "$ARCH" in
 esac
 
 ASSET="carina_${CARINA_VERSION}_${ARCH_TAG}.tar.gz"
-URL="${CARINA_RELEASE_URL:-https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSION}/${ASSET}}"
+ORIGIN_URL="https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSION}/${ASSET}"
 
 mkdir -p "$CARINA_ROOT/bin" "$CARINA_ROOT/run" "$CARINA_ROOT/ws" "$CARINA_ROOT/state" "$CARINA_ROOT/tmp"
 
-# Prefer a binary pre-staged by CI (avoids slow GH→China ECS download).
+# Prefer a binary pre-staged by CI (avoids any GH→China download).
 STAGED="${CARINA_STAGED_BIN:-/tmp/carina-ops/carina-daemon}"
 if [ -f "$STAGED" ] && [ -s "$STAGED" ]; then
   install -m 0755 "$STAGED" "$CARINA_ROOT/bin/carina-daemon"
@@ -38,15 +44,97 @@ fi
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-echo "Downloading $URL"
-# Hard timeouts — GH Actions SSH session must not hang forever on a bad release CDN.
-if ! curl -fsSL --connect-timeout 30 --max-time 480 --retry 3 --retry-delay 5     "$URL" -o "$TMP/$ASSET"; then
-  echo "ERROR: failed to download $URL" >&2
+# Build candidate URL list.
+# Mirrors prefix the full origin URL (common GH proxy pattern).
+# Override: CARINA_RELEASE_URL=... (single) or CARINA_RELEASE_MIRRORS="m1 m2"
+urls=()
+if [ -n "${CARINA_RELEASE_URL:-}" ]; then
+  urls+=("$CARINA_RELEASE_URL")
+fi
+
+# Default CN-friendly proxies (order: historically faster → origin).
+# Operators can replace entirely via CARINA_RELEASE_MIRRORS.
+DEFAULT_MIRRORS=(
+  "https://ghfast.top/"
+  "https://ghproxy.net/"
+  "https://mirror.ghproxy.com/"
+  "https://gitdl.cn/"
+  "https://gh.ddlc.top/"
+)
+
+if [ -n "${CARINA_RELEASE_MIRRORS:-}" ]; then
+  # shellcheck disable=SC2206
+  DEFAULT_MIRRORS=($CARINA_RELEASE_MIRRORS)
+fi
+
+for m in "${DEFAULT_MIRRORS[@]}"; do
+  # Accept either full URL or prefix mirror
+  case "$m" in
+    http*"$ASSET"*) urls+=("$m") ;;
+    */) urls+=("${m}${ORIGIN_URL#https://}") ;; # some mirrors want host path without scheme re-add
+  esac
+done
+
+# Fix prefix mirrors: standard pattern is mirror + full https://github.com/...
+urls=()
+if [ -n "${CARINA_RELEASE_URL:-}" ]; then
+  urls+=("$CARINA_RELEASE_URL")
+fi
+if [ -n "${CARINA_RELEASE_MIRRORS:-}" ]; then
+  # shellcheck disable=SC2206
+  for m in $CARINA_RELEASE_MIRRORS; do
+    case "$m" in
+      */) urls+=("${m}${ORIGIN_URL}") ;;
+      *) urls+=("${m%/}/${ORIGIN_URL}") ;;
+    esac
+  done
+else
+  for m in \
+    "https://ghfast.top/" \
+    "https://ghproxy.net/" \
+    "https://mirror.ghproxy.com/" \
+    "https://gitdl.cn/" \
+    "https://gh.ddlc.top/"
+  do
+    urls+=("${m}${ORIGIN_URL}")
+  done
+fi
+# Always try origin last (US/global).
+urls+=("$ORIGIN_URL")
+
+download_ok=0
+for URL in "${urls[@]}"; do
+  echo "Trying $URL"
+  # Short per-attempt budget so we rotate mirrors quickly on CN links.
+  if curl -fsSL \
+      --connect-timeout 15 \
+      --max-time 120 \
+      --retry 1 \
+      --retry-delay 2 \
+      -A "nebutra-carina-install/1.0" \
+      "$URL" -o "$TMP/$ASSET"; then
+    # Basic sanity: gzip/tar magic, non-empty
+    if [ -s "$TMP/$ASSET" ] && tar -tzf "$TMP/$ASSET" >/dev/null 2>&1; then
+      echo "Downloaded via $URL"
+      download_ok=1
+      break
+    fi
+    echo "  bad archive from $URL — try next"
+    rm -f "$TMP/$ASSET"
+  else
+    echo "  failed — try next"
+    rm -f "$TMP/$ASSET"
+  fi
+done
+
+if [ "$download_ok" != "1" ]; then
+  echo "ERROR: failed to download $ASSET from all mirrors + origin" >&2
+  echo "Hint: set CARINA_RELEASE_URL or stage binary at $STAGED" >&2
   exit 1
 fi
+
 tar -xzf "$TMP/$ASSET" -C "$TMP"
 
-# tarball layout may nest binaries; find carina-daemon
 BIN="$(find "$TMP" -type f -name 'carina-daemon' | head -1)"
 if [ -z "$BIN" ]; then
   echo "carina-daemon not found in archive" >&2
@@ -55,7 +143,6 @@ if [ -z "$BIN" ]; then
 fi
 install -m 0755 "$BIN" "$CARINA_ROOT/bin/carina-daemon"
 
-# optional CLI helpers
 for name in carina carina-cli; do
   C="$(find "$TMP" -type f -name "$name" | head -1 || true)"
   if [ -n "$C" ]; then


### PR DESCRIPTION
## Why

Production ECS in China cannot finish `github.com/.../releases/download` within deploy budgets. DNS/path to GitHub is the bottleneck, not the install logic.

## What

- **install-carina-daemon.sh**: mirror chain (ghfast → ghproxy → mirror.ghproxy → gitdl → gh.ddlc → origin), 120s per attempt, validate tar before accept
- **carina-codeploy.sh**: Docker `ubuntu:22.04` via DaoCloud / dockerproxy before Docker Hub
- **deploy-ecs.yml**: CI prestage also tries the same GH proxies if origin flakes
- Overrides: `CARINA_RELEASE_URL`, `CARINA_RELEASE_MIRRORS`, `CARINA_DOCKER_IMAGE`

## Still preferred

CI-staged binary (`/tmp/carina-ops/carina-daemon`) remains **first** — zero CN download when deploy scp works.