### PR TITLE
chore(ops): automate Carina co-deploy version maintenance

### DIFF
--- a/.github/workflows/carina-upstream-sync.yml
+++ b/.github/workflows/carina-upstream-sync.yml
@@ -1,0 +1,104 @@
+name: Carina upstream sync
+
+# Keep infra/ops/carina.pin aligned with Nebutra/carina releases.
+# Renovate also manages the pin (regex manager); this workflow is the
+# belt-and-suspenders path that runs on a schedule and can force-update.
+
+on:
+  schedule:
+    # Twice daily — Carina 0.8.x can ship multiple patches in a day.
+    - cron: "17 2,14 * * *"
+  workflow_dispatch:
+    inputs:
+      write:
+        description: "If true, open a PR that bumps carina.pin to latest"
+        required: false
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: carina-upstream-sync
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check / bump carina.pin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve pin vs latest
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          chmod +x infra/ops/scripts/carina-version.sh infra/ops/scripts/carina-upstream-check.sh
+          set +e
+          out="$(bash infra/ops/scripts/carina-upstream-check.sh --print 2>&1)"
+          code=$?
+          set -e
+          echo "$out"
+          pinned="$(echo "$out" | awk -F': *' '/^pinned:/{print $2}')"
+          latest="$(echo "$out" | awk -F': *' '/^latest:/{print $2}')"
+          status="$(echo "$out" | awk -F': *' '/^status:/{print $2}')"
+          echo "pinned=$pinned" >>"$GITHUB_OUTPUT"
+          echo "latest=$latest" >>"$GITHUB_OUTPUT"
+          echo "status=$status" >>"$GITHUB_OUTPUT"
+          if [ -z "$latest" ]; then
+            echo "::error::failed to resolve latest Carina release"
+            exit 1
+          fi
+          # print-only always exits 0; recompute behind
+          if [ "$pinned" != "$latest" ]; then
+            echo "behind=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "behind=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump pin file
+        if: steps.resolve.outputs.behind == 'true' && (github.event_name == 'schedule' || inputs.write == 'true')
+        run: |
+          set -euo pipefail
+          bash infra/ops/scripts/carina-upstream-check.sh --write || true
+          # --write exits 2 when it rewrote; 0 if somehow current
+          grep -E '^version=' infra/ops/carina.pin
+          # Keep install script default comment in sync for human readers (optional)
+          # Prefer a single source of truth — scripts already source carina.pin.
+
+      - name: Open or update PR
+        if: steps.resolve.outputs.behind == 'true' && (github.event_name == 'schedule' || inputs.write == 'true')
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(ops): bump Carina co-deploy pin to ${{ steps.resolve.outputs.latest }}"
+          branch: chore/carina-pin-${{ steps.resolve.outputs.latest }}
+          delete-branch: true
+          title: "chore(ops): bump Carina co-deploy pin to ${{ steps.resolve.outputs.latest }}"
+          labels: |
+            dependencies
+            ops
+          body: |
+            ## Summary
+            Automated bump of `infra/ops/carina.pin` from **${{ steps.resolve.outputs.pinned }}** → **${{ steps.resolve.outputs.latest }}**
+            (source: [Nebutra/carina](https://github.com/Nebutra/carina/releases)).
+
+            ## What happens next
+            - Merging this PR updates the co-deploy binary pin.
+            - `deploy-ecs` path filter includes `infra/ops/carina.pin` → next api co-deploy stages **${{ steps.resolve.outputs.latest }}**.
+            - `carina-codeploy.sh` always refreshes `/var/carina/bin` from staged binaries.
+
+            ## Checklist
+            - [ ] Release notes look non-breaking for Track-B (`protocol_version` still ≥ 1)
+            - [ ] After merge, confirm `/var/carina/VERSION` and `GET …/carina/status`
+
+            _Opened by `carina-upstream-sync` workflow._

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -68,6 +68,8 @@ on:
       - "infra/ops/scripts/carina-codeploy.sh"
       - "infra/ops/scripts/install-carina-daemon.sh"
       - "infra/ops/scripts/configure-api-carina-env.sh"
+      - "infra/ops/scripts/carina-version.sh"
+      - "infra/ops/carina.pin"
       - ".github/workflows/deploy-ecs.yml"
 
 permissions:
@@ -876,14 +878,21 @@ jobs:
             infra/ops/scripts/carina-codeploy.sh \
             infra/ops/scripts/install-carina-daemon.sh \
             infra/ops/scripts/configure-api-carina-env.sh \
+            infra/ops/scripts/carina-version.sh \
+            infra/ops/carina.pin \
             "${ECS_USER}@${ECS_HOST}:/tmp/carina-ops/"
           # Pre-stage carina-daemon on the GH runner (US) then scp — ECS cannot
           # reliably pull GitHub Releases in reasonable time from CN.
-          CARINA_VERSION="${CARINA_VERSION:-0.8.5}"
+          # Version comes from infra/ops/carina.pin unless CARINA_VERSION is set.
+          if [ -z "${CARINA_VERSION:-}" ]; then
+            # shellcheck source=infra/ops/scripts/carina-version.sh
+            source infra/ops/scripts/carina-version.sh
+            CARINA_VERSION="$(carina_version_from_pin)"
+          fi
           ARCH_TAG="linux_amd64"
           ASSET="carina_${CARINA_VERSION}_${ARCH_TAG}.tar.gz"
           URL="https://github.com/Nebutra/carina/releases/download/v${CARINA_VERSION}/${ASSET}"
-          echo "Pre-staging carina-daemon from $URL"
+          echo "Pre-staging carina-daemon v${CARINA_VERSION} from $URL"
           mkdir -p /tmp/carina-stage
           # Prefer origin on GH runners; fall back to CN proxies if origin flakes.
           ok=0

--- a/docs/architecture/2026-08-03-carina-track-b-upstream.md
+++ b/docs/architecture/2026-08-03-carina-track-b-upstream.md
@@ -76,8 +76,17 @@ Bearer tokens are **Gateway / product credentials**, never local owner tokens.
 
 ## Appendix A — v0.8.1 wire mapping (Phase 1)
 
-Catalog baseline: **Carina v0.8.1+** (co-deploy binary pin tracks latest 0.8.x
-release via `CARINA_VERSION` in ops scripts; currently **0.8.5**).
+Catalog baseline: **Carina v0.8.1+**.
+Co-deploy binary pin is the single file **`infra/ops/carina.pin`**
+(`version=`), read by install + `deploy-ecs` prestage. Maintenance is
+automated:
+
+| Mechanism | Role |
+|-----------|------|
+| Renovate regex manager | bumps `carina.pin` when `Nebutra/carina` publishes; patch automerge |
+| `.github/workflows/carina-upstream-sync.yml` | scheduled/manual belt-and-suspenders PR |
+| `carina-codeploy.sh` | always refreshes `/var/carina/bin` from staged binaries |
+
 Protocol pin: `CARINA_MIN_PROTOCOL_VERSION = 1`.
 
 | Sailor | Carina (catalog) |

--- a/infra/ops/carina.pin
+++ b/infra/ops/carina.pin
@@ -1,0 +1,9 @@
+# Single source of truth for same-host Carina co-deploy binary pin.
+# Renovate (custom regex manager) bumps `version=` when Nebutra/carina
+# publishes a new release. Ops scripts and deploy-ecs read this file.
+#
+# channel: optional major.minor floor for the auto-check workflow
+# (only propose bumps that stay on the same 0.8 line unless channel is empty).
+version=0.8.6
+channel=0.8
+repository=Nebutra/carina

--- a/infra/ops/scripts/carina-upstream-check.sh
+++ b/infra/ops/scripts/carina-upstream-check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Compare infra/ops/carina.pin against the latest Nebutra/carina release.
+#
+# Exit codes:
+#   0  pin is current (or only --print)
+#   2  pin is behind latest (for CI to open a PR)
+#   1  hard error
+#
+# Flags:
+#   --print     only print pin / latest / status
+#   --write     rewrite carina.pin version= to latest (used by CI bot)
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=carina-version.sh
+source "$SCRIPTS_DIR/carina-version.sh"
+
+PRINT_ONLY=0
+WRITE=0
+for arg in "$@"; do
+  case "$arg" in
+    --print) PRINT_ONLY=1 ;;
+    --write) WRITE=1 ;;
+    -h|--help)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+PIN_FILE="$(carina_pin_file)"
+PINNED="$(carina_version_from_pin)"
+CHANNEL="$(carina_pin_field channel 2>/dev/null || true)"
+REPO="$(carina_pin_field repository 2>/dev/null || echo Nebutra/carina)"
+export CARINA_REPOSITORY="$REPO"
+LATEST="$(carina_latest_release "$CHANNEL")"
+
+if [ -z "$LATEST" ]; then
+  echo "ERROR: could not resolve latest release for $REPO (channel=${CHANNEL:-*})" >&2
+  exit 1
+fi
+
+status="current"
+if [ "$PINNED" != "$LATEST" ]; then
+  status="behind"
+fi
+
+echo "repository: $REPO"
+echo "channel:    ${CHANNEL:-(any)}"
+echo "pinned:     $PINNED"
+echo "latest:     $LATEST"
+echo "status:     $status"
+echo "pin_file:   $PIN_FILE"
+
+if [ "$PRINT_ONLY" = "1" ]; then
+  exit 0
+fi
+
+if [ "$status" = "current" ]; then
+  exit 0
+fi
+
+if [ "$WRITE" = "1" ]; then
+  tmp="$(mktemp)"
+  awk -v v="$LATEST" '
+    BEGIN{FS=OFS="="}
+    $1=="version" {$2=v}
+    {print}
+  ' "$PIN_FILE" >"$tmp"
+  mv "$tmp" "$PIN_FILE"
+  echo "Updated $PIN_FILE version=$LATEST"
+  exit 2
+fi
+
+exit 2

--- a/infra/ops/scripts/carina-version.sh
+++ b/infra/ops/scripts/carina-version.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Resolve the Carina co-deploy binary version from infra/ops/carina.pin.
+#
+# Usage:
+#   source infra/ops/scripts/carina-version.sh
+#   carina_version_from_pin          # → 0.8.5
+#   carina_pin_field channel         # → 0.8
+#   carina_pin_field repository      # → Nebutra/carina
+#   carina_latest_release [channel]  # → latest GH release (optionally filtered)
+#
+# Library-style: do not enable `set -u` here (safe to source from zsh/bash).
+
+_carina_script_dir() {
+  # Resolve this file's directory under bash, zsh, or plain sh ($0).
+  if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+    return 0
+  fi
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    # shellcheck disable=SC2296
+    cd "$(dirname "${(%):-%x}")" && pwd
+    return 0
+  fi
+  cd "$(dirname "$0")" && pwd
+}
+
+carina_pin_file() {
+  if [ -n "${CARINA_PIN_FILE:-}" ] && [ -f "$CARINA_PIN_FILE" ]; then
+    printf '%s\n' "$CARINA_PIN_FILE"
+    return 0
+  fi
+  local here
+  here="$(_carina_script_dir)"
+  # scripts/ → ops/
+  if [ -f "$here/../carina.pin" ]; then
+    printf '%s\n' "$here/../carina.pin"
+    return 0
+  fi
+  if [ -f "infra/ops/carina.pin" ]; then
+    printf '%s\n' "infra/ops/carina.pin"
+    return 0
+  fi
+  if [ -f "/tmp/carina-ops/carina.pin" ]; then
+    printf '%s\n' "/tmp/carina-ops/carina.pin"
+    return 0
+  fi
+  return 1
+}
+
+carina_pin_field() {
+  local key="$1"
+  local pin
+  pin="$(carina_pin_file)" || {
+    echo "carina.pin not found (set CARINA_PIN_FILE=...)" >&2
+    return 1
+  }
+  # shellcheck disable=SC2002
+  local val
+  val="$(grep -E "^${key}=" "$pin" | head -1 | cut -d= -f2- | tr -d '[:space:]')"
+  if [ -z "$val" ]; then
+    echo "carina.pin missing key: $key" >&2
+    return 1
+  fi
+  printf '%s\n' "$val"
+}
+
+carina_version_from_pin() {
+  if [ -n "${CARINA_VERSION:-}" ]; then
+    printf '%s\n' "$CARINA_VERSION"
+    return 0
+  fi
+  carina_pin_field version
+}
+
+# Latest published non-draft, non-prerelease tag on GitHub (without leading v).
+# Optional channel filter: channel=0.8 → only 0.8.x.
+carina_latest_release() {
+  local channel="${1:-}"
+  local repo
+  repo="${CARINA_REPOSITORY:-}"
+  if [ -z "$repo" ]; then
+    repo="$(carina_pin_field repository 2>/dev/null || echo Nebutra/carina)"
+  fi
+  if [ -z "$channel" ]; then
+    channel="$(carina_pin_field channel 2>/dev/null || true)"
+  fi
+
+  local api="https://api.github.com/repos/${repo}/releases?per_page=30"
+  local json
+  if command -v gh >/dev/null 2>&1; then
+    json="$(gh api "repos/${repo}/releases?per_page=30" 2>/dev/null || true)"
+  fi
+  if [ -z "${json:-}" ]; then
+    json="$(curl -fsSL \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "$api")"
+  fi
+
+  # Prefer jq; fall back to node.
+  if command -v jq >/dev/null 2>&1; then
+    if [ -n "$channel" ]; then
+      printf '%s' "$json" | jq -r --arg c "$channel" '
+        [.[] | select(.draft==false and .prerelease==false)
+          | .tag_name | ltrimstr("v")
+          | select(test("^" + ($c | gsub("\\."; "\\.")) + "\\."))]
+        | .[0] // empty'
+    else
+      printf '%s' "$json" | jq -r '
+        [.[] | select(.draft==false and .prerelease==false)
+          | .tag_name | ltrimstr("v")]
+        | .[0] // empty'
+    fi
+    return 0
+  fi
+
+  node --input-type=module -e '
+const channel = process.env.CHANNEL || "";
+const data = JSON.parse(process.argv[1]);
+const tags = data
+  .filter((r) => !r.draft && !r.prerelease)
+  .map((r) => String(r.tag_name || "").replace(/^v/, ""));
+const hit = channel
+  ? tags.find((t) => t.startsWith(channel + "."))
+  : tags[0];
+if (hit) process.stdout.write(hit);
+' "$json"
+}

--- a/infra/ops/scripts/install-carina-daemon.sh
+++ b/infra/ops/scripts/install-carina-daemon.sh
@@ -18,19 +18,33 @@
 #   sudo bash install-carina-daemon.sh
 #   CARINA_VERSION=0.8.5 bash install-carina-daemon.sh
 #   CARINA_RELEASE_MIRRORS="https://ghfast.top/ https://ghproxy.net/" bash install-carina-daemon.sh
+#
+# Version resolution (first hit wins):
+#   1) CARINA_VERSION env
+#   2) staged /tmp/carina-ops/VERSION (CI)
+#   3) infra/ops/carina.pin (repo single source of truth)
+#   4) hard fallback (last known good in script; prefer pin)
 set -euo pipefail
 
-# Default tracks latest published Carina release pin for co-deploy.
-# Override with CARINA_VERSION=… when you need to hold a known-good.
-# CI may stage /tmp/carina-ops/VERSION so refresh installs report the true pin.
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 CARINA_ROOT="${CARINA_ROOT:-/var/carina}"
 STAGED_DIR="${CARINA_STAGED_DIR:-/tmp/carina-ops}"
 STAGED_DAEMON="${CARINA_STAGED_BIN:-$STAGED_DIR/carina-daemon}"
 STAGED_KERNEL="${CARINA_STAGED_KERNEL:-$STAGED_DIR/carina-kernel-service}"
+
 if [ -z "${CARINA_VERSION:-}" ] && [ -f "$STAGED_DIR/VERSION" ]; then
   CARINA_VERSION="$(tr -d '[:space:]' <"$STAGED_DIR/VERSION")"
 fi
-CARINA_VERSION="${CARINA_VERSION:-0.8.5}"
+if [ -z "${CARINA_VERSION:-}" ] && [ -f "$SCRIPTS_DIR/carina-version.sh" ]; then
+  # shellcheck source=carina-version.sh
+  source "$SCRIPTS_DIR/carina-version.sh"
+  CARINA_VERSION="$(carina_version_from_pin 2>/dev/null || true)"
+fi
+# staged carina.pin may be uploaded next to install scripts
+if [ -z "${CARINA_VERSION:-}" ] && [ -f "$STAGED_DIR/carina.pin" ]; then
+  CARINA_VERSION="$(grep -E '^version=' "$STAGED_DIR/carina.pin" | head -1 | cut -d= -f2- | tr -d '[:space:]')"
+fi
+CARINA_VERSION="${CARINA_VERSION:-0.8.6}"
 ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64|amd64) ARCH_TAG="linux_amd64" ;;

--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,35 @@
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Carina co-deploy binary pin (infra/ops/carina.pin)",
+      "fileMatch": ["^infra/ops/carina\\.pin$"],
+      "matchStrings": ["(?m)^version=(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*$"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "Nebutra/carina",
+      "packageNameTemplate": "Nebutra/carina",
+      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$"
+    }
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "description": "Carina co-deploy: auto-merge patch within 0.8.x; open PR for minor/major",
+      "matchDepNames": ["Nebutra/carina"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "labels": ["dependencies", "ops", "carina"]
+    },
+    {
+      "matchDepNames": ["Nebutra/carina"],
+      "matchUpdateTypes": ["minor", "major"],
+      "automerge": false,
+      "labels": ["dependencies", "ops", "carina"]
     },
     {
       "matchPackagePatterns": ["@nebutra/*"],


### PR DESCRIPTION
## Summary
Stop hand-editing `CARINA_VERSION=0.8.x` every time upstream ships.

### Automation
| Layer | What |
|-------|------|
| **`infra/ops/carina.pin`** | Single pin (`version=0.8.6`, `channel=0.8`) |
| **Renovate** | regex manager on `carina.pin` → GH releases `Nebutra/carina`; **patch automerge** |
| **`carina-upstream-sync.yml`** | Cron 02:17 / 14:17 UTC + dispatch; opens PR if pin lags |
| **install / deploy-ecs** | Read pin (or staged VERSION); always refresh binaries on co-deploy |
| **path filters** | `infra/ops/carina.pin` triggers deploy-ecs |

### Manual override
```bash
CARINA_VERSION=0.8.5 bash install-carina-daemon.sh   # hold a known-good
# or edit infra/ops/carina.pin
```

### Verify
```bash
bash infra/ops/scripts/carina-upstream-check.sh --print
# repository / pinned / latest / status
```

## Test plan
- [x] `carina-upstream-check.sh --print` → current for 0.8.6
- [x] pin resolves from install helper
- [ ] Merge; next api deploy stages 0.8.6
- [ ] Renovate / scheduled workflow can open bump PRs