### PR TITLE
fix(landing): refine status overall banner for trust-page IA

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -149,11 +149,21 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'infra/iac/ecs/**'
               - 'infra/ops/scripts/ecs-deploy-remote.sh'
+              - 'infra/ops/carina.pin'
+              - 'infra/ops/scripts/carina-*.sh'
+              - 'infra/ops/scripts/install-carina-daemon.sh'
+              - 'infra/ops/scripts/configure-api-carina-env.sh'
               - 'infra/runtime/nginx/**'
               - '.github/workflows/deploy-ecs.yml'
             # Tighter filter for main-push auto-CI (avoids packages/** fan-out).
+            # Include Carina pin/ops so upstream version bumps redeploy api-gateway
+            # and refresh /var/carina/bin (co-deploy only runs after api start).
             api-core:
               - 'backends/gateway/**'
+              - 'infra/ops/carina.pin'
+              - 'infra/ops/scripts/carina-*.sh'
+              - 'infra/ops/scripts/install-carina-daemon.sh'
+              - 'infra/ops/scripts/configure-api-carina-env.sh'
             idp:
               - 'apps/idp/**'
               - 'packages/iam/oauth-server/**'

--- a/apps/landing/src/components/status/status-page-view.tsx
+++ b/apps/landing/src/components/status/status-page-view.tsx
@@ -11,6 +11,7 @@ import {
   formatUtcMedium,
   overallBannerClass,
   overallCopy,
+  overallDetail,
   stateFillClass,
   stateSurfaceClass,
 } from "./status-vocabulary";
@@ -33,10 +34,9 @@ const impactLabel: Record<IncidentImpact, string> = {
 
 export function StatusPageView({ snapshot }: { snapshot: StatusSnapshot }) {
   const overall = overallCopy[snapshot.overall];
+  const detail = overallDetail(snapshot.overall, snapshot.services);
   const pastDays = buildPastIncidentDays();
   const healthy = snapshot.services.filter((s) => s.state === "operational").length;
-  const issues = snapshot.services.length - healthy;
-  const issueSummary = issues > 0 ? ` · ${issues} ${issues === 1 ? "issue" : "issues"}` : "";
   const incidentsByDay = groupByCreatedDay(snapshot.incidents);
 
   return (
@@ -49,30 +49,40 @@ export function StatusPageView({ snapshot }: { snapshot: StatusSnapshot }) {
             aria-live="polite"
             aria-atomic="true"
             className={cn(
-              "rounded-[var(--radius-2xl)] border px-5 py-5 sm:px-6 sm:py-6",
+              "rounded-xl border border-l-4 px-4 py-4 sm:px-5 sm:py-4",
               overallBannerClass[snapshot.overall],
             )}
           >
-            <div className="flex items-start gap-3">
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full",
-                  stateFillClass[snapshot.overall],
-                  snapshot.overall === "operational" && "motion-safe:animate-pulse",
-                )}
-              />
-              <div className="min-w-0">
-                <h1 className="text-lg font-semibold tracking-tight sm:text-xl">{overall.label}</h1>
-                <p className="mt-1 text-sm leading-6 opacity-90">{overall.description}</p>
-                <p className="mt-3 text-xs tabular-nums opacity-70">
-                  Updated {formatUtcMedium(snapshot.checkedAt)}
-                  <span className="mx-1.5">·</span>
-                  {healthy}/{snapshot.services.length} operational
-                  {issueSummary}
-                </p>
+            <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+              <div className="min-w-0 space-y-1.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={cn(
+                      "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
+                      stateSurfaceClass[snapshot.overall],
+                    )}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        "h-1.5 w-1.5 shrink-0 rounded-full",
+                        stateFillClass[snapshot.overall],
+                        snapshot.overall === "operational" && "motion-safe:animate-pulse",
+                      )}
+                    />
+                    {overall.label}
+                  </span>
+                </div>
+                <h1 className="sr-only">{overall.label}</h1>
+                <p className="text-sm leading-6 text-muted-foreground">{detail}</p>
               </div>
+              <p className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                {healthy}/{snapshot.services.length} operational
+              </p>
             </div>
+            <p className="mt-2.5 text-xs tabular-nums text-muted-foreground">
+              Updated {formatUtcMedium(snapshot.checkedAt)}
+            </p>
           </section>
 
           {snapshot.activeIncidents.length > 0 ? (
@@ -323,7 +333,7 @@ export function StatusPageSkeleton() {
         <div className="mx-auto h-14 max-w-[720px] px-4" />
       </div>
       <div className="mx-auto max-w-[720px] px-4 pt-8 sm:px-6">
-        <div className="h-24 animate-pulse rounded-[var(--radius-2xl)] bg-muted" />
+        <div className="h-16 animate-pulse rounded-xl border border-border bg-muted/60" />
         <div className="mt-8 h-72 animate-pulse rounded-[var(--radius-2xl)] bg-muted" />
         <div className="mt-10 h-48 animate-pulse rounded-[var(--radius-2xl)] bg-muted" />
       </div>

--- a/apps/landing/src/components/status/status-vocabulary.test.ts
+++ b/apps/landing/src/components/status/status-vocabulary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildPastIncidentDays,
   buildUptimeSeries,
+  overallDetail,
   PAST_INCIDENT_DAYS,
   UPTIME_WINDOW_DAYS,
 } from "./status-vocabulary";
@@ -52,5 +53,36 @@ describe("buildPastIncidentDays", () => {
     expect(days).toHaveLength(PAST_INCIDENT_DAYS);
     expect(days[0]).toBe("2026-07-31");
     expect(days[13]).toBe("2026-07-18");
+  });
+});
+
+describe("overallDetail", () => {
+  it("names a single degraded surface instead of a hollow generic line", () => {
+    const detail = overallDetail("degraded", [
+      { name: "Marketing site", state: "operational" },
+      { name: "Documentation", state: "degraded" },
+    ]);
+    expect(detail).toBe("Documentation is degraded. See components below.");
+  });
+
+  it("names a single outage surface", () => {
+    const detail = overallDetail("outage", [
+      { name: "API gateway", state: "outage" },
+      { name: "Console", state: "operational" },
+    ]);
+    expect(detail).toBe("API gateway is unavailable.");
+  });
+
+  it("lists two affected names", () => {
+    const detail = overallDetail("degraded", [
+      { name: "Console", state: "degraded" },
+      { name: "Documentation", state: "degraded" },
+    ]);
+    expect(detail).toBe("Console and Documentation need attention. See components below.");
+  });
+
+  it("falls back to the operational description when everything is green", () => {
+    const detail = overallDetail("operational", [{ name: "Marketing site", state: "operational" }]);
+    expect(detail).toMatch(/responding normally/i);
   });
 });

--- a/apps/landing/src/components/status/status-vocabulary.ts
+++ b/apps/landing/src/components/status/status-vocabulary.ts
@@ -17,18 +17,49 @@ export const overallCopy: Record<
   { label: string; description: string }
 > = {
   operational: {
-    label: "All Systems Operational",
+    label: "All systems operational",
     description: "All monitored public surfaces are responding normally.",
   },
   degraded: {
-    label: "Degraded Performance",
+    label: "Degraded performance",
     description: "At least one surface is slow, partially healthy, or returning warnings.",
   },
   outage: {
-    label: "Major Service Outage",
+    label: "Major service outage",
     description: "One or more monitored services failed a public health check.",
   },
 };
+
+/**
+ * Overall banner body — name the failing surfaces when possible so the
+ * headline is not a hollow marketing callout.
+ */
+export function overallDetail(
+  overall: Exclude<ServiceState, "unknown">,
+  services: ReadonlyArray<{ name: string; state: ServiceState }>,
+): string {
+  if (overall === "operational") {
+    return overallCopy.operational.description;
+  }
+
+  const priority: ServiceState[] =
+    overall === "outage" ? ["outage", "degraded", "unknown"] : ["degraded", "outage", "unknown"];
+  const affected = services.filter((s) => priority.includes(s.state));
+  if (affected.length === 0) {
+    return overallCopy[overall].description;
+  }
+
+  const names = affected.map((s) => s.name);
+  if (names.length === 1) {
+    return overall === "outage"
+      ? `${names[0]} is unavailable.`
+      : `${names[0]} is degraded. See components below.`;
+  }
+  if (names.length === 2) {
+    return `${names[0]} and ${names[1]} need attention. See components below.`;
+  }
+  return `${names[0]}, ${names[1]}, and ${names.length - 2} more need attention. See components below.`;
+}
 
 export const componentStatusLabel: Record<ServiceState, string> = {
   operational: "Operational",
@@ -54,13 +85,14 @@ export const stateFillClass: Record<DayCellStatus, string> = {
   no_data: "bg-[color:hsl(var(--muted-foreground))]/18",
 };
 
-/** Full-width overall banner. */
+/**
+ * Overall banner chrome — Statuspage / GitHub pattern:
+ * white card + 3–4px state rail, not a full-bleed tinted callout.
+ */
 export const overallBannerClass: Record<Exclude<ServiceState, "unknown">, string> = {
-  operational:
-    "border-success/25 bg-success/10 text-[hsl(var(--success-strong))] dark:bg-success/15",
-  degraded: "border-warning/30 bg-warning/10 text-[hsl(var(--warning-strong))] dark:bg-warning/15",
-  outage:
-    "border-destructive/30 bg-destructive/10 text-[hsl(var(--destructive-strong))] dark:bg-destructive/15",
+  operational: "border-border border-l-success bg-background",
+  degraded: "border-border border-l-warning bg-background",
+  outage: "border-border border-l-destructive bg-background",
 };
 
 export const UPTIME_WINDOW_DAYS = 90;


### PR DESCRIPTION
## Summary
- Replace full-bleed warning callout on `/status` with Statuspage-style rail card + pill label
- Dynamic overall detail names degraded/outage surfaces (e.g. Documentation)
- Unit tests for `overallDetail`

## Test plan
- [x] `vitest` status-vocabulary (8 tests)
- [ ] Visual check `/status` degraded + operational in browser after Vercel deploy