### PR TITLE
fix(auth): tighten login column to max-w-xs and stack dual OAuth

### DIFF
--- a/apps/auth/src/components/oauth-buttons.tsx
+++ b/apps/auth/src/components/oauth-buttons.tsx
@@ -116,8 +116,12 @@ export function OAuthButtons({ providers, returnTo }: OAuthButtonsProps) {
     window.location.assign(buildOAuthStartPath(provider, returnTo));
   }
 
+  // Two providers side-by-side stretches empty pills across the login card;
+  // dual columns only pay off at three or more.
+  const multiCol = providers.length >= 3;
+
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+    <div className={multiCol ? "grid grid-cols-1 gap-3 sm:grid-cols-2" : "grid grid-cols-1 gap-3"}>
       {providers.map((provider) => {
         const Icon = PROVIDER_ICON[provider];
         const label =

--- a/apps/web/src/components/auth/oauth-buttons.tsx
+++ b/apps/web/src/components/auth/oauth-buttons.tsx
@@ -123,8 +123,12 @@ export function OAuthButtons({ mode, providers = OAUTH_PROVIDERS, returnUrl }: O
 
   if (providers.length === 0) return null;
 
+  // Two providers side-by-side stretches empty pills across the login card;
+  // dual columns only pay off at three or more.
+  const multiCol = providers.length >= 3;
+
   return (
-    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
+    <div className={multiCol ? "grid gap-3 grid-cols-1 sm:grid-cols-2" : "grid gap-3 grid-cols-1"}>
       {providers.map((provider) => {
         const Icon = PROVIDER_ICON[provider];
         const label = t(`providers.${provider}`);

--- a/packages/design/ui/src/tokens/spacing.ts
+++ b/packages/design/ui/src/tokens/spacing.ts
@@ -54,8 +54,8 @@ export const semanticSpacing = {
  * told to follow.
  */
 export const containerWidths = {
-  /** Credentials / auth form column — form-scale, not page-scale. */
-  authForm: "max-w-sm", // 24rem / 384px — SSOT: AUTH_FORM_COLUMN_CLASS in utils/auth-surfaces
+  /** Credentials / auth form column — login-card scale, not page-form. */
+  authForm: "max-w-xs", // 20rem / 320px — SSOT: AUTH_FORM_COLUMN_CLASS in utils/auth-surfaces
   narrow: "max-w-[var(--container-text)]", // 896px - FAQ, focused reading
   medium: "max-w-[var(--container-content)]", // 1152px - Architecture, Pricing
   wide: "max-w-[var(--container-wide)]", // 1400px - Full layouts, Bento

--- a/packages/design/ui/src/utils/__tests__/auth-surfaces-governance.test.ts
+++ b/packages/design/ui/src/utils/__tests__/auth-surfaces-governance.test.ts
@@ -7,7 +7,7 @@ import { AUTH_FORM_COLUMN_CLASS, AUTH_PRIMARY_CTA_CLASS } from "../auth-surfaces
  * Auth form-column + primary CTA contracts.
  *
  * Hard-and-correct: one width, one CTA recipe. Both product shells
- * (auth-center + Agent OS web) must import the SSOT; magic pixel max-widths
+ * (auth-center + Agent OS web) must import the SSOT; ad-hoc max-widths
  * and bg-[hsl(var(--foreground))] fights against btn-brand-default are
  * banned so the column cannot silently widen or re-paint identity blue.
  *
@@ -30,12 +30,18 @@ const AUTH_SURFACES = [
   "apps/web/src/components/auth/clerk-enterprise-sso-handoff.tsx",
 ] as const;
 
+const OAUTH_BUTTONS = [
+  "apps/auth/src/components/oauth-buttons.tsx",
+  "apps/web/src/components/auth/oauth-buttons.tsx",
+] as const;
+
 const FOREGROUND_FILL_FIGHT =
   /bg-\[hsl\(var\(--foreground\)\)\][\s\S]{0,120}text-\[hsl\(var\(--background\)\)\]/;
 
 describe("auth surface layout contracts", () => {
-  it("exports a form-scale column (max-w-sm), not a magic pixel width", () => {
-    expect(AUTH_FORM_COLUMN_CLASS).toContain("max-w-sm");
+  it("exports a login-card column (max-w-xs / 20rem), not looser form scales", () => {
+    expect(AUTH_FORM_COLUMN_CLASS).toContain("max-w-xs");
+    expect(AUTH_FORM_COLUMN_CLASS).not.toContain("max-w-sm");
     expect(AUTH_FORM_COLUMN_CLASS).not.toMatch(/max-w-\[\d+px\]/);
     expect(AUTH_PRIMARY_CTA_CLASS).toContain("w-full");
   });
@@ -45,8 +51,8 @@ describe("auth surface layout contracts", () => {
       const source = readFileSync(join(REPO_ROOT, rel), "utf8");
       expect(source, rel).toContain("AUTH_FORM_COLUMN_CLASS");
       expect(source, rel).toContain('from "@nebutra/ui/utils"');
-      // No ad-hoc pixel form columns (historical 440px drift).
       expect(source, rel).not.toMatch(/max-w-\[\d+px\]/);
+      expect(source, rel).not.toMatch(/max-w-sm(?![\w-])/);
     }
   });
 
@@ -54,6 +60,15 @@ describe("auth surface layout contracts", () => {
     for (const rel of AUTH_SURFACES) {
       const source = readFileSync(join(REPO_ROOT, rel), "utf8");
       expect(source, rel).not.toMatch(FOREGROUND_FILL_FIGHT);
+    }
+  });
+
+  it("OAuth grids stay single-column for two providers (no stretched dual pills)", () => {
+    for (const rel of OAUTH_BUTTONS) {
+      const source = readFileSync(join(REPO_ROOT, rel), "utf8");
+      expect(source, rel).toMatch(/providers\.length\s*>=\s*3/);
+      expect(source, rel).not.toMatch(/className="grid grid-cols-1 gap-3 sm:grid-cols-2"/);
+      expect(source, rel).not.toMatch(/className="grid gap-3 grid-cols-1 sm:grid-cols-2"/);
     }
   });
 });

--- a/packages/design/ui/src/utils/auth-surfaces.ts
+++ b/packages/design/ui/src/utils/auth-surfaces.ts
@@ -4,12 +4,14 @@
  * Split-shell login (apps/auth + apps/web) and the marketing AuthPage must
  * share one form-column width. Inventing a second max-width on either shell
  * is how the credentials column drifts wider than the design (e.g. the
- * historical 440px one-off that shipped on auth-center).
+ * historical 440px one-off, then 384px max-w-sm that still felt wide with
+ * dual OAuth side-by-side on a 64vw white pane).
  *
- * `max-w-sm` = 24rem / 384px — form-scale, not page-scale. Matches the
- * credentials column on Marketing/AuthPage.
+ * `max-w-xs` = 20rem / 320px — login-card scale (Clerk / Linear band), not
+ * the looser page-form `max-w-sm` (24rem). Pair with single-column OAuth
+ * when only two providers so controls do not stretch into empty pills.
  */
-export const AUTH_FORM_COLUMN_CLASS = "relative w-full max-w-sm";
+export const AUTH_FORM_COLUMN_CLASS = "relative w-full max-w-xs";
 
 /**
  * Primary auth CTA sizing. Pair with `variant="ink"` on Button — never fight


### PR DESCRIPTION
## Summary

- SSOT `AUTH_FORM_COLUMN_CLASS`: `max-w-sm` (384px) → **`max-w-xs` (320px)** — login-card scale
- OAuth: dual columns only when **≥3 providers**; Google+GitHub stay single-column (no stretched empty pills)
- Governance test updated for the tighter contract + OAuth gate

## Why

After #416, ink CTA and `max-w-sm` were live, but the form still read as a wide island on the 64vw white pane. Not a broken `--container-sm` (that resolves to 24rem correctly) — the scale was still too loose for login.

## Test plan

- [x] governance tests (4) green
- [x] pre-push typecheck green
- [ ] ECS PM2 deploy auth after merge
- [ ] Visual: https://auth.nebutra.com/sign-in ~320px column, stacked OAuth