### PR TITLE
fix(auth): root-cause login card width and Neon OAuth grid

### DIFF
--- a/apps/auth/src/components/auth-split-layout.tsx
+++ b/apps/auth/src/components/auth-split-layout.tsx
@@ -1,6 +1,6 @@
 import { getBrandOrigin } from "@nebutra/brand/metadata-helpers";
 import { ArrowLeft } from "@nebutra/icons";
-import { AUTH_FORM_COLUMN_CLASS } from "@nebutra/ui/utils";
+import { AUTH_FORM_CARD_CLASS, AUTH_FORM_COLUMN_CLASS } from "@nebutra/ui/utils";
 import { getTranslations } from "next-intl/server";
 import { cn } from "@/lib/cn";
 import { AuthBanner } from "./auth-banner";
@@ -56,7 +56,7 @@ export async function AuthSplitLayout({
           aria-hidden
           className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-[linear-gradient(180deg,color-mix(in_srgb,hsl(var(--muted))_80%,transparent),transparent)] lg:hidden"
         />
-        <div className={AUTH_FORM_COLUMN_CLASS}>{children}</div>
+        <div className={cn(AUTH_FORM_COLUMN_CLASS, AUTH_FORM_CARD_CLASS)}>{children}</div>
       </main>
     </div>
   );

--- a/apps/auth/src/components/oauth-buttons.tsx
+++ b/apps/auth/src/components/oauth-buttons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@nebutra/ui/primitives";
+import { AUTH_OAUTH_BUTTON_CLASS, AUTH_OAUTH_GRID_CLASS } from "@nebutra/ui/utils";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import {
@@ -116,12 +117,8 @@ export function OAuthButtons({ providers, returnTo }: OAuthButtonsProps) {
     window.location.assign(buildOAuthStartPath(provider, returnTo));
   }
 
-  // Two providers side-by-side stretches empty pills across the login card;
-  // dual columns only pay off at three or more.
-  const multiCol = providers.length >= 3;
-
   return (
-    <div className={multiCol ? "grid grid-cols-1 gap-3 sm:grid-cols-2" : "grid grid-cols-1 gap-3"}>
+    <div className={AUTH_OAUTH_GRID_CLASS}>
       {providers.map((provider) => {
         const Icon = PROVIDER_ICON[provider];
         const label =
@@ -131,7 +128,7 @@ export function OAuthButtons({ providers, returnTo }: OAuthButtonsProps) {
             key={provider}
             type="button"
             variant="outline"
-            className="h-10 w-full justify-center gap-2.5 border-border bg-background px-3 text-foreground shadow-none hover:bg-muted"
+            className={AUTH_OAUTH_BUTTON_CLASS}
             disabled={loadingProvider !== null}
             aria-label={`${t("continueWith")} ${label}`}
             onClick={() => handleOAuth(provider)}

--- a/apps/web/src/components/auth/auth-split-layout.tsx
+++ b/apps/web/src/components/auth/auth-split-layout.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft } from "@nebutra/icons";
-import { AUTH_FORM_COLUMN_CLASS, cn } from "@nebutra/ui/utils";
+import { AUTH_FORM_CARD_CLASS, AUTH_FORM_COLUMN_CLASS, cn } from "@nebutra/ui/utils";
 import { useTranslations } from "next-intl";
 import { LocaleSwitcher } from "@/components/navigation/locale-switcher";
 import { AuthBanner } from "./auth-banner";
@@ -50,7 +50,7 @@ export function AuthSplitLayout({ children, className }: AuthSplitLayoutProps) {
           aria-hidden
           className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-[linear-gradient(180deg,color-mix(in_srgb,hsl(var(--muted))_80%,transparent),transparent)] lg:hidden"
         />
-        <div className={AUTH_FORM_COLUMN_CLASS}>{children}</div>
+        <div className={cn(AUTH_FORM_COLUMN_CLASS, AUTH_FORM_CARD_CLASS)}>{children}</div>
       </main>
     </div>
   );

--- a/apps/web/src/components/auth/oauth-buttons.tsx
+++ b/apps/web/src/components/auth/oauth-buttons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@nebutra/ui/primitives";
+import { AUTH_OAUTH_BUTTON_CLASS, AUTH_OAUTH_GRID_CLASS } from "@nebutra/ui/utils";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import {
@@ -123,12 +124,8 @@ export function OAuthButtons({ mode, providers = OAUTH_PROVIDERS, returnUrl }: O
 
   if (providers.length === 0) return null;
 
-  // Two providers side-by-side stretches empty pills across the login card;
-  // dual columns only pay off at three or more.
-  const multiCol = providers.length >= 3;
-
   return (
-    <div className={multiCol ? "grid gap-3 grid-cols-1 sm:grid-cols-2" : "grid gap-3 grid-cols-1"}>
+    <div className={AUTH_OAUTH_GRID_CLASS}>
       {providers.map((provider) => {
         const Icon = PROVIDER_ICON[provider];
         const label = t(`providers.${provider}`);
@@ -137,7 +134,7 @@ export function OAuthButtons({ mode, providers = OAUTH_PROVIDERS, returnUrl }: O
             key={provider}
             type="button"
             variant="outline"
-            className="h-10 w-full justify-center gap-2.5 border-border bg-background px-3 text-foreground shadow-none hover:bg-muted"
+            className={AUTH_OAUTH_BUTTON_CLASS}
             disabled={loadingProvider !== null}
             aria-label={`${t("continueWith")} ${label}`}
             onClick={() => handleOAuth(provider)}

--- a/packages/design/ui/src/tokens/spacing.ts
+++ b/packages/design/ui/src/tokens/spacing.ts
@@ -55,7 +55,7 @@ export const semanticSpacing = {
  */
 export const containerWidths = {
   /** Credentials / auth form column — login-card scale, not page-form. */
-  authForm: "max-w-xs", // 20rem / 320px — SSOT: AUTH_FORM_COLUMN_CLASS in utils/auth-surfaces
+  authForm: "max-w-[360px]", // login-card — SSOT: AUTH_FORM_COLUMN_CLASS in utils/auth-surfaces
   narrow: "max-w-[var(--container-text)]", // 896px - FAQ, focused reading
   medium: "max-w-[var(--container-content)]", // 1152px - Architecture, Pricing
   wide: "max-w-[var(--container-wide)]", // 1400px - Full layouts, Bento

--- a/packages/design/ui/src/utils/__tests__/auth-surfaces-governance.test.ts
+++ b/packages/design/ui/src/utils/__tests__/auth-surfaces-governance.test.ts
@@ -1,18 +1,14 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { AUTH_FORM_COLUMN_CLASS, AUTH_PRIMARY_CTA_CLASS } from "../auth-surfaces";
+import {
+  AUTH_FORM_CARD_CLASS,
+  AUTH_FORM_COLUMN_CLASS,
+  AUTH_OAUTH_BUTTON_CLASS,
+  AUTH_OAUTH_GRID_CLASS,
+  AUTH_PRIMARY_CTA_CLASS,
+} from "../auth-surfaces";
 
-/**
- * Auth form-column + primary CTA contracts.
- *
- * Hard-and-correct: one width, one CTA recipe. Both product shells
- * (auth-center + Agent OS web) must import the SSOT; ad-hoc max-widths
- * and bg-[hsl(var(--foreground))] fights against btn-brand-default are
- * banned so the column cannot silently widen or re-paint identity blue.
- *
- * Paths are monorepo-relative from packages/design/ui (vitest cwd).
- */
 const REPO_ROOT = join(process.cwd(), "../../..");
 
 const SPLIT_LAYOUTS = [
@@ -39,20 +35,23 @@ const FOREGROUND_FILL_FIGHT =
   /bg-\[hsl\(var\(--foreground\)\)\][\s\S]{0,120}text-\[hsl\(var\(--background\)\)\]/;
 
 describe("auth surface layout contracts", () => {
-  it("exports a login-card column (max-w-xs / 20rem), not looser form scales", () => {
-    expect(AUTH_FORM_COLUMN_CLASS).toContain("max-w-xs");
+  it("forces login-card width (min 360px cap), not soft max-w-sm/xs alone", () => {
+    expect(AUTH_FORM_COLUMN_CLASS).toMatch(/360px|min\(100%/);
+    expect(AUTH_FORM_COLUMN_CLASS).toContain("min-w-0");
     expect(AUTH_FORM_COLUMN_CLASS).not.toContain("max-w-sm");
-    expect(AUTH_FORM_COLUMN_CLASS).not.toMatch(/max-w-\[\d+px\]/);
+    expect(AUTH_FORM_COLUMN_CLASS).not.toContain("max-w-xs");
+    expect(AUTH_FORM_CARD_CLASS).toContain("rounded");
     expect(AUTH_PRIMARY_CTA_CLASS).toContain("w-full");
   });
 
-  it("both product AuthSplitLayouts import and apply AUTH_FORM_COLUMN_CLASS", () => {
+  it("both product AuthSplitLayouts apply column + card SSOT", () => {
     for (const rel of SPLIT_LAYOUTS) {
       const source = readFileSync(join(REPO_ROOT, rel), "utf8");
       expect(source, rel).toContain("AUTH_FORM_COLUMN_CLASS");
+      expect(source, rel).toContain("AUTH_FORM_CARD_CLASS");
       expect(source, rel).toContain('from "@nebutra/ui/utils"');
-      expect(source, rel).not.toMatch(/max-w-\[\d+px\]/);
       expect(source, rel).not.toMatch(/max-w-sm(?![\w-])/);
+      expect(source, rel).not.toMatch(/max-w-xs(?![\w-])/);
     }
   });
 
@@ -63,12 +62,19 @@ describe("auth surface layout contracts", () => {
     }
   });
 
-  it("OAuth grids stay single-column for two providers (no stretched dual pills)", () => {
+  it("OAuth is Neon-style always-2-col compact grid (never stacked full-width bars)", () => {
+    expect(AUTH_OAUTH_GRID_CLASS).toContain("grid-cols-2");
+    expect(AUTH_OAUTH_BUTTON_CLASS).toContain("h-9");
     for (const rel of OAUTH_BUTTONS) {
       const source = readFileSync(join(REPO_ROOT, rel), "utf8");
-      expect(source, rel).toMatch(/providers\.length\s*>=\s*3/);
+      expect(source, rel).toContain("AUTH_OAUTH_GRID_CLASS");
+      expect(source, rel).toContain("AUTH_OAUTH_BUTTON_CLASS");
+      // Forbidden: stack-when-two gate or always-single-col for 2 providers
+      expect(source, rel).not.toMatch(/providers\.length\s*>=\s*3/);
+      expect(source, rel).not.toMatch(/multiCol/);
       expect(source, rel).not.toMatch(/className="grid grid-cols-1 gap-3 sm:grid-cols-2"/);
       expect(source, rel).not.toMatch(/className="grid gap-3 grid-cols-1 sm:grid-cols-2"/);
+      expect(source, rel).not.toMatch(/className="grid grid-cols-1 gap-3"/);
     }
   });
 });

--- a/packages/design/ui/src/utils/auth-surfaces.ts
+++ b/packages/design/ui/src/utils/auth-surfaces.ts
@@ -1,22 +1,29 @@
 /**
  * Auth surface layout contracts.
  *
- * Split-shell login (apps/auth + apps/web) and the marketing AuthPage must
- * share one form-column width. Inventing a second max-width on either shell
- * is how the credentials column drifts wider than the design (e.g. the
- * historical 440px one-off, then 384px max-w-sm that still felt wide with
- * dual OAuth side-by-side on a 64vw white pane).
+ * ## Width (root cause)
+ * Do NOT use `w-full max-w-sm|xs` alone inside a flex/grid shell. Percentage
+ * width resolves against the full right pane (~64vw); if max-width is ever
+ * soft-failed (token miss, cascade, min-width:auto content), the column
+ * expands to the pane. Force the used width with min() + min-w-0 + shrink-0.
  *
- * `max-w-xs` = 20rem / 320px — login-card scale (Clerk / Linear band), not
- * the looser page-form `max-w-sm` (24rem). Pair with single-column OAuth
- * when only two providers so controls do not stretch into empty pills.
+ * 360px matches the Neon / Clerk login-card band (not page-form 24rem).
+ *
+ * ## OAuth (Neon)
+ * Always a 2-column compact grid — never full-width stacked bars, never
+ * "stack when only two providers". Buttons fill the *cell*, not the pane.
  */
-export const AUTH_FORM_COLUMN_CLASS = "relative w-full max-w-xs";
+export const AUTH_FORM_COLUMN_CLASS = "relative mx-auto min-w-0 w-[min(100%,360px)] shrink-0";
 
-/**
- * Primary auth CTA sizing. Pair with `variant="ink"` on Button — never fight
- * `btn-brand-default`'s background-image with `bg-[hsl(var(--foreground))]`.
- * The image layer wins and the identity/action blue reappears on the first
- * surface a visitor touches.
- */
+/** Optional card chrome — same width SSOT, visual containment like Neon. */
+export const AUTH_FORM_CARD_CLASS =
+  "rounded-2xl border border-border bg-background p-6 shadow-sm sm:p-8";
+
 export const AUTH_PRIMARY_CTA_CLASS = "h-11 w-full";
+
+/** Neon-style OAuth: always 2 columns, tight gap. */
+export const AUTH_OAUTH_GRID_CLASS = "grid grid-cols-2 gap-2";
+
+/** Compact OAuth chip — fills grid cell only. */
+export const AUTH_OAUTH_BUTTON_CLASS =
+  "h-9 w-full justify-center gap-2 border-border bg-background px-2.5 text-sm font-medium text-foreground shadow-none hover:bg-muted";

--- a/packages/design/ui/src/utils/index.ts
+++ b/packages/design/ui/src/utils/index.ts
@@ -3,7 +3,13 @@
  */
 
 /** Auth split-shell + primary CTA contracts (width + ink CTA pairing). */
-export { AUTH_FORM_COLUMN_CLASS, AUTH_PRIMARY_CTA_CLASS } from "./auth-surfaces";
+export {
+  AUTH_FORM_CARD_CLASS,
+  AUTH_FORM_COLUMN_CLASS,
+  AUTH_OAUTH_BUTTON_CLASS,
+  AUTH_OAUTH_GRID_CLASS,
+  AUTH_PRIMARY_CTA_CLASS,
+} from "./auth-surfaces";
 /**
  * Merge class names — canonical implementation from ./cn.ts
  * Uses twMerge(clsx(...)) to correctly resolve Tailwind class conflicts.


### PR DESCRIPTION
## Root cause

Soft `max-w-xs/sm` on a **flex child with `w-full`** resolves percentage width against the full right pane (~64vw). OAuth used **full-width bars** (and briefly stacked them), so the column always *read* as a highway even when max-width tokens were correct (`--container-xs: 20rem` was fine).

## Fix (Neon-aligned)

1. **Forced used width**: `w-[min(100%,360px)] min-w-0 shrink-0` — cannot expand to the pane
2. **Card chrome**: bordered rounded card around the credentials column
3. **OAuth always 2-col compact grid** (`grid-cols-2 gap-2`, `h-9` chips) — side-by-side like Neon, never stacked full-width bars
4. Governance tests lock all of the above

## Test plan

- [x] 4 governance tests
- [x] auth-center typecheck
- [x] pre-push typecheck
- [ ] ECS PM2 deploy auth
- [ ] Visual: compact ~360px card, Google|GitHub side by side