### PR TITLE
chore(ops): upgrade Carina co-deploy pin to 0.8.5

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -928,7 +928,7 @@ jobs:
             "${ECS_USER}@${ECS_HOST}:/tmp/carina-ops/"
           # Pre-stage carina-daemon on the GH runner (US) then scp — ECS cannot
           # reliably pull GitHub Releases in reasonable time from CN.
-          CARINA_VERSION="${CARINA_VERSION:-0.8.1}"
+          CARINA_VERSION="${CARINA_VERSION:-0.8.5}"
           ARCH_TAG="linux_amd64"
           ASSET="carina_${CARINA_VERSION}_${ARCH_TAG}.tar.gz"
           URL="https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSION}/${ASSET}"
@@ -958,6 +958,9 @@ jobs:
           tar -xzf "/tmp/carina-stage/$ASSET" -C /tmp/carina-stage
           BIN="$(find /tmp/carina-stage -type f -name carina-daemon | head -1)"
           KERNEL="$(find /tmp/carina-stage -type f -name carina-kernel-service | head -1)"
+          printf '%s\n' "$CARINA_VERSION" > /tmp/carina-stage/VERSION
+          scp "${SCP_OPTS[@]}" /tmp/carina-stage/VERSION \
+            "${ECS_USER}@${ECS_HOST}:/tmp/carina-ops/VERSION" || true
           if [ -z "$BIN" ]; then
             echo "::warning::carina-daemon not found in release archive — VM will try network install"
           else

--- a/docs/architecture/2026-08-03-carina-track-b-upstream.md
+++ b/docs/architecture/2026-08-03-carina-track-b-upstream.md
@@ -76,7 +76,9 @@ Bearer tokens are **Gateway / product credentials**, never local owner tokens.
 
 ## Appendix A — v0.8.1 wire mapping (Phase 1)
 
-Catalog baseline: **Carina v0.8.1**. Pin: `CARINA_MIN_PROTOCOL_VERSION = 1`.
+Catalog baseline: **Carina v0.8.1+** (co-deploy binary pin tracks latest 0.8.x
+release via `CARINA_VERSION` in ops scripts; currently **0.8.5**).
+Protocol pin: `CARINA_MIN_PROTOCOL_VERSION = 1`.
 
 | Sailor | Carina (catalog) |
 |--------|------------------|

--- a/infra/ops/scripts/carina-codeploy.sh
+++ b/infra/ops/scripts/carina-codeploy.sh
@@ -24,13 +24,12 @@ TOOLS_DIR="${CARINA_TOOLS_DIR:-$CARINA_ROOT/bin}"
 echo "Injecting api-gateway Carina env (co-deploy defaults)…"
 bash "$SCRIPTS_DIR/configure-api-carina-env.sh" || true
 
+# Always refresh binaries so version pin bumps (CI-staged) actually land.
 # Daemon alone is not enough — kernel child is required for capability startup.
-if [ ! -x "$DAEMON_BIN" ] || [ ! -x "$KERNEL_BIN" ]; then
-  echo "Installing carina-daemon + carina-kernel-service…"
-  if ! bash "$SCRIPTS_DIR/install-carina-daemon.sh"; then
-    echo "ERROR: install-carina-daemon.sh failed" >&2
-    exit 1
-  fi
+echo "Installing/refreshing carina-daemon + carina-kernel-service…"
+if ! bash "$SCRIPTS_DIR/install-carina-daemon.sh"; then
+  echo "ERROR: install-carina-daemon.sh failed" >&2
+  exit 1
 fi
 
 if [ ! -x "$DAEMON_BIN" ]; then

--- a/infra/ops/scripts/install-carina-daemon.sh
+++ b/infra/ops/scripts/install-carina-daemon.sh
@@ -16,12 +16,21 @@
 #
 # Usage (on the VM):
 #   sudo bash install-carina-daemon.sh
-#   CARINA_VERSION=0.8.1 bash install-carina-daemon.sh
+#   CARINA_VERSION=0.8.5 bash install-carina-daemon.sh
 #   CARINA_RELEASE_MIRRORS="https://ghfast.top/ https://ghproxy.net/" bash install-carina-daemon.sh
 set -euo pipefail
 
-CARINA_VERSION="${CARINA_VERSION:-0.8.1}"
+# Default tracks latest published Carina release pin for co-deploy.
+# Override with CARINA_VERSION=… when you need to hold a known-good.
+# CI may stage /tmp/carina-ops/VERSION so refresh installs report the true pin.
 CARINA_ROOT="${CARINA_ROOT:-/var/carina}"
+STAGED_DIR="${CARINA_STAGED_DIR:-/tmp/carina-ops}"
+STAGED_DAEMON="${CARINA_STAGED_BIN:-$STAGED_DIR/carina-daemon}"
+STAGED_KERNEL="${CARINA_STAGED_KERNEL:-$STAGED_DIR/carina-kernel-service}"
+if [ -z "${CARINA_VERSION:-}" ] && [ -f "$STAGED_DIR/VERSION" ]; then
+  CARINA_VERSION="$(tr -d '[:space:]' <"$STAGED_DIR/VERSION")"
+fi
+CARINA_VERSION="${CARINA_VERSION:-0.8.5}"
 ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64|amd64) ARCH_TAG="linux_amd64" ;;
@@ -33,10 +42,6 @@ ASSET="carina_${CARINA_VERSION}_${ARCH_TAG}.tar.gz"
 ORIGIN_URL="https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSION}/${ASSET}"
 
 mkdir -p "$CARINA_ROOT/bin" "$CARINA_ROOT/run" "$CARINA_ROOT/ws" "$CARINA_ROOT/state" "$CARINA_ROOT/tmp"
-
-STAGED_DIR="${CARINA_STAGED_DIR:-/tmp/carina-ops}"
-STAGED_DAEMON="${CARINA_STAGED_BIN:-$STAGED_DIR/carina-daemon}"
-STAGED_KERNEL="${CARINA_STAGED_KERNEL:-$STAGED_DIR/carina-kernel-service}"
 
 install_bin() {
   local src="$1" dest="$2"
@@ -67,7 +72,8 @@ if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ] || [ ! -x "$CARINA_ROOT/bin/carina-
 fi
 
 if [ "$need_archive" = "0" ]; then
-  echo "Carina binaries ready under $CARINA_ROOT/bin (staged path)"
+  printf '%s\n' "$CARINA_VERSION" >"$CARINA_ROOT/VERSION"
+  echo "Carina binaries ready under $CARINA_ROOT/bin (staged path, v${CARINA_VERSION})"
   "$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | head -8 || true
   exit 0
 fi
@@ -178,5 +184,6 @@ if [ ! -x "$CARINA_ROOT/bin/carina-daemon" ] || [ ! -x "$CARINA_ROOT/bin/carina-
   exit 1
 fi
 
+printf '%s\n' "$CARINA_VERSION" >"$CARINA_ROOT/VERSION"
 echo "Installed carina-daemon + carina-kernel-service (v${CARINA_VERSION}) → $CARINA_ROOT/bin"
 "$CARINA_ROOT/bin/carina-daemon" -h 2>&1 | head -8 || true

--- a/packages/ai/agent-runtime/src/sandbox.ts
+++ b/packages/ai/agent-runtime/src/sandbox.ts
@@ -16,15 +16,15 @@
  * @see docs/architecture/2026-08-03-carina-track-b-upstream.md
  */
 
-import type { CapabilityPolicy } from "./policy";
 import {
+  CarinaNdjsonError,
   CODEPLOY_CARINA_SOCKET_PATH,
   CODEPLOY_CARINA_WORKSPACE_ROOT,
-  CarinaNdjsonError,
   createCarinaNdjsonClient,
   defaultCarinaSocketPath,
   type NdjsonRpcClient,
 } from "./carina-ndjson";
+import type { CapabilityPolicy } from "./policy";
 
 export interface SandboxExecRequest {
   /** Mandatory tenant scope — every delegated exec is tenant-bound. */
@@ -127,7 +127,7 @@ export function createHttpSandbox(
   };
 }
 
-// ── Carina v0.8.1 JSON-RPC mapping ───────────────────────────────────────────
+// ── Carina v0.8.x JSON-RPC mapping (catalog baseline 0.8.1; pin co-deploy binary separately) ─
 
 /** Minimum `protocol_version` we accept from `gateway.hello` (Carina catalog). */
 export const CARINA_MIN_PROTOCOL_VERSION = 1;
@@ -262,13 +262,11 @@ function extractCarinaSessionId(session: unknown): string {
     const v = rec[key];
     if (typeof v === "string" && v.length > 0) return v;
   }
-  throw new CarinaProtocolError(
-    "Carina session.create Session missing id/session_id/sessionId",
-  );
+  throw new CarinaProtocolError("Carina session.create Session missing id/session_id/sessionId");
 }
 
 /**
- * Track-B adapter: Sailor control plane → **Carina** public RPC catalog (v0.8.1+).
+ * Track-B adapter: Sailor control plane → **Carina** public RPC catalog (v0.8.x).
  *
  * Mapping (Sailor → Carina, never the reverse ownership):
  * - `threadId` → `command.exec` `session_id` (via ensureSession cache, else threadId)
@@ -440,9 +438,7 @@ export function createCarinaSandbox(options: CarinaSandboxOptions): CarinaSandbo
 
       const root = request.workspaceRoot.trim();
       if (!root) {
-        throw new CarinaProtocolError(
-          "Carina session.create requires a non-empty workspaceRoot",
-        );
+        throw new CarinaProtocolError("Carina session.create requires a non-empty workspaceRoot");
       }
 
       await ensureHello();
@@ -564,12 +560,10 @@ export function assertSafePosture(policy: CapabilityPolicy, allowDanger = false)
   }
 }
 
-
 // ── Env resolution + command-exec tool (Phase 2 host helpers) ────────────────
 
 /** Env bag for Carina host config. Compatible with `process.env`. */
 export type CarinaEnv = Readonly<Record<string, string | undefined>>;
-
 
 /**
  * Resolve workspace path for a tenant/thread.
@@ -592,10 +586,7 @@ export function resolveCarinaWorkspaceRoot(
   }
   const template = env.CARINA_WORKSPACE_TEMPLATE?.trim();
   if (template) {
-    return template
-      .replaceAll("{tenantId}", tenantId)
-      .replaceAll("{threadId}", threadId)
-      .trim();
+    return template.replaceAll("{tenantId}", tenantId).replaceAll("{threadId}", threadId).trim();
   }
   const root = env.CARINA_WORKSPACE_ROOT?.trim();
   return root || undefined;
@@ -630,8 +621,7 @@ export function resolveCarinaSandboxFromEnv(
   env: CarinaEnv = process.env,
   overrides: Partial<CarinaSandboxOptions> = {},
 ): ExternalSandbox {
-  const auto =
-    env.CARINA_AUTO_APPROVE === "1" || env.CARINA_AUTO_APPROVE === "true";
+  const auto = env.CARINA_AUTO_APPROVE === "1" || env.CARINA_AUTO_APPROVE === "true";
   const common: Partial<CarinaSandboxOptions> = {
     ...(env.CARINA_CLIENT_ID ? { clientId: env.CARINA_CLIENT_ID } : {}),
     ...(auto ? { autoApproveOnRequire: true } : {}),


### PR DESCRIPTION
## Summary
Upstream Carina moved **0.8.1 → 0.8.5** today. Sailor co-deploy was still pinning **0.8.1**, and install only ran when binaries were missing — upgrades never landed on the VM.

## Changes
- Default `CARINA_VERSION=0.8.5` (install + deploy-ecs prestage)
- Always refresh install on co-deploy
- Stage VERSION marker; write `/var/carina/VERSION`
- Docs: catalog baseline 0.8.1+; binary pin 0.8.5

## Protocol
No breaking `protocol/` changes 0.8.1→0.8.5. `CARINA_MIN_PROTOCOL_VERSION = 1` unchanged.

## Test plan
- [ ] Merge + `apps=api` deploy
- [ ] `/var/carina/VERSION` = `0.8.5`
- [ ] socket ready + status `protocolVersion:1`