### PR TITLE
fix(gateway): carina/status reports enabled for socket co-deploy

### DIFF
--- a/backends/gateway/src/lib/carina-sandbox.ts
+++ b/backends/gateway/src/lib/carina-sandbox.ts
@@ -2,7 +2,9 @@
  * Gateway Track-B wiring — resolve Carina from env and attach command_exec.
  *
  * Env (operator / self-deployed daemon):
- *   CARINA_JSONRPC_URL            HTTP JSON-RPC base (required to enable)
+ *   CARINA_CODEPLOY               1 (default) same-host; 0 = opt out
+ *   CARINA_DAEMON_SOCK            unix NDJSON path (default /var/carina/run/daemon.sock)
+ *   CARINA_JSONRPC_URL            optional HTTP JSON-RPC base (non-socket bridge)
  *   CARINA_JSONRPC_TOKEN          product/gateway Bearer (never local owner unlock)
  *   CARINA_JSONRPC_PATH           optional path under base (e.g. /jsonrpc)
  *   CARINA_WORKSPACE_ROOT         default absolute path on Carina host
@@ -19,20 +21,20 @@
  */
 
 import {
-  RuntimeToolRegistry,
-  isCarinaSandbox,
-  registerCommandExecTool,
-  resolveCarinaSandboxFromEnv,
-  resolveCarinaWorkspaceRootWithCodeploy,
   type CarinaEnv,
   type CarinaSandbox,
   type ExternalSandbox,
+  isCarinaSandbox,
+  RuntimeToolRegistry,
+  registerCommandExecTool,
+  resolveCarinaSandboxFromEnv,
+  resolveCarinaWorkspaceRootWithCodeploy,
 } from "@nebutra/agent-runtime";
 
 export type GatewayCarinaBundle = {
   readonly sandbox: ExternalSandbox;
   readonly tools: RuntimeToolRegistry;
-  /** True when CARINA_JSONRPC_URL is set (sandbox is Carina, not refuse stub). */
+  /** True when sandbox is Carina (socket co-deploy and/or HTTP URL), not refuse stub. */
   readonly carinaEnabled: boolean;
   readonly workspaceRoot?: string;
 };
@@ -72,16 +74,12 @@ export function createGatewayCarinaBundle(
   };
 }
 
-export function gatewaySandboxOrRefuse(
-  env: CarinaEnv = process.env,
-): ExternalSandbox {
+export function gatewaySandboxOrRefuse(env: CarinaEnv = process.env): ExternalSandbox {
   return resolveCarinaSandboxFromEnv(env);
 }
 
 /** Narrow helper for routes that need Carina-only methods. */
-export function getCarinaSandbox(
-  env: CarinaEnv = process.env,
-): CarinaSandbox | null {
+export function getCarinaSandbox(env: CarinaEnv = process.env): CarinaSandbox | null {
   const sandbox = resolveCarinaSandboxFromEnv(env);
   return isCarinaSandbox(sandbox) ? sandbox : null;
 }

--- a/backends/gateway/src/routes/agent-runtime/index.ts
+++ b/backends/gateway/src/routes/agent-runtime/index.ts
@@ -7,7 +7,8 @@
  * (enable with FEATURE_FLAG_AGENT_RUNTIME_DEMO=true or KILL_SWITCH_…).
  *
  * Track B (Carina):
- *  - `createGatewayCarinaBundle({ tenantId, threadId })` when CARINA_JSONRPC_URL
+ *  - `createGatewayCarinaBundle({ tenantId, threadId })` for socket co-deploy
+ *    (default) or CARINA_JSONRPC_URL
  *  - `GET  /carina/status`     connectivity probe (auth; no demo flag)
  *  - `POST /carina/approvals`  governance.approval.resolve bridge (auth)
  */
@@ -31,10 +32,7 @@ import { getTenantDb } from "@nebutra/db";
 import { FLAGS, featureFlagMiddleware } from "@nebutra/feature-flags";
 import { streamSSE } from "hono/streaming";
 import { getGatewayOrchestrator } from "../../agents/orchestrator-singleton.js";
-import {
-  createGatewayCarinaBundle,
-  getCarinaSandbox,
-} from "../../lib/carina-sandbox.js";
+import { createGatewayCarinaBundle, getCarinaSandbox } from "../../lib/carina-sandbox.js";
 import { requireAuth } from "../../middlewares/tenantContext.js";
 
 export const agentRuntimeRoutes = new OpenAPIHono();
@@ -121,7 +119,10 @@ const carinaStatusRoute = createRoute({
 
 agentRuntimeRoutes.openapi(carinaStatusRoute, async (c) => {
   const env = process.env;
-  const enabled = Boolean(env.CARINA_JSONRPC_URL?.trim());
+  // Co-deploy (unix socket) is the product default; HTTP URL is optional.
+  // Do not gate on CARINA_JSONRPC_URL alone — that leaves socket hosts as enabled:false.
+  const sandbox = getCarinaSandbox(env);
+  const enabled = Boolean(sandbox);
   const workspaceConfigured = Boolean(
     env.CARINA_WORKSPACE_ROOT?.trim() ||
       env.CARINA_WORKSPACE_TEMPLATE?.trim() ||
@@ -129,18 +130,8 @@ agentRuntimeRoutes.openapi(carinaStatusRoute, async (c) => {
   );
   const autoApprove = env.CARINA_AUTO_APPROVE === "1" || env.CARINA_AUTO_APPROVE === "true";
 
-  if (!enabled) {
-    return c.json({ enabled: false, workspaceConfigured, autoApprove });
-  }
-
-  const sandbox = getCarinaSandbox(env);
   if (!sandbox) {
-    return c.json({
-      enabled: false,
-      workspaceConfigured,
-      autoApprove,
-      error: "url set but sandbox resolve failed",
-    });
+    return c.json({ enabled: false, workspaceConfigured, autoApprove });
   }
 
   try {
@@ -201,7 +192,13 @@ const carinaApprovalRoute = createRoute({
 agentRuntimeRoutes.openapi(carinaApprovalRoute, async (c) => {
   const sandbox = getCarinaSandbox();
   if (!sandbox) {
-    return c.json({ ok: false, error: "Carina not configured (CARINA_JSONRPC_URL)" }, 503);
+    return c.json(
+      {
+        ok: false,
+        error: "Carina not configured (set co-deploy socket or CARINA_JSONRPC_URL)",
+      },
+      503,
+    );
   }
   const tenant = tenantFrom(c);
   const body = c.req.valid("json");


### PR DESCRIPTION
## Summary
Authenticated prod probe returned:

```json
{"enabled":false,"workspaceConfigured":true,"autoApprove":false}
```

while `/var/carina/run/daemon.sock` was live and docker `carina-daemon` was up. The route gated `enabled` on `CARINA_JSONRPC_URL` only, ignoring co-deploy socket defaults.

## Change
- `GET /carina/status` uses `getCarinaSandbox(env)` (socket or HTTP)
- Docs/comments and approvals 503 message aligned

## Test plan
- [x] Local: `@nebutra/gateway` carina-sandbox tests
- [ ] Deploy api + S2S probe → `enabled:true` + `protocolVersion`