### PR TITLE
fix(ops): ship carina-kernel-service for co-deploy socket

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -957,16 +957,41 @@ jobs:
           fi
           tar -xzf "/tmp/carina-stage/$ASSET" -C /tmp/carina-stage
           BIN="$(find /tmp/carina-stage -type f -name carina-daemon | head -1)"
+          KERNEL="$(find /tmp/carina-stage -type f -name carina-kernel-service | head -1)"
           if [ -z "$BIN" ]; then
             echo "::warning::carina-daemon not found in release archive — VM will try network install"
           else
             scp "${SCP_OPTS[@]}" "$BIN" \
               "${ECS_USER}@${ECS_HOST}:/tmp/carina-ops/carina-daemon"
           fi
+          if [ -z "$KERNEL" ]; then
+            echo "::warning::carina-kernel-service not found in release archive — daemon will not start without it"
+          else
+            # Required child process of carina-daemon (capability kernel).
+            scp "${SCP_OPTS[@]}" "$KERNEL" \
+              "${ECS_USER}@${ECS_HOST}:/tmp/carina-ops/carina-kernel-service"
+          fi
+          # Optional zig native tools (carina-scan, carina-patch, …) next to daemon.
+          mkdir -p /tmp/carina-stage/tools-out
+          while IFS= read -r -d '' tool; do
+            base="$(basename "$tool")"
+            case "$base" in
+              carina-daemon|carina-kernel-service|carina|carina-cli|carina-worker|carina-tui|carina-ui) continue ;;
+            esac
+            cp "$tool" "/tmp/carina-stage/tools-out/$base"
+          done < <(find /tmp/carina-stage -type f -name 'carina-*' -print0 2>/dev/null || true)
+          if [ -n "$(ls -A /tmp/carina-stage/tools-out 2>/dev/null || true)" ]; then
+            ssh -i ~/.ssh/id_deploy -p "${ECS_SSH_PORT}" \
+                -o StrictHostKeyChecking=yes -o ConnectTimeout=20 \
+                "${ECS_USER}@${ECS_HOST}" \
+                'mkdir -p /tmp/carina-ops/tools'
+            scp "${SCP_OPTS[@]}" /tmp/carina-stage/tools-out/* \
+              "${ECS_USER}@${ECS_HOST}:/tmp/carina-ops/tools/" || true
+          fi
           ssh -i ~/.ssh/id_deploy -p "${ECS_SSH_PORT}" \
               -o StrictHostKeyChecking=yes -o ConnectTimeout=20 \
               "${ECS_USER}@${ECS_HOST}" \
-              'chmod +x /tmp/carina-ops/*.sh /tmp/carina-ops/carina-daemon 2>/dev/null || chmod +x /tmp/carina-ops/*.sh'
+              'chmod +x /tmp/carina-ops/*.sh /tmp/carina-ops/carina-daemon /tmp/carina-ops/carina-kernel-service /tmp/carina-ops/tools/* 2>/dev/null || chmod +x /tmp/carina-ops/*.sh'
           scp "${SCP_OPTS[@]}" infra/iac/ecs/ecosystem.config.cjs \
             "${ECS_USER}@${ECS_HOST}:${ECS_DEPLOY_ROOT}/ecosystem.config.cjs"
           scp "${SCP_OPTS[@]}" infra/runtime/nginx/nginx.conf \

--- a/infra/iac/ecs/ecosystem.config.cjs
+++ b/infra/iac/ecs/ecosystem.config.cjs
@@ -146,16 +146,18 @@ module.exports = {
     },
     {
       // Carina Track-B kernel — same host as api-gateway (local-first co-deploy).
-      // Install binary: infra/ops/scripts/install-carina-daemon.sh
+      // Install binaries: infra/ops/scripts/install-carina-daemon.sh
+      //   (carina-daemon + carina-kernel-service; docker fallback when glibc is old)
       // Socket: /var/carina/run/daemon.sock → CARINA_DAEMON_SOCK on api-gateway.
       name: "carina-daemon",
       cwd: "/var/carina",
       script: "/var/carina/bin/carina-daemon",
-      args: "-socket /var/carina/run/daemon.sock -state /var/carina/state -approval-mode always-approve",
+      args: "-socket /var/carina/run/daemon.sock -state /var/carina/state -kernel /var/carina/bin/carina-kernel-service -tools /var/carina/bin -approval-mode always-approve",
       interpreter: "none",
       env: {
-        HOME: "/var/carina",
+        HOME: "/var/carina/home",
         CARINA_HOME: "/var/carina",
+        CARINA_KERNEL_BIN: "/var/carina/bin/carina-kernel-service",
       },
       max_memory_restart: "512M",
       instances: 1,

--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Same-host Carina co-deploy with Sailor api-gateway.
 #
-# 1) Ensures binary + dirs under /var/carina
-# 2) Starts/reloads PM2 process `carina-daemon`
+# 1) Ensures binary + kernel + dirs under /var/carina
+# 2) Starts/reloads PM2 process `carina-daemon` (or Docker when host glibc is old)
 # 3) Injects default api-gateway env (socket + workspace + demo flag)
 #
 # Usage (on the VM as deploy user with sudo for /var/carina if needed):
@@ -16,20 +16,33 @@ SOCKET_PATH="${CARINA_DAEMON_SOCK:-$CARINA_ROOT/run/daemon.sock}"
 STATE_DIR="${CARINA_STATE_DIR:-$CARINA_ROOT/state}"
 WS_ROOT="${CARINA_WORKSPACE_ROOT:-$CARINA_ROOT/ws}"
 APPROVAL_MODE="${CARINA_SESSION_APPROVAL_MODE:-always-approve}"
+KERNEL_BIN="${CARINA_KERNEL_BIN:-$CARINA_ROOT/bin/carina-kernel-service}"
+DAEMON_BIN="${CARINA_DAEMON_BIN:-$CARINA_ROOT/bin/carina-daemon}"
+TOOLS_DIR="${CARINA_TOOLS_DIR:-$CARINA_ROOT/bin}"
 
 # Env first — gateway can fail-closed cleanly while daemon installs.
 echo "Injecting api-gateway Carina env (co-deploy defaults)…"
 bash "$SCRIPTS_DIR/configure-api-carina-env.sh" || true
 
-if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ]; then
-  echo "Installing carina-daemon…"
+# Daemon alone is not enough — kernel child is required for capability startup.
+if [ ! -x "$DAEMON_BIN" ] || [ ! -x "$KERNEL_BIN" ]; then
+  echo "Installing carina-daemon + carina-kernel-service…"
   if ! bash "$SCRIPTS_DIR/install-carina-daemon.sh"; then
     echo "ERROR: install-carina-daemon.sh failed" >&2
     exit 1
   fi
 fi
 
-mkdir -p "$CARINA_ROOT/run" "$WS_ROOT" "$STATE_DIR"
+if [ ! -x "$DAEMON_BIN" ]; then
+  echo "ERROR: missing $DAEMON_BIN" >&2
+  exit 1
+fi
+if [ ! -x "$KERNEL_BIN" ]; then
+  echo "ERROR: missing $KERNEL_BIN (carina-daemon cannot start without it)" >&2
+  exit 1
+fi
+
+mkdir -p "$CARINA_ROOT/run" "$WS_ROOT" "$STATE_DIR" "$CARINA_ROOT/home"
 
 # Remove stale socket if present and no live process
 if [ -S "$SOCKET_PATH" ] && ! pgrep -f "carina-daemon.*$SOCKET_PATH" >/dev/null 2>&1; then
@@ -39,18 +52,29 @@ fi
 # Detect whether the binary can run on the host (GLIBC). Official linux_amd64
 # builds need GLIBC_2.34+; older ECS images fall back to Docker (ubuntu:22.04).
 needs_docker=0
-if ! "$CARINA_ROOT/bin/carina-daemon" -h >/dev/null 2>&1; then
-  if "$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | grep -qi 'GLIBC'; then
+if ! "$DAEMON_BIN" -h >/dev/null 2>&1; then
+  if "$DAEMON_BIN" -h 2>&1 | grep -qi 'GLIBC'; then
     echo "Host glibc too old for carina-daemon — using Docker (ubuntu:22.04)"
     needs_docker=1
   else
     # Binary may print help to stderr and exit non-zero; only force docker on GLIBC.
-    if ldd "$CARINA_ROOT/bin/carina-daemon" 2>&1 | grep -qi 'not found\|GLIBC'; then
+    if ldd "$DAEMON_BIN" 2>&1 | grep -qi 'not found\|GLIBC'; then
       echo "Shared library mismatch for carina-daemon — using Docker"
+      needs_docker=1
+    elif ldd "$KERNEL_BIN" 2>&1 | grep -qi 'not found\|GLIBC'; then
+      echo "Shared library mismatch for carina-kernel-service — using Docker"
       needs_docker=1
     fi
   fi
 fi
+
+daemon_args=(
+  -socket "$SOCKET_PATH"
+  -state "$STATE_DIR"
+  -kernel "$KERNEL_BIN"
+  -tools "$TOOLS_DIR"
+  -approval-mode "$APPROVAL_MODE"
+)
 
 start_native() {
   if command -v pm2 >/dev/null 2>&1; then
@@ -63,18 +87,15 @@ start_native() {
       if [ -f "$ECO" ] && grep -q 'carina-daemon' "$ECO" 2>/dev/null; then
         pm2 start "$ECO" --only carina-daemon
       else
-        pm2 start "$CARINA_ROOT/bin/carina-daemon" --name carina-daemon -- \
-          -socket "$SOCKET_PATH" \
-          -state "$STATE_DIR" \
-          -approval-mode "$APPROVAL_MODE"
+        pm2 start "$DAEMON_BIN" --name carina-daemon -- \
+          "${daemon_args[@]}"
       fi
     fi
     pm2 save || true
   else
-    nohup "$CARINA_ROOT/bin/carina-daemon" \
-      -socket "$SOCKET_PATH" \
-      -state "$STATE_DIR" \
-      -approval-mode "$APPROVAL_MODE" \
+    nohup env HOME="$CARINA_ROOT/home" CARINA_KERNEL_BIN="$KERNEL_BIN" \
+      "$DAEMON_BIN" \
+      "${daemon_args[@]}" \
       >"$CARINA_ROOT/run/daemon.log" 2>&1 &
   fi
 }
@@ -121,25 +142,40 @@ start_docker() {
     IMAGE_REF="carina-runtime-ubuntu:22.04"
   fi
   # Ensure host dirs exist and are writable from container (root)
-  mkdir -p "$CARINA_ROOT/run" "$STATE_DIR" "$WS_ROOT"
-  chmod 755 "$CARINA_ROOT/run" "$STATE_DIR" "$WS_ROOT" || true
+  mkdir -p "$CARINA_ROOT/run" "$STATE_DIR" "$WS_ROOT" "$CARINA_ROOT/home"
+  chmod 755 "$CARINA_ROOT/run" "$STATE_DIR" "$WS_ROOT" "$CARINA_ROOT/home" || true
   rm -f "$SOCKET_PATH" || true
 
+  # Mount full bin/ so kernel auto-discover (sibling of daemon) works, and set
+  # CARINA_KERNEL_BIN explicitly. Do NOT bind only carina-daemon into
+  # /usr/local/bin — that orphans the kernel.
   docker run -d --name carina-daemon --restart unless-stopped \
-    -e HOME="$CARINA_ROOT" \
+    -e HOME="$CARINA_ROOT/home" \
+    -e CARINA_KERNEL_BIN="$KERNEL_BIN" \
+    -e PATH="$CARINA_ROOT/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    -v "$CARINA_ROOT/bin:$CARINA_ROOT/bin:ro" \
     -v "$CARINA_ROOT/run:$CARINA_ROOT/run" \
     -v "$STATE_DIR:$STATE_DIR" \
     -v "$WS_ROOT:$WS_ROOT" \
-    -v "$CARINA_ROOT/bin/carina-daemon:/usr/local/bin/carina-daemon:ro" \
+    -v "$CARINA_ROOT/home:$CARINA_ROOT/home" \
     "$IMAGE_REF" \
-    /usr/local/bin/carina-daemon \
-      -socket "$SOCKET_PATH" \
-      -state "$STATE_DIR" \
-      -approval-mode "$APPROVAL_MODE"
-  echo "carina-daemon running in docker ($IMAGE_REF)"
+    "$DAEMON_BIN" \
+      "${daemon_args[@]}"
+  echo "carina-daemon running in docker ($IMAGE_REF) kernel=$KERNEL_BIN"
   # Brief settle before wait loop
   sleep 2
-  docker ps --filter name=carina-daemon --format 'table {{.Names}}\t{{.Status}}' || true
+  docker ps -a --filter name=carina-daemon --format 'table {{.Names}}\t{{.Status}}' || true
+  # Surface first crash immediately (kernel missing used to loop Restarting)
+  if ! docker ps --format '{{.Names}}' | grep -qx carina-daemon; then
+    echo "ERROR: carina-daemon container exited immediately" >&2
+    docker logs carina-daemon 2>&1 | tail -40 >&2 || true
+    return 1
+  fi
+  # If already restarting, dump logs early
+  if docker ps --filter name=carina-daemon --format '{{.Status}}' | grep -qi restarting; then
+    echo "WARNING: carina-daemon is restarting — recent logs:" >&2
+    docker logs carina-daemon 2>&1 | tail -20 >&2 || true
+  fi
 }
 
 if [ "$needs_docker" = "1" ]; then
@@ -168,6 +204,14 @@ for i in $(seq 1 "$wait_secs"); do
       docker logs carina-daemon 2>&1 | tail -40 >&2 || true
       break
     fi
+    if docker ps --filter name=carina-daemon --format '{{.Status}}' | grep -qi restarting; then
+      # Give a few seconds of backoff, but don't wait full 120s on crash-loop
+      if [ "$i" -ge 15 ]; then
+        echo "ERROR: carina-daemon crash-looping (status=Restarting)" >&2
+        docker logs carina-daemon 2>&1 | tail -40 >&2 || true
+        break
+      fi
+    fi
   fi
   sleep 1
 done
@@ -180,6 +224,7 @@ if [ "$ready" != "1" ]; then
   if command -v pm2 >/dev/null 2>&1; then
     pm2 describe carina-daemon 2>&1 | tail -20 >&2 || true
   fi
+  ls -la "$CARINA_ROOT/bin" 2>&1 | tail -20 >&2 || true
   exit 1
 fi
 
@@ -188,5 +233,6 @@ bash "$SCRIPTS_DIR/configure-api-carina-env.sh" || true
 
 echo "Carina co-deploy complete."
 echo "  socket:    $SOCKET_PATH"
+echo "  kernel:    $KERNEL_BIN"
 echo "  workspace: $WS_ROOT"
 echo "  api env:   $API_ENV_FILE"

--- a/infra/ops/scripts/install-carina-daemon.sh
+++ b/infra/ops/scripts/install-carina-daemon.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# Install carina-daemon binary for same-host Track-B co-deploy with api-gateway.
+# Install carina-daemon + carina-kernel-service for same-host Track-B co-deploy.
 #
 # Default layout:
 #   /var/carina/bin/carina-daemon
-#   /var/carina/run/daemon.sock   (created at runtime)
-#   /var/carina/ws               (workspace root)
-#   /var/carina/state            (session/event storage)
+#   /var/carina/bin/carina-kernel-service   (required — daemon spawns this)
+#   /var/carina/bin/carina-*               (optional zig native tools)
+#   /var/carina/run/daemon.sock            (created at runtime)
+#   /var/carina/ws                         (workspace root)
+#   /var/carina/state                      (session/event storage)
 #
 # Download order (fastest path first for CN ECS):
-#   1) CI-staged binary at /tmp/carina-ops/carina-daemon
+#   1) CI-staged binaries at /tmp/carina-ops/{carina-daemon,carina-kernel-service}
 #   2) CARINA_RELEASE_URL (explicit override)
 #   3) GitHub release via CN-friendly mirrors, then origin
 #
@@ -32,13 +34,46 @@ ORIGIN_URL="https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSIO
 
 mkdir -p "$CARINA_ROOT/bin" "$CARINA_ROOT/run" "$CARINA_ROOT/ws" "$CARINA_ROOT/state" "$CARINA_ROOT/tmp"
 
-# Prefer a binary pre-staged by CI (avoids any GH→China download).
-STAGED="${CARINA_STAGED_BIN:-/tmp/carina-ops/carina-daemon}"
-if [ -f "$STAGED" ] && [ -s "$STAGED" ]; then
-  install -m 0755 "$STAGED" "$CARINA_ROOT/bin/carina-daemon"
-  echo "Installed $CARINA_ROOT/bin/carina-daemon from staged $STAGED"
-  "$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | head -5 || true
+STAGED_DIR="${CARINA_STAGED_DIR:-/tmp/carina-ops}"
+STAGED_DAEMON="${CARINA_STAGED_BIN:-$STAGED_DIR/carina-daemon}"
+STAGED_KERNEL="${CARINA_STAGED_KERNEL:-$STAGED_DIR/carina-kernel-service}"
+
+install_bin() {
+  local src="$1" dest="$2"
+  install -m 0755 "$src" "$dest"
+  echo "Installed $dest"
+}
+
+# Prefer CI-staged binaries (avoids any GH→China download).
+staged_ok=0
+if [ -f "$STAGED_DAEMON" ] && [ -s "$STAGED_DAEMON" ]; then
+  install_bin "$STAGED_DAEMON" "$CARINA_ROOT/bin/carina-daemon"
+  staged_ok=1
+fi
+if [ -f "$STAGED_KERNEL" ] && [ -s "$STAGED_KERNEL" ]; then
+  install_bin "$STAGED_KERNEL" "$CARINA_ROOT/bin/carina-kernel-service"
+fi
+# Optional zig tools staged as /tmp/carina-ops/tools/carina-*
+if [ -d "$STAGED_DIR/tools" ]; then
+  for t in "$STAGED_DIR"/tools/carina-*; do
+    [ -f "$t" ] || continue
+    install_bin "$t" "$CARINA_ROOT/bin/$(basename "$t")"
+  done
+fi
+
+need_archive=0
+if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ] || [ ! -x "$CARINA_ROOT/bin/carina-kernel-service" ]; then
+  need_archive=1
+fi
+
+if [ "$need_archive" = "0" ]; then
+  echo "Carina binaries ready under $CARINA_ROOT/bin (staged path)"
+  "$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | head -8 || true
   exit 0
+fi
+
+if [ "$staged_ok" = "1" ] && [ ! -x "$CARINA_ROOT/bin/carina-kernel-service" ]; then
+  echo "Staged carina-daemon present but carina-kernel-service missing — fetching full release archive"
 fi
 
 TMP="$(mktemp -d)"
@@ -47,35 +82,6 @@ trap 'rm -rf "$TMP"' EXIT
 # Build candidate URL list.
 # Mirrors prefix the full origin URL (common GH proxy pattern).
 # Override: CARINA_RELEASE_URL=... (single) or CARINA_RELEASE_MIRRORS="m1 m2"
-urls=()
-if [ -n "${CARINA_RELEASE_URL:-}" ]; then
-  urls+=("$CARINA_RELEASE_URL")
-fi
-
-# Default CN-friendly proxies (order: historically faster → origin).
-# Operators can replace entirely via CARINA_RELEASE_MIRRORS.
-DEFAULT_MIRRORS=(
-  "https://ghfast.top/"
-  "https://ghproxy.net/"
-  "https://mirror.ghproxy.com/"
-  "https://gitdl.cn/"
-  "https://gh.ddlc.top/"
-)
-
-if [ -n "${CARINA_RELEASE_MIRRORS:-}" ]; then
-  # shellcheck disable=SC2206
-  DEFAULT_MIRRORS=($CARINA_RELEASE_MIRRORS)
-fi
-
-for m in "${DEFAULT_MIRRORS[@]}"; do
-  # Accept either full URL or prefix mirror
-  case "$m" in
-    http*"$ASSET"*) urls+=("$m") ;;
-    */) urls+=("${m}${ORIGIN_URL#https://}") ;; # some mirrors want host path without scheme re-add
-  esac
-done
-
-# Fix prefix mirrors: standard pattern is mirror + full https://github.com/...
 urls=()
 if [ -n "${CARINA_RELEASE_URL:-}" ]; then
   urls+=("$CARINA_RELEASE_URL")
@@ -129,7 +135,7 @@ done
 
 if [ "$download_ok" != "1" ]; then
   echo "ERROR: failed to download $ASSET from all mirrors + origin" >&2
-  echo "Hint: set CARINA_RELEASE_URL or stage binary at $STAGED" >&2
+  echo "Hint: set CARINA_RELEASE_URL or stage binaries at $STAGED_DIR" >&2
   exit 1
 fi
 
@@ -141,14 +147,36 @@ if [ -z "$BIN" ]; then
   ls -laR "$TMP" >&2 || true
   exit 1
 fi
-install -m 0755 "$BIN" "$CARINA_ROOT/bin/carina-daemon"
+install_bin "$BIN" "$CARINA_ROOT/bin/carina-daemon"
 
-for name in carina carina-cli; do
+KERNEL="$(find "$TMP" -type f -name 'carina-kernel-service' | head -1)"
+if [ -z "$KERNEL" ]; then
+  echo "ERROR: carina-kernel-service not found in archive (required by carina-daemon)" >&2
+  ls -laR "$TMP" >&2 || true
+  exit 1
+fi
+install_bin "$KERNEL" "$CARINA_ROOT/bin/carina-kernel-service"
+
+# CLI helpers + zig native tools (carina-scan, carina-patch, …) live next to daemon.
+for name in carina carina-cli carina-worker; do
   C="$(find "$TMP" -type f -name "$name" | head -1 || true)"
   if [ -n "$C" ]; then
-    install -m 0755 "$C" "$CARINA_ROOT/bin/$name"
+    install_bin "$C" "$CARINA_ROOT/bin/$name"
   fi
 done
+while IFS= read -r -d '' tool; do
+  base="$(basename "$tool")"
+  case "$base" in
+    carina-daemon|carina-kernel-service|carina|carina-cli|carina-worker|carina-tui|carina-ui) continue ;;
+  esac
+  install_bin "$tool" "$CARINA_ROOT/bin/$base"
+done < <(find "$TMP" -type f -name 'carina-*' -print0 2>/dev/null || true)
 
-echo "Installed $CARINA_ROOT/bin/carina-daemon (v${CARINA_VERSION})"
-"$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | head -5 || true
+if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ] || [ ! -x "$CARINA_ROOT/bin/carina-kernel-service" ]; then
+  echo "ERROR: incomplete install under $CARINA_ROOT/bin" >&2
+  ls -la "$CARINA_ROOT/bin" >&2 || true
+  exit 1
+fi
+
+echo "Installed carina-daemon + carina-kernel-service (v${CARINA_VERSION}) → $CARINA_ROOT/bin"
+"$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | head -8 || true


### PR DESCRIPTION
## Summary
Production co-deploy left the socket missing because `carina-daemon` started in Docker then crash-looped:

```
cannot start capability kernel: carina-kernel-service not found
```

We only installed/prestaged `carina-daemon`, and Docker bind-mounted that single binary into `/usr/local/bin`, so kernel auto-discover (sibling of the daemon executable) could never succeed.

## Changes
- Install **both** `carina-daemon` and `carina-kernel-service` (plus optional `carina-*` zig tools)
- CI prestage + scp the kernel (and tools) to `/tmp/carina-ops/`
- Docker path: mount full `/var/carina/bin`, set `CARINA_KERNEL_BIN`, pass `-kernel` / `-tools`
- Fail faster on crash-loop (`Restarting`) instead of waiting full 120s
- PM2 ecosystem args include `-kernel` / `-tools`

## Test plan
- [x] Root cause confirmed in deploy logs (run 30877785987)
- [ ] Merge + `workflow_dispatch` deploy-ecs with `apps=api`
- [ ] Remote log shows `carina socket ready: /var/carina/run/daemon.sock`
- [ ] No `carina-kernel-service not found` in docker logs